### PR TITLE
Add PortAudio support

### DIFF
--- a/Exports.def
+++ b/Exports.def
@@ -1,6 +1,7 @@
 LIBRARY	"mimicDll"
 EXPORTS 
 	mimic_init
+	mimic_exit
 	mimic_voice_select
 	mimic_file_to_speech
 	mimic_text_to_speech
@@ -46,6 +47,8 @@ EXPORTS
 	audio_close
 	audio_stream_chunk
 	audio_streaming_info_val
+	audio_init
+	audio_exit
 	new_audio_streaming_info
 	
 	

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,0 +1,13 @@
+# mimic 0.0.0.9000
+
+* Add PortAudio support. PortAudio is a cross-platform audio I/O library. We
+  can support audio output on Mac OS X and Windows.
+
+* Add some unit tests and convert part of the testsuite to unit tests
+
+* Rebuild English cmulex lexicon and letter to sound rules
+
+## Bug fixes
+
+* Workaround for issue #18, where if PulseAudio is running ALSA output was
+  stopped mid-word.

--- a/README.md
+++ b/README.md
@@ -1,25 +1,60 @@
-[![Stories in Ready](https://badge.waffle.io/MycroftAI/mimic.png?label=ready&title=Ready)](https://waffle.io/MycroftAI/mimic)
 Mimic, the Mycroft TTS Engine
-==========
+==============================
+
+[![Stories in Ready](https://badge.waffle.io/MycroftAI/mimic.png?label=ready&title=Ready)](https://waffle.io/MycroftAI/mimic)
 
 Mimic is a lightweight run-time speech synthesis engine, based on
 Flite (Festival-Lite). The Flite project website can be found
 here: http://www.festvox.org/flite/ - further information can be found
 in the ACKNOWLEDGEMENTS file in the Mimic repo.
 
-###Requirements:
+### Requirements:
 
-- A good C compiler, some of these files are quite large and some C
-  compilers might choke on these, gcc is fine.  Sun CC 3.01 has been
-  tested too.  Visual C++ 6.0 is known to fail on the large diphone
-  database files.  We recommend you use GCC under Cygwin or mingw32
-  instead.
-- GNU Make
-- An audio device isn't required as mimic can write its output to
-  a waveform file.
-- `libasound2-dev` (ubuntu)
+An audio device and audio libraries aren't strictly required as mimic can write
+its output to a waveform file. However they are included in requirements for
+their convenience.
 
-Supported platforms:
+
+#### Linux
+
+- A good C compiler. gcc or clang are fine.
+- GNU make
+- pkg-config
+- For audio output: either ALSA, PortAudio or PulseAudio headers. We recommend
+  ALSA output for greater compatibility with most setups.
+
+On a Debian/Ubuntu computer this can be installed by using:
+
+    sudo apt-get install gcc make pkg-config libasound2-dev
+
+#### Mac OSX
+
+- A good C compiler. gcc or clang are fine.
+- GNU make
+- pkg-config
+- PortAudio
+
+In order to install pkg-config and PortAudio, `brew` can be used:
+
+1. Install brew
+
+    /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
+
+2. Install pkg-config and PortAudio
+
+    brew install pkg-config portaudio
+
+#### Windows
+
+* A good C compiler, some of these files are quite large and some C
+  compilers might choke on these, gcc is fine. Visual C++ 6.0 is known to fail
+  on the large diphone database files.  We recommend you use GCC under Cygwin
+  or mingw32 instead.
+* GNU Make
+* PortAudio
+
+
+### Supported platforms:
 
 We have successfully compiled and run on
 
@@ -27,29 +62,27 @@ We have successfully compiled and run on
 - Mac OS X
 - Android
 
-###Compilation
+### Building mimic
 
-    TODO: update this to reflect compilation
-####Linux:
-  Obtain copy of the git repo:
+1. Clone the repository (or download a tarball)
 
-  `git clone https://github.com/MycroftAI/mimic.git`
+    git clone https://github.com/MycroftAI/mimic.git
 
-  Navigate to the mimic directory:
+2. Navigate to the mimic directory
 
-  `cd mimic`
+    cd mimic
 
-  Setup configuration files for your machine:
+3. Configure.
 
-  `./configure`
+    ./configure
 
-  Build mimic:
+4. Build:
 
-  `make`
-
-  Note: When rebuilding, often you will only need to run `make`.
-  If you make changes to compile flags you will probably want to
-  run `make clean` before recompiling with `make`.
+    make
+ 
+Note: When rebuilding, often you will only need to run `make`.
+If you make changes to compile flags you will probably want to
+run `make clean` before recompiling with `make`.
 
 ###Usage:
 

--- a/configure
+++ b/configure
@@ -4356,6 +4356,17 @@ rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
 
 OLDLIBS="$LIBS"
 LIBS="-lportaudio"
+OLDCFLAGS="$CFLAGS"
+if test -e "/usr/local/include/portaudio.h" ; then
+   LOCALINC="-I/usr/local/include"
+   LOCALLIB="-L/usr/local/lib"
+else
+   LOCALINC=
+   LOCALLIB=
+fi
+
+CFLAGS="$LOCALINC $CFLAGS"
+LIBS="$LOCALLIB $LIBS"
 if test "$cross_compiling" = yes; then :
   { { $as_echo "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
 $as_echo "$as_me: error: in \`$ac_pwd':" >&2;}
@@ -4375,14 +4386,16 @@ int main() {
 _ACEOF
 if ac_fn_c_try_run "$LINENO"; then :
   AUDIODRIVER="portaudio"
-            AUDIODEFS=-DCST_AUDIO_PORTAUDIO
-            AUDIOLIBS=-lportaudio
+            AUDIODEFS="$LOCALINC -DCST_AUDIO_PORTAUDIO"
+            AUDIOLIBS="$LOCALLIB -lportaudio"
 fi
 rm -f core *.core core.conftest.* gmon.out bb.out conftest$ac_exeext \
   conftest.$ac_objext conftest.beam conftest.$ac_ext
 fi
 
 LIBS="$OLDLIBS"
+CFLAGS="$OLDCFLAGS"
+
 ac_fn_c_check_header_mongrel "$LINENO" "mmsystem.h" "ac_cv_header_mmsystem_h" "$ac_includes_default"
 if test "x$ac_cv_header_mmsystem_h" = xyes; then :
   AUDIODRIVER="wince"

--- a/configure
+++ b/configure
@@ -4343,7 +4343,7 @@ int
 main ()
 {
 int j=
-                #if SND_LIB_SUBMINOR >= 11
+                #if SND_LIB_SUBMINOR >= 11 || SND_LIB_MINOR > 0
                 3;
                 #endif
   ;

--- a/configure
+++ b/configure
@@ -628,6 +628,10 @@ FL_LANG
 AUDIOLIBS
 AUDIODEFS
 AUDIODRIVER
+PORTAUDIO_LIBS
+PORTAUDIO_CFLAGS
+ALSA_LIBS
+ALSA_CFLAGS
 STDIOTYPE
 MMAPTYPE
 SHFLAGS
@@ -645,6 +649,9 @@ WINDRES
 M68KCC
 TARGET_CPU
 TARGET_OS
+PKG_CONFIG_LIBDIR
+PKG_CONFIG_PATH
+PKG_CONFIG
 EGREP
 GREP
 CPP
@@ -731,7 +738,14 @@ CFLAGS
 LDFLAGS
 LIBS
 CPPFLAGS
-CPP'
+CPP
+PKG_CONFIG
+PKG_CONFIG_PATH
+PKG_CONFIG_LIBDIR
+ALSA_CFLAGS
+ALSA_LIBS
+PORTAUDIO_CFLAGS
+PORTAUDIO_LIBS'
 
 
 # Initialize some variables set by options.
@@ -1367,6 +1381,17 @@ Some influential environment variables:
   CPPFLAGS    (Objective) C/C++ preprocessor flags, e.g. -I<include dir> if
               you have headers in a nonstandard directory <include dir>
   CPP         C preprocessor
+  PKG_CONFIG  path to pkg-config utility
+  PKG_CONFIG_PATH
+              directories to add to pkg-config's search path
+  PKG_CONFIG_LIBDIR
+              path overriding pkg-config's built-in search path
+  ALSA_CFLAGS C compiler flags for ALSA, overriding pkg-config
+  ALSA_LIBS   linker flags for ALSA, overriding pkg-config
+  PORTAUDIO_CFLAGS
+              C compiler flags for PORTAUDIO, overriding pkg-config
+  PORTAUDIO_LIBS
+              linker flags for PORTAUDIO, overriding pkg-config
 
 Use these variables to override the choices made by `configure' or to help
 it to find libraries and programs with nonstandard names/locations.
@@ -3977,6 +4002,127 @@ $as_echo "#define AC_APPLE_UNIVERSAL_BUILD 1" >>confdefs.h
  esac
 
 
+
+
+
+
+
+
+if test "x$ac_cv_env_PKG_CONFIG_set" != "xset"; then
+	if test -n "$ac_tool_prefix"; then
+  # Extract the first word of "${ac_tool_prefix}pkg-config", so it can be a program name with args.
+set dummy ${ac_tool_prefix}pkg-config; ac_word=$2
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
+$as_echo_n "checking for $ac_word... " >&6; }
+if ${ac_cv_path_PKG_CONFIG+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  case $PKG_CONFIG in
+  [\\/]* | ?:[\\/]*)
+  ac_cv_path_PKG_CONFIG="$PKG_CONFIG" # Let the user override the test with a path.
+  ;;
+  *)
+  as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
+for as_dir in $PATH
+do
+  IFS=$as_save_IFS
+  test -z "$as_dir" && as_dir=.
+    for ac_exec_ext in '' $ac_executable_extensions; do
+  if as_fn_executable_p "$as_dir/$ac_word$ac_exec_ext"; then
+    ac_cv_path_PKG_CONFIG="$as_dir/$ac_word$ac_exec_ext"
+    $as_echo "$as_me:${as_lineno-$LINENO}: found $as_dir/$ac_word$ac_exec_ext" >&5
+    break 2
+  fi
+done
+  done
+IFS=$as_save_IFS
+
+  ;;
+esac
+fi
+PKG_CONFIG=$ac_cv_path_PKG_CONFIG
+if test -n "$PKG_CONFIG"; then
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $PKG_CONFIG" >&5
+$as_echo "$PKG_CONFIG" >&6; }
+else
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
+fi
+
+
+fi
+if test -z "$ac_cv_path_PKG_CONFIG"; then
+  ac_pt_PKG_CONFIG=$PKG_CONFIG
+  # Extract the first word of "pkg-config", so it can be a program name with args.
+set dummy pkg-config; ac_word=$2
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
+$as_echo_n "checking for $ac_word... " >&6; }
+if ${ac_cv_path_ac_pt_PKG_CONFIG+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  case $ac_pt_PKG_CONFIG in
+  [\\/]* | ?:[\\/]*)
+  ac_cv_path_ac_pt_PKG_CONFIG="$ac_pt_PKG_CONFIG" # Let the user override the test with a path.
+  ;;
+  *)
+  as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
+for as_dir in $PATH
+do
+  IFS=$as_save_IFS
+  test -z "$as_dir" && as_dir=.
+    for ac_exec_ext in '' $ac_executable_extensions; do
+  if as_fn_executable_p "$as_dir/$ac_word$ac_exec_ext"; then
+    ac_cv_path_ac_pt_PKG_CONFIG="$as_dir/$ac_word$ac_exec_ext"
+    $as_echo "$as_me:${as_lineno-$LINENO}: found $as_dir/$ac_word$ac_exec_ext" >&5
+    break 2
+  fi
+done
+  done
+IFS=$as_save_IFS
+
+  ;;
+esac
+fi
+ac_pt_PKG_CONFIG=$ac_cv_path_ac_pt_PKG_CONFIG
+if test -n "$ac_pt_PKG_CONFIG"; then
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_pt_PKG_CONFIG" >&5
+$as_echo "$ac_pt_PKG_CONFIG" >&6; }
+else
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
+fi
+
+  if test "x$ac_pt_PKG_CONFIG" = x; then
+    PKG_CONFIG=""
+  else
+    case $cross_compiling:$ac_tool_warned in
+yes:)
+{ $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: using cross tools not prefixed with host triplet" >&5
+$as_echo "$as_me: WARNING: using cross tools not prefixed with host triplet" >&2;}
+ac_tool_warned=yes ;;
+esac
+    PKG_CONFIG=$ac_pt_PKG_CONFIG
+  fi
+else
+  PKG_CONFIG="$ac_cv_path_PKG_CONFIG"
+fi
+
+fi
+if test -n "$PKG_CONFIG"; then
+	_pkg_min_version=0.9.0
+	{ $as_echo "$as_me:${as_lineno-$LINENO}: checking pkg-config is at least version $_pkg_min_version" >&5
+$as_echo_n "checking pkg-config is at least version $_pkg_min_version... " >&6; }
+	if $PKG_CONFIG --atleast-pkgconfig-version $_pkg_min_version; then
+		{ $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+$as_echo "yes" >&6; }
+	else
+		{ $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
+		PKG_CONFIG=""
+	fi
+fi
+
+
 if test "x$GCC" = "xyes"; then
 	CFLAGS="$CFLAGS -Wall"
 fi
@@ -4333,68 +4479,154 @@ if test "x$ac_cv_header_sys_audioio_h" = xyes; then :
 fi
 
 
-cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
-#include <alsa/version.h>
-int
-main ()
-{
-int j=
-                #if SND_LIB_SUBMINOR >= 11 || SND_LIB_MINOR > 0
-                3;
-                #endif
-  ;
-  return 0;
-}
-_ACEOF
-if ac_fn_c_try_compile "$LINENO"; then :
-  AUDIODRIVER="alsa"
-	       AUDIODEFS=-DCST_AUDIO_ALSA
-               AUDIOLIBS=-lasound
-fi
-rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
 
-OLDLIBS="$LIBS"
-LIBS="-lportaudio"
-OLDCFLAGS="$CFLAGS"
-if test -e "/usr/local/include/portaudio.h" ; then
-   LOCALINC="-I/usr/local/include"
-   LOCALLIB="-L/usr/local/lib"
+
+pkg_failed=no
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for ALSA" >&5
+$as_echo_n "checking for ALSA... " >&6; }
+
+if test -n "$ALSA_CFLAGS"; then
+    pkg_cv_ALSA_CFLAGS="$ALSA_CFLAGS"
+ elif test -n "$PKG_CONFIG"; then
+    if test -n "$PKG_CONFIG" && \
+    { { $as_echo "$as_me:${as_lineno-$LINENO}: \$PKG_CONFIG --exists --print-errors \"alsa >= 1.0.11\""; } >&5
+  ($PKG_CONFIG --exists --print-errors "alsa >= 1.0.11") 2>&5
+  ac_status=$?
+  $as_echo "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
+  test $ac_status = 0; }; then
+  pkg_cv_ALSA_CFLAGS=`$PKG_CONFIG --cflags "alsa >= 1.0.11" 2>/dev/null`
+		      test "x$?" != "x0" && pkg_failed=yes
 else
-   LOCALINC=
-   LOCALLIB=
+  pkg_failed=yes
 fi
-
-CFLAGS="$LOCALINC $CFLAGS"
-LIBS="$LOCALLIB $LIBS"
-if test "$cross_compiling" = yes; then :
-  { { $as_echo "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
-$as_echo "$as_me: error: in \`$ac_pwd':" >&2;}
-as_fn_error $? "cannot run test program while cross compiling
-See \`config.log' for more details" "$LINENO" 5; }
+ else
+    pkg_failed=untried
+fi
+if test -n "$ALSA_LIBS"; then
+    pkg_cv_ALSA_LIBS="$ALSA_LIBS"
+ elif test -n "$PKG_CONFIG"; then
+    if test -n "$PKG_CONFIG" && \
+    { { $as_echo "$as_me:${as_lineno-$LINENO}: \$PKG_CONFIG --exists --print-errors \"alsa >= 1.0.11\""; } >&5
+  ($PKG_CONFIG --exists --print-errors "alsa >= 1.0.11") 2>&5
+  ac_status=$?
+  $as_echo "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
+  test $ac_status = 0; }; then
+  pkg_cv_ALSA_LIBS=`$PKG_CONFIG --libs "alsa >= 1.0.11" 2>/dev/null`
+		      test "x$?" != "x0" && pkg_failed=yes
 else
-  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
-
-#include <portaudio.h>
-int main() {
-  int j= Pa_GetVersion();
-  if (j>=1899)
-     return 0;
-  return -1;
-}
-_ACEOF
-if ac_fn_c_try_run "$LINENO"; then :
-  AUDIODRIVER="portaudio"
-            AUDIODEFS="$LOCALINC -DCST_AUDIO_PORTAUDIO"
-            AUDIOLIBS="$LOCALLIB -lportaudio"
+  pkg_failed=yes
 fi
-rm -f core *.core core.conftest.* gmon.out bb.out conftest$ac_exeext \
-  conftest.$ac_objext conftest.beam conftest.$ac_ext
+ else
+    pkg_failed=untried
 fi
 
-LIBS="$OLDLIBS"
-CFLAGS="$OLDCFLAGS"
+
+
+if test $pkg_failed = yes; then
+   	{ $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
+
+if $PKG_CONFIG --atleast-pkgconfig-version 0.20; then
+        _pkg_short_errors_supported=yes
+else
+        _pkg_short_errors_supported=no
+fi
+        if test $_pkg_short_errors_supported = yes; then
+	        ALSA_PKG_ERRORS=`$PKG_CONFIG --short-errors --print-errors --cflags --libs "alsa >= 1.0.11" 2>&1`
+        else
+	        ALSA_PKG_ERRORS=`$PKG_CONFIG --print-errors --cflags --libs "alsa >= 1.0.11" 2>&1`
+        fi
+	# Put the nasty error message in config.log where it belongs
+	echo "$ALSA_PKG_ERRORS" >&5
+
+
+elif test $pkg_failed = untried; then
+     	{ $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
+
+else
+	ALSA_CFLAGS=$pkg_cv_ALSA_CFLAGS
+	ALSA_LIBS=$pkg_cv_ALSA_LIBS
+        { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+$as_echo "yes" >&6; }
+	AUDIODRIVER="alsa"
+                   AUDIODEFS="-DCST_AUDIO_ALSA ${ALSA_CFLAGS}"
+                   AUDIOLIBS="${ALSA_LIBS}"
+fi
+
+
+pkg_failed=no
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for PORTAUDIO" >&5
+$as_echo_n "checking for PORTAUDIO... " >&6; }
+
+if test -n "$PORTAUDIO_CFLAGS"; then
+    pkg_cv_PORTAUDIO_CFLAGS="$PORTAUDIO_CFLAGS"
+ elif test -n "$PKG_CONFIG"; then
+    if test -n "$PKG_CONFIG" && \
+    { { $as_echo "$as_me:${as_lineno-$LINENO}: \$PKG_CONFIG --exists --print-errors \"portaudio-2.0 >= 19\""; } >&5
+  ($PKG_CONFIG --exists --print-errors "portaudio-2.0 >= 19") 2>&5
+  ac_status=$?
+  $as_echo "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
+  test $ac_status = 0; }; then
+  pkg_cv_PORTAUDIO_CFLAGS=`$PKG_CONFIG --cflags "portaudio-2.0 >= 19" 2>/dev/null`
+		      test "x$?" != "x0" && pkg_failed=yes
+else
+  pkg_failed=yes
+fi
+ else
+    pkg_failed=untried
+fi
+if test -n "$PORTAUDIO_LIBS"; then
+    pkg_cv_PORTAUDIO_LIBS="$PORTAUDIO_LIBS"
+ elif test -n "$PKG_CONFIG"; then
+    if test -n "$PKG_CONFIG" && \
+    { { $as_echo "$as_me:${as_lineno-$LINENO}: \$PKG_CONFIG --exists --print-errors \"portaudio-2.0 >= 19\""; } >&5
+  ($PKG_CONFIG --exists --print-errors "portaudio-2.0 >= 19") 2>&5
+  ac_status=$?
+  $as_echo "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
+  test $ac_status = 0; }; then
+  pkg_cv_PORTAUDIO_LIBS=`$PKG_CONFIG --libs "portaudio-2.0 >= 19" 2>/dev/null`
+		      test "x$?" != "x0" && pkg_failed=yes
+else
+  pkg_failed=yes
+fi
+ else
+    pkg_failed=untried
+fi
+
+
+
+if test $pkg_failed = yes; then
+   	{ $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
+
+if $PKG_CONFIG --atleast-pkgconfig-version 0.20; then
+        _pkg_short_errors_supported=yes
+else
+        _pkg_short_errors_supported=no
+fi
+        if test $_pkg_short_errors_supported = yes; then
+	        PORTAUDIO_PKG_ERRORS=`$PKG_CONFIG --short-errors --print-errors --cflags --libs "portaudio-2.0 >= 19" 2>&1`
+        else
+	        PORTAUDIO_PKG_ERRORS=`$PKG_CONFIG --print-errors --cflags --libs "portaudio-2.0 >= 19" 2>&1`
+        fi
+	# Put the nasty error message in config.log where it belongs
+	echo "$PORTAUDIO_PKG_ERRORS" >&5
+
+
+elif test $pkg_failed = untried; then
+     	{ $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
+
+else
+	PORTAUDIO_CFLAGS=$pkg_cv_PORTAUDIO_CFLAGS
+	PORTAUDIO_LIBS=$pkg_cv_PORTAUDIO_LIBS
+        { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+$as_echo "yes" >&6; }
+	AUDIODRIVER="portaudio"
+                   AUDIODEFS="-DCST_AUDIO_PORTAUDIO ${PORTAUDIO_CFLAGS}"
+                   AUDIOLIBS="${PORTAUDIO_LIBS}"
+fi
 
 ac_fn_c_check_header_mongrel "$LINENO" "mmsystem.h" "ac_cv_header_mmsystem_h" "$ac_includes_default"
 if test "x$ac_cv_header_mmsystem_h" = xyes; then :
@@ -4446,8 +4678,8 @@ if test "x$AUDIODEFS" = x; then
 	    ;;
 	alsa)
             AUDIODRIVER="alsa"
-	    AUDIODEFS=-DCST_AUDIO_ALSA
-            AUDIOLIBS=-lasound
+	    AUDIODEFS="-DCST_AUDIO_ALSA ${ALSA_CFLAGS}"
+            AUDIOLIBS="${ALSA_LIBS}"
 	    ;;
 	pa|pulseaudio)
             AUDIODRIVER="pulseaudio"
@@ -4456,8 +4688,8 @@ if test "x$AUDIODEFS" = x; then
 	    ;;
         portaudio)
             AUDIODRIVER="portaudio"
-	    AUDIODEFS=-DCST_AUDIO_PORTAUDIO
-            AUDIOLIBS='-lportaudio'
+	    AUDIODEFS="-DCST_AUDIO_PORTAUDIO ${PORTAUDIO_CFLAGS}"
+            AUDIOLIBS="${PORTAUDIO_LIBS}"
 	    ;;
 	*bsd)
 	    AUDIODRIVER=oss

--- a/configure
+++ b/configure
@@ -4333,9 +4333,6 @@ if test "x$ac_cv_header_sys_audioio_h" = xyes; then :
 fi
 
 
-# Seems the alsa code I have breaks on earlier versions
-# I'm not sure what the threshold version is, but made this depend on
-# the one I know -- you can still specific --with-audio=alsa
 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 #include <alsa/version.h>
@@ -4356,23 +4353,36 @@ if ac_fn_c_try_compile "$LINENO"; then :
                AUDIOLIBS=-lasound
 fi
 rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
-cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+
+OLDLIBS="$LIBS"
+LIBS="-lportaudio"
+if test "$cross_compiling" = yes; then :
+  { { $as_echo "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
+$as_echo "$as_me: error: in \`$ac_pwd':" >&2;}
+as_fn_error $? "cannot run test program while cross compiling
+See \`config.log' for more details" "$LINENO" 5; }
+else
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
+
 #include <portaudio.h>
-int
-main ()
-{
-int j= 3;
-  ;
-  return 0;
+int main() {
+  int j= Pa_GetVersion();
+  if (j>=1899)
+     return 0;
+  return -1;
 }
 _ACEOF
-if ac_fn_c_try_compile "$LINENO"; then :
+if ac_fn_c_try_run "$LINENO"; then :
   AUDIODRIVER="portaudio"
-	       AUDIODEFS=-DCST_AUDIO_PORTAUDIO
-               AUDIOLIBS=-lportaudio
+            AUDIODEFS=-DCST_AUDIO_PORTAUDIO
+            AUDIOLIBS=-lportaudio
 fi
-rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+rm -f core *.core core.conftest.* gmon.out bb.out conftest$ac_exeext \
+  conftest.$ac_objext conftest.beam conftest.$ac_ext
+fi
+
+LIBS="$OLDLIBS"
 ac_fn_c_check_header_mongrel "$LINENO" "mmsystem.h" "ac_cv_header_mmsystem_h" "$ac_includes_default"
 if test "x$ac_cv_header_mmsystem_h" = xyes; then :
   AUDIODRIVER="wince"

--- a/configure
+++ b/configure
@@ -4356,6 +4356,23 @@ if ac_fn_c_try_compile "$LINENO"; then :
                AUDIOLIBS=-lasound
 fi
 rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+#include <portaudio.h>
+int
+main ()
+{
+int j= 3;
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_compile "$LINENO"; then :
+  AUDIODRIVER="portaudio"
+	       AUDIODEFS=-DCST_AUDIO_PORTAUDIO
+               AUDIOLIBS=-lportaudio
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
 ac_fn_c_check_header_mongrel "$LINENO" "mmsystem.h" "ac_cv_header_mmsystem_h" "$ac_includes_default"
 if test "x$ac_cv_header_mmsystem_h" = xyes; then :
   AUDIODRIVER="wince"
@@ -4413,6 +4430,11 @@ if test "x$AUDIODEFS" = x; then
             AUDIODRIVER="pulseaudio"
 	    AUDIODEFS=-DCST_AUDIO_PULSEAUDIO
             AUDIOLIBS='-lpulse-simple -lpulse'
+	    ;;
+        portaudio)
+            AUDIODRIVER="portaudio"
+	    AUDIODEFS=-DCST_AUDIO_PORTAUDIO
+            AUDIOLIBS='-lportaudio'
 	    ;;
 	*bsd)
 	    AUDIODRIVER=oss

--- a/configure.in
+++ b/configure.in
@@ -389,6 +389,11 @@ AC_TRY_COMPILE([#include <alsa/version.h>],
               [AUDIODRIVER="alsa"
 	       AUDIODEFS=-DCST_AUDIO_ALSA
                AUDIOLIBS=-lasound])
+AC_TRY_COMPILE([#include <portaudio.h>],
+               [int j= 3;],
+              [AUDIODRIVER="portaudio"
+	       AUDIODEFS=-DCST_AUDIO_PORTAUDIO
+               AUDIOLIBS=-lportaudio])
 AC_CHECK_HEADER(mmsystem.h,
 	      [AUDIODRIVER="wince"
 	       AUDIODEFS=-DCST_AUDIO_WINCE
@@ -443,6 +448,11 @@ if test "x$AUDIODEFS" = x; then
             AUDIODRIVER="pulseaudio"
 	    AUDIODEFS=-DCST_AUDIO_PULSEAUDIO
             AUDIOLIBS='-lpulse-simple -lpulse'
+	    ;;
+        portaudio)
+            AUDIODRIVER="portaudio"
+	    AUDIODEFS=-DCST_AUDIO_PORTAUDIO
+            AUDIOLIBS='-lportaudio'
 	    ;;
 	*bsd)
 	    AUDIODRIVER=oss

--- a/configure.in
+++ b/configure.in
@@ -383,7 +383,7 @@ AC_CHECK_HEADER(sys/audioio.h,
 # the one I know -- you can still specific --with-audio=alsa
 AC_TRY_COMPILE([#include <alsa/version.h>],
                [int j=
-                #if SND_LIB_SUBMINOR >= 11
+                #if SND_LIB_SUBMINOR >= 11 || SND_LIB_MINOR > 0
                 3;
                 #endif],
               [AUDIODRIVER="alsa"

--- a/configure.in
+++ b/configure.in
@@ -393,6 +393,17 @@ AC_TRY_COMPILE([#include <alsa/version.h>],
 dnl Check PortAudio is at least 1899 (v19-dev)
 OLDLIBS="$LIBS"
 LIBS="-lportaudio"
+OLDCFLAGS="$CFLAGS"
+if test -e "/usr/local/include/portaudio.h" ; then
+   LOCALINC="-I/usr/local/include"
+   LOCALLIB="-L/usr/local/lib"
+else
+   LOCALINC=
+   LOCALLIB=
+fi
+
+CFLAGS="$LOCALINC $CFLAGS"
+LIBS="$LOCALLIB $LIBS"
 AC_TRY_RUN([
 #include <portaudio.h>
 int main() {
@@ -402,9 +413,11 @@ int main() {
   return -1;
 }],
            [AUDIODRIVER="portaudio"
-            AUDIODEFS=-DCST_AUDIO_PORTAUDIO
-            AUDIOLIBS=-lportaudio])
+            AUDIODEFS="$LOCALINC -DCST_AUDIO_PORTAUDIO"
+            AUDIOLIBS="$LOCALLIB -lportaudio"])
 LIBS="$OLDLIBS"
+CFLAGS="$OLDCFLAGS"
+
 AC_CHECK_HEADER(mmsystem.h,
 	      [AUDIODRIVER="wince"
 	       AUDIODEFS=-DCST_AUDIO_WINCE

--- a/configure.in
+++ b/configure.in
@@ -38,6 +38,8 @@ AC_PROG_RANLIB
 AC_PROG_INSTALL
 AC_CHECK_TOOL(AR, ar)
 AC_C_BIGENDIAN
+PKG_PROG_PKG_CONFIG
+
 
 if test "x$GCC" = "xyes"; then
 	CFLAGS="$CFLAGS -Wall"
@@ -378,45 +380,20 @@ AC_CHECK_HEADER(machine/soundcard.h,
 AC_CHECK_HEADER(sys/audioio.h,
               [AUDIODRIVER="sun"
                AUDIODEFS=-DCST_AUDIO_SUNOS])
-dnl Seems the alsa code I have breaks on earlier versions
-dnl I'm not sure what the threshold version is, but made this depend on
-dnl the one I know -- you can still specific --with-audio=alsa
-AC_TRY_COMPILE([#include <alsa/version.h>],
-               [int j=
-                #if SND_LIB_SUBMINOR >= 11 || SND_LIB_MINOR > 0
-                3;
-                #endif],
-              [AUDIODRIVER="alsa"
-	       AUDIODEFS=-DCST_AUDIO_ALSA
-               AUDIOLIBS=-lasound])
 
-dnl Check PortAudio is at least 1899 (v19-dev)
-OLDLIBS="$LIBS"
-LIBS="-lportaudio"
-OLDCFLAGS="$CFLAGS"
-if test -e "/usr/local/include/portaudio.h" ; then
-   LOCALINC="-I/usr/local/include"
-   LOCALLIB="-L/usr/local/lib"
-else
-   LOCALINC=
-   LOCALLIB=
-fi
+dnl Check for ALSA sound library
+PKG_CHECK_MODULES([ALSA], [alsa >= 1.0.11],
+                  [AUDIODRIVER="alsa"
+                   AUDIODEFS="-DCST_AUDIO_ALSA ${ALSA_CFLAGS}"
+                   AUDIOLIBS="${ALSA_LIBS}"],
+                  [m4_ignore])
 
-CFLAGS="$LOCALINC $CFLAGS"
-LIBS="$LOCALLIB $LIBS"
-AC_TRY_RUN([
-#include <portaudio.h>
-int main() {
-  int j= Pa_GetVersion();
-  if (j>=1899)
-     return 0;
-  return -1;
-}],
-           [AUDIODRIVER="portaudio"
-            AUDIODEFS="$LOCALINC -DCST_AUDIO_PORTAUDIO"
-            AUDIOLIBS="$LOCALLIB -lportaudio"])
-LIBS="$OLDLIBS"
-CFLAGS="$OLDCFLAGS"
+dnl Check PortAudio is at least (v19-dev)
+PKG_CHECK_MODULES([PORTAUDIO], [portaudio-2.0 >= 19],
+                  [AUDIODRIVER="portaudio"
+                   AUDIODEFS="-DCST_AUDIO_PORTAUDIO ${PORTAUDIO_CFLAGS}"
+                   AUDIOLIBS="${PORTAUDIO_LIBS}"],
+                  [m4_ignore])
 
 AC_CHECK_HEADER(mmsystem.h,
 	      [AUDIODRIVER="wince"
@@ -465,8 +442,8 @@ if test "x$AUDIODEFS" = x; then
 	    ;;
 	alsa)
             AUDIODRIVER="alsa"
-	    AUDIODEFS=-DCST_AUDIO_ALSA
-            AUDIOLIBS=-lasound
+	    AUDIODEFS="-DCST_AUDIO_ALSA ${ALSA_CFLAGS}"
+            AUDIOLIBS="${ALSA_LIBS}"
 	    ;;
 	pa|pulseaudio)
             AUDIODRIVER="pulseaudio"
@@ -475,8 +452,8 @@ if test "x$AUDIODEFS" = x; then
 	    ;;
         portaudio)
             AUDIODRIVER="portaudio"
-	    AUDIODEFS=-DCST_AUDIO_PORTAUDIO
-            AUDIOLIBS='-lportaudio'
+	    AUDIODEFS="-DCST_AUDIO_PORTAUDIO ${PORTAUDIO_CFLAGS}"
+            AUDIOLIBS="${PORTAUDIO_LIBS}"
 	    ;;
 	*bsd)
 	    AUDIODRIVER=oss

--- a/configure.in
+++ b/configure.in
@@ -378,9 +378,9 @@ AC_CHECK_HEADER(machine/soundcard.h,
 AC_CHECK_HEADER(sys/audioio.h,
               [AUDIODRIVER="sun"
                AUDIODEFS=-DCST_AUDIO_SUNOS])
-# Seems the alsa code I have breaks on earlier versions
-# I'm not sure what the threshold version is, but made this depend on
-# the one I know -- you can still specific --with-audio=alsa
+dnl Seems the alsa code I have breaks on earlier versions
+dnl I'm not sure what the threshold version is, but made this depend on
+dnl the one I know -- you can still specific --with-audio=alsa
 AC_TRY_COMPILE([#include <alsa/version.h>],
                [int j=
                 #if SND_LIB_SUBMINOR >= 11 || SND_LIB_MINOR > 0
@@ -389,11 +389,22 @@ AC_TRY_COMPILE([#include <alsa/version.h>],
               [AUDIODRIVER="alsa"
 	       AUDIODEFS=-DCST_AUDIO_ALSA
                AUDIOLIBS=-lasound])
-AC_TRY_COMPILE([#include <portaudio.h>],
-               [int j= 3;],
-              [AUDIODRIVER="portaudio"
-	       AUDIODEFS=-DCST_AUDIO_PORTAUDIO
-               AUDIOLIBS=-lportaudio])
+
+dnl Check PortAudio is at least 1899 (v19-dev)
+OLDLIBS="$LIBS"
+LIBS="-lportaudio"
+AC_TRY_RUN([
+#include <portaudio.h>
+int main() {
+  int j= Pa_GetVersion();
+  if (j>=1899)
+     return 0;
+  return -1;
+}],
+           [AUDIODRIVER="portaudio"
+            AUDIODEFS=-DCST_AUDIO_PORTAUDIO
+            AUDIOLIBS=-lportaudio])
+LIBS="$OLDLIBS"
 AC_CHECK_HEADER(mmsystem.h,
 	      [AUDIODRIVER="wince"
 	       AUDIODEFS=-DCST_AUDIO_WINCE

--- a/include/cst_audio.h
+++ b/include/cst_audio.h
@@ -44,9 +44,11 @@
 #include "cst_hrg.h"
 
 #ifdef CST_AUDIO_WIN32
-#define CST_AUDIOBUFFSIZE 8092
+  #define CST_AUDIOBUFFSIZE 8092
+#elif defined(CST_AUDIO_PORTAUDIO)
+  #define CST_AUDIOBUFFSIZE 0
 #else
-#define CST_AUDIOBUFFSIZE 128
+  #define CST_AUDIOBUFFSIZE 128
 #endif
 
 #define CST_AUDIO_DEFAULT_PORT 1746

--- a/include/cst_audio.h
+++ b/include/cst_audio.h
@@ -71,11 +71,13 @@ typedef struct cst_audiodev_struct {
 } cst_audiodev;
 
 /* Generic audio functions */
+int audio_init();
 cst_audiodev *audio_open(int sps, int channels, cst_audiofmt fmt);
 int audio_close(cst_audiodev *ad);
 int audio_write(cst_audiodev *ad, void *buff, int num_bytes);
 int audio_flush(cst_audiodev *ad); /* wait for buffers to empty */
 int audio_drain(cst_audiodev *ad); /* empty buffers now */
+int audio_exit();
 
 /* Generic high level audio functions */
 int play_wave(cst_wave *w);

--- a/include/mimic.h
+++ b/include/mimic.h
@@ -70,6 +70,7 @@ extern cst_lang mimic_lang_list[20];
 
 /* Public functions */
 int mimic_init();
+int mimic_exit();
 
 /* General top level functions */
 cst_voice *mimic_voice_select(const char *name);

--- a/main/mimic_main.c
+++ b/main/mimic_main.c
@@ -419,5 +419,6 @@ loop:
     delete_val(mimic_voice_list); mimic_voice_list=0;
     /*    cst_alloc_debug_summary(); */
 
+    mimic_exit();
     return 0;
 }

--- a/main/mimic_time_main.c
+++ b/main/mimic_time_main.c
@@ -102,6 +102,8 @@ int main(int argc, char **argv)
     printf("%s\n",thetime);
     mimic_text_to_speech(thetime,v,output);
 
+    mimic_exit();
+
     return 0;
 }
 

--- a/main/mimicvox_info_main.c
+++ b/main/mimicvox_info_main.c
@@ -103,6 +103,8 @@ int main(int argc, char **argv)
         printf("%s \"%s\"\n",feat,feat_string(v->features,feat));
     }
 
+    mimic_exit();
+
     return 0;
 
 }

--- a/main/t2p_main.c
+++ b/main/t2p_main.c
@@ -135,5 +135,6 @@ int main(int argc, char **argv)
     delete_features(args);
     delete_val(files);
     
+    mimic_exit();
     return 0;
 }

--- a/src/audio/Makefile
+++ b/src/audio/Makefile
@@ -46,7 +46,7 @@ SRCS = $(BASESRCS) $(AUDIODRIVER:%=au_%.c)
 OBJS = $(SRCS:.c=.o)
 FILES = Makefile $(H) $(BASESRCS) au_command.c au_none.c \
 	au_oss.c au_sun.c au_wince.c au_palmos.c au_alsa.c \
-        au_pulseaudio.c
+        au_pulseaudio.c au_portaudio.c
 LIBNAME = mimic
 
 LOCAL_INCLUDES = -I. $(AUDIODEFS)

--- a/src/audio/au_alsa.c
+++ b/src/audio/au_alsa.c
@@ -55,6 +55,14 @@
 
 int audio_flush_alsa(cst_audiodev *ad);
 
+int audio_init_alsa() {
+   return 0;
+}
+
+int audio_exit_alsa() {
+    return 0;
+}
+
 /*static char *pcm_dev_name = "hw:0,0"; */
 static const char *pcm_dev_name ="default";
 

--- a/src/audio/au_command.c
+++ b/src/audio/au_command.c
@@ -39,6 +39,14 @@
 /*************************************************************************/
 #include "cst_audio.h"
 
+int audio_init_command() {
+   return 0;
+}
+
+int audio_exit_command() {
+    return 0;
+}
+
 cst_audiodev * audio_open_command(int sps, int channels, int fmt)
 {
     cst_audiodev *ad;

--- a/src/audio/au_none.c
+++ b/src/audio/au_none.c
@@ -42,6 +42,15 @@
 #include "cst_wave.h"
 #include "cst_audio.h"
 
+int audio_init_none() {
+   return 0;
+}
+
+int audio_exit_none() {
+    return 0;
+}
+
+
 cst_audiodev * audio_open_none(int sps, int channels, int fmt)
 {
     cst_audiodev *ad;

--- a/src/audio/au_oss.c
+++ b/src/audio/au_oss.c
@@ -63,6 +63,15 @@
 
 static const char * const oss_audio_device = "/dev/dsp";
 
+int audio_init_oss() {
+   return 0;
+}
+
+int audio_exit_oss() {
+    return 0;
+}
+
+
 cst_audiodev *audio_open_oss(int sps, int channels, cst_audiofmt fmt)
 {
     cst_audiodev *ad;

--- a/src/audio/au_palmos.c
+++ b/src/audio/au_palmos.c
@@ -47,6 +47,15 @@
 
 #include <System/SoundMgr.h>
 
+int audio_init_palmos() {
+   return 0;
+}
+
+int audio_exit_palmos() {
+    return 0;
+}
+
+
 cst_audiodev *audio_open_palmos(int sps, int channels, cst_audiofmt fmt)
 {
     cst_audiodev *ad;

--- a/src/audio/au_portaudio.c
+++ b/src/audio/au_portaudio.c
@@ -102,11 +102,10 @@ static int audio_error_portaudio(int err) {
   if( err == paNoError ) {
     return err;
   }
-    Pa_Terminate();
-    fprintf( stderr, "An error occured while using the portaudio stream\n" );
-    fprintf( stderr, "Error number: %d\n", err );
-    fprintf( stderr, "Error message: %s\n", Pa_GetErrorText( err ) );
-    return err;
+  cst_errmsg("An error occured while using the portaudio stream\n");
+  cst_errmsg("Error number: %d\n", err);
+  cst_errmsg("Error message: %s\n", Pa_GetErrorText(err));
+  return err;
 }
 
 
@@ -126,7 +125,7 @@ cst_audiodev * audio_open_portaudio(int sps, int channels, cst_audiofmt fmt) {
 
   hdl->outputParameters->device = Pa_GetDefaultOutputDevice(); /* default output device */
   if (hdl->outputParameters->device == paNoDevice) {
-    fprintf(stderr,"Error: No default output device.\n");
+    cst_errmsg("Error: No default output device.\n");
     audio_error_portaudio(paInvalidDevice);
     return NULL;
   }
@@ -141,7 +140,7 @@ cst_audiodev * audio_open_portaudio(int sps, int channels, cst_audiofmt fmt) {
       hdl->bytes_per_frame = channels*1;
       break;
     case CST_AUDIO_MULAW:
-      fprintf(stderr,"Error: MULAW not supported in portaudio.\n");
+      cst_errmsg("Error: MULAW not supported in portaudio.\n");
     default:
       audio_error_portaudio(paSampleFormatNotSupported);
       free(ad);
@@ -216,56 +215,21 @@ int audio_write_portaudio(cst_audiodev *ad, void *buff, int num_bytes) {
       paClipOff,  /* we won't output out of range samples?*/
       pa_callback,
       data);
-  if (audio_error_portaudio(err) < 0) return err;
+  if (audio_error_portaudio(err) < 0)
+    return err;
   err = Pa_StartStream(hdl->stream);
-  if (audio_error_portaudio(err) < 0) return err;
+  if (audio_error_portaudio(err) < 0)
+    return err;
   while((err = Pa_IsStreamActive(hdl->stream)) == 1){
     Pa_Sleep(100);
   }
   err = Pa_StopStream(hdl->stream);
-  if (audio_error_portaudio(err) < 0) return err;
+  if (audio_error_portaudio(err) < 0)
+    return err;
   err = Pa_CloseStream(hdl->stream);
-  if (audio_error_portaudio(err) < 0) return err;
+  if (audio_error_portaudio(err) < 0)
+    return err;
   free(data);
   return num_bytes;
 }
 
-
-
-/*
-int main(void)
-{
-    PaError err;
-
-    if (audio_init_portaudio() < 0) {
-    return -1;
-  }
-
-  int sps = 44100;
-  int channels = 2;
-  int num_seconds = 5;
-  long int i,j;
-  double freqs[] = {1500, 3500};
-  long int num_frames = num_seconds*sps;
-  long int num_bytes = num_frames*channels*sizeof(int16_t);
-  int16_t *buff = malloc(num_bytes);
-  int16_t *iter = buff;
-  if (buff == NULL) {
-    return -1;
-  }
-  for (i=0;i<num_frames;i++) {
-    for (j=0;j<channels;j++) {
-      *iter++ = 32767*sin(2*3.14*freqs[j]*i/sps);
-    }
-  }
-  cst_audiofmt fmt = CST_AUDIO_LINEAR16;
-  cst_audiodev *ad = audio_open_portaudio(sps, channels, fmt);
-  if (ad == NULL) return -1;
-  err = audio_write_portaudio(ad, buff, num_bytes);
-  if (err < 0) return -1;
-  
-  audio_exit_portaudio();
-    
-    return 0;
-}
-*/

--- a/src/audio/au_portaudio.c
+++ b/src/audio/au_portaudio.c
@@ -1,0 +1,271 @@
+/*************************************************************************/
+/*                                                                       */
+/*                  Language Technologies Institute                      */
+/*                     Carnegie Mellon University                        */
+/*                        Copyright (c) 2004                             */
+/*                        All Rights Reserved.                           */
+/*                                                                       */
+/*  Permission is hereby granted, free of charge, to use and distribute  */
+/*  this software and its documentation without restriction, including   */
+/*  without limitation the rights to use, copy, modify, merge, publish,  */
+/*  distribute, sublicense, and/or sell copies of this work, and to      */
+/*  permit persons to whom this work is furnished to do so, subject to   */
+/*  the following conditions:                                            */
+/*   1. The code must retain the above copyright notice, this list of    */
+/*      conditions and the following disclaimer.                         */
+/*   2. Any modifications must be clearly marked as such.                */
+/*   3. Original authors' names are not deleted.                         */
+/*   4. The authors' names are not used to endorse or promote products   */
+/*      derived from this software without specific prior written        */
+/*      permission.                                                      */
+/*                                                                       */
+/*  CARNEGIE MELLON UNIVERSITY AND THE CONTRIBUTORS TO THIS WORK         */
+/*  DISCLAIM ALL WARRANTIES WITH REGARD TO THIS SOFTWARE, INCLUDING      */
+/*  ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS, IN NO EVENT   */
+/*  SHALL CARNEGIE MELLON UNIVERSITY NOR THE CONTRIBUTORS BE LIABLE      */
+/*  FOR ANY SPECIAL, INDIRECT OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES    */
+/*  WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN   */
+/*  AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION,          */
+/*  ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF       */
+/*  THIS SOFTWARE.                                                       */
+/*                                                                       */
+/*************************************************************************/
+/*             Author:  Sergio Oller                                     */
+/*               Date:  February 2016                                    */
+/*************************************************************************/
+/*                                                                       */
+/*  Audio support based on the PortAudio library                         */
+/*                                                                       */
+/*************************************************************************/
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <string.h>
+#include <math.h>
+#include <portaudio.h>
+
+#include "cst_audio.h"
+
+typedef struct {
+    void *buff;
+    long int bufpos;
+    long int num_frames;
+    int channels;
+    int sample_size;
+} callback_data;
+
+
+static int pa_callback(const void *inputBuffer, void *outputBuffer,
+                       unsigned long framesPerBuffer,
+                       const PaStreamCallbackTimeInfo* timeInfo,
+                       PaStreamCallbackFlags statusFlags,
+                       void *userData )
+{
+  callback_data *data = (callback_data *) userData;
+  long int remaining_frames, do_frames, num_bytes;
+
+  (void) timeInfo;
+  (void) statusFlags;
+  (void) inputBuffer;
+
+  if (data->num_frames <= 0) {
+    return paComplete;
+  }
+
+  /* Number of frames to process in this call: */
+  if (framesPerBuffer < data->num_frames) {
+    do_frames = framesPerBuffer;
+    remaining_frames = data->num_frames - framesPerBuffer;
+  } else {
+    do_frames = data->num_frames;
+    remaining_frames = 0;
+  }
+  num_bytes = do_frames*data->channels*data->sample_size;
+  memcpy(outputBuffer, data->buff+data->bufpos, num_bytes);
+  data->bufpos += num_bytes;
+  data->num_frames = remaining_frames;
+  if (remaining_frames == 0) return paComplete;
+  return paContinue;
+}
+
+
+typedef struct cst_audio_portaudiodata_struct {
+  PaStreamParameters *outputParameters;
+  double sample_rate;
+  long int bytes_per_frame;
+  PaStream *stream;
+} cst_audio_portaudiodata;
+
+
+static int audio_error_portaudio(int err) {
+  if( err == paNoError ) {
+    return err;
+  }
+    Pa_Terminate();
+    fprintf( stderr, "An error occured while using the portaudio stream\n" );
+    fprintf( stderr, "Error number: %d\n", err );
+    fprintf( stderr, "Error message: %s\n", Pa_GetErrorText( err ) );
+    return err;
+}
+
+
+cst_audiodev * audio_open_portaudio(int sps, int channels, cst_audiofmt fmt) {
+  cst_audiodev *ad = cst_alloc(cst_audiodev, 1);
+  ad->sps = sps;
+  ad->real_sps = sps;
+  ad->channels = channels;
+  ad->real_channels = channels;
+  ad->fmt = fmt;
+  ad->real_fmt = fmt;
+  ad->byteswap = 0; /* not used */
+  ad->rateconv = NULL; /* not used */
+  cst_audio_portaudiodata *hdl = cst_alloc(cst_audio_portaudiodata, 1);
+  ad->platform_data = (void*) hdl;
+  hdl->outputParameters = cst_alloc(PaStreamParameters, 1);
+
+  hdl->outputParameters->device = Pa_GetDefaultOutputDevice(); /* default output device */
+  if (hdl->outputParameters->device == paNoDevice) {
+    fprintf(stderr,"Error: No default output device.\n");
+    audio_error_portaudio(paInvalidDevice);
+    return NULL;
+  }
+  hdl->outputParameters->channelCount = channels; /* stereo output */
+  switch(fmt) {
+    case CST_AUDIO_LINEAR16:
+      hdl->outputParameters->sampleFormat = paInt16;
+      hdl->bytes_per_frame = channels*2;
+      break;
+    case CST_AUDIO_LINEAR8:
+      hdl->outputParameters->sampleFormat = paInt8;
+      hdl->bytes_per_frame = channels*1;
+      break;
+    case CST_AUDIO_MULAW:
+      fprintf(stderr,"Error: MULAW not supported in portaudio.\n");
+    default:
+      audio_error_portaudio(paSampleFormatNotSupported);
+      free(ad);
+      free(hdl->outputParameters);
+      free(hdl);
+      free(ad);
+      return NULL;
+      break;
+  }
+  hdl->outputParameters->suggestedLatency = Pa_GetDeviceInfo( hdl->outputParameters->device )->defaultLowOutputLatency;
+  hdl->outputParameters->hostApiSpecificStreamInfo = NULL;
+  hdl->sample_rate = (double) sps;
+
+  return ad;
+}
+
+int audio_drain_portaudio(cst_audiodev *ad) {
+  /* audio_write_portaudio does everything */
+  return 0;
+}
+
+int audio_flush_portaudio(cst_audiodev *ad) {
+  /* audio_write_portaudio does everything */
+  return 0;
+}
+
+int audio_close_portaudio(cst_audiodev *ad) {
+  if (ad != NULL) {
+    cst_audio_portaudiodata *hdl = (cst_audio_portaudiodata*) ad->platform_data;
+    if (hdl != NULL) {
+      if (hdl->outputParameters != NULL) {
+        free(hdl->outputParameters);
+      }
+      free(ad->platform_data);
+    }
+    free(ad);
+  }
+  return 0;
+}
+
+int audio_init_portaudio() {
+    int err = Pa_Initialize();
+    audio_error_portaudio(err);
+    return err;
+}
+
+int audio_exit_portaudio() {
+  Pa_Terminate();
+  return 0;
+}
+
+int audio_write_portaudio(cst_audiodev *ad, void *buff, int num_bytes) {
+  int err;
+  cst_audio_portaudiodata * hdl = (cst_audio_portaudiodata*) ad->platform_data;
+  PaStreamParameters *outputParameters = hdl->outputParameters;
+  double sample_rate = hdl->sample_rate;
+  long int num_frames = num_bytes/hdl->bytes_per_frame;
+  /* Data for the callback function */
+  callback_data *data = cst_alloc(callback_data, 1);
+  data->buff = buff;
+  data->num_frames = num_frames;
+  data->channels = ad->channels;
+  data->bufpos=0;
+  data->sample_size = audio_bps(ad->fmt);
+  /* Stream */
+  err = Pa_OpenStream(
+      &(hdl->stream),
+      NULL, /* no input */
+      outputParameters,
+      sample_rate,
+      64,
+      paClipOff,  /* we won't output out of range samples?*/
+      pa_callback,
+      data);
+  if (audio_error_portaudio(err) < 0) return err;
+  err = Pa_StartStream(hdl->stream);
+  if (audio_error_portaudio(err) < 0) return err;
+  while((err = Pa_IsStreamActive(hdl->stream)) == 1){
+    Pa_Sleep(100);
+  }
+  err = Pa_StopStream(hdl->stream);
+  if (audio_error_portaudio(err) < 0) return err;
+  err = Pa_CloseStream(hdl->stream);
+  if (audio_error_portaudio(err) < 0) return err;
+  free(data);
+  return num_bytes;
+}
+
+
+
+/*
+int main(void)
+{
+    PaError err;
+
+    if (audio_init_portaudio() < 0) {
+    return -1;
+  }
+
+  int sps = 44100;
+  int channels = 2;
+  int num_seconds = 5;
+  long int i,j;
+  double freqs[] = {1500, 3500};
+  long int num_frames = num_seconds*sps;
+  long int num_bytes = num_frames*channels*sizeof(int16_t);
+  int16_t *buff = malloc(num_bytes);
+  int16_t *iter = buff;
+  if (buff == NULL) {
+    return -1;
+  }
+  for (i=0;i<num_frames;i++) {
+    for (j=0;j<channels;j++) {
+      *iter++ = 32767*sin(2*3.14*freqs[j]*i/sps);
+    }
+  }
+  cst_audiofmt fmt = CST_AUDIO_LINEAR16;
+  cst_audiodev *ad = audio_open_portaudio(sps, channels, fmt);
+  if (ad == NULL) return -1;
+  err = audio_write_portaudio(ad, buff, num_bytes);
+  if (err < 0) return -1;
+  
+  audio_exit_portaudio();
+    
+    return 0;
+}
+*/

--- a/src/audio/au_portaudio.c
+++ b/src/audio/au_portaudio.c
@@ -182,7 +182,9 @@ int audio_close_portaudio(cst_audiodev *ad) {
 }
 
 int audio_init_portaudio() {
+    cst_errmsg("If audio works ignore messages below\n");
     int err = Pa_Initialize();
+    cst_errmsg("If audio works ignore messages above\n");
     audio_error_portaudio(err);
     return err;
 }

--- a/src/audio/au_pulseaudio.c
+++ b/src/audio/au_pulseaudio.c
@@ -47,6 +47,15 @@
 
 #include <pulse/simple.h>
 
+int audio_init_pulseaudio() {
+   return 0;
+}
+
+int audio_exit_pulseaudio() {
+    return 0;
+}
+
+
 cst_audiodev *audio_open_pulseaudio(unsigned int sps, int channels, cst_audiofmt fmt)
 {
   cst_audiodev *ad;

--- a/src/audio/au_sun.c
+++ b/src/audio/au_sun.c
@@ -53,6 +53,14 @@
 
 static const char *sun_audio_device = "/dev/audio";
 
+int audio_init_sun() {
+   return 0;
+}
+
+int audio_exit_sun() {
+    return 0;
+}
+
 cst_audiodev *audio_open_sun(int sps, int channels, cst_audiofmt fmt)
 {
     audio_info_t ainfo;

--- a/src/audio/au_wince.c
+++ b/src/audio/au_wince.c
@@ -254,3 +254,12 @@ int audio_drain_wince(cst_audiodev *ad)
         WaitForSingleObject(pd->bevt, INFINITE);
     return 0;
 }
+
+int audio_init_wince() {
+   return 0;
+}
+
+int audio_exit_wince() {
+    return 0;
+}
+

--- a/src/audio/auclient.c
+++ b/src/audio/auclient.c
@@ -54,85 +54,89 @@
 #include <unistd.h>
 
 int play_wave_client(cst_wave *w,const char *servername,int port,
-		     const char *encoding)
+                   const char *encoding)
 {
-    int audiofd,q,i,n,r;
-    int sample_width;
-    unsigned char bytes[CST_AUDIOBUFFSIZE];
-    short shorts[CST_AUDIOBUFFSIZE];
-    snd_header header;
+  int audiofd,q,i,n,r;
+  int sample_width;
+  unsigned char *bytes;
+  short *shorts;
+  snd_header header;
 
-    if (!w)
-	return CST_ERROR_FORMAT;
+  if (!w)
+      return CST_ERROR_FORMAT;
 
-    if ((audiofd = cst_socket_open(servername,port)) == 0)
-	return CST_ERROR_FORMAT;
+  if ((audiofd = cst_socket_open(servername,port)) == 0)
+      return CST_ERROR_FORMAT;
 
-    header.magic = (unsigned int)0x2e736e64;
-    header.hdr_size = sizeof(header);
-    if (cst_streq(encoding,"ulaw"))
-    {
-	sample_width = 1;
-	header.encoding = 1; /* ulaw */
-    }
-    else if (cst_streq(encoding,"uchar"))
-    {
-	sample_width = 1;
-	header.encoding = 2; /* unsigned char */
-    }
-    else 
-    {
-	sample_width = 2;
-	header.encoding = 3; /* short */
-    }
-    header.data_size = sample_width * w->num_samples * w->num_channels;
-    header.sample_rate = w->sample_rate;
-    header.channels = w->num_channels;
-    if (CST_LITTLE_ENDIAN)
-    {   /* If I'm intel etc swap things, so "network byte order" */
-	header.magic = SWAPINT(header.magic);
-	header.hdr_size = SWAPINT(header.hdr_size);
-	header.data_size = SWAPINT(header.data_size);
-	header.encoding = SWAPINT(header.encoding);
-	header.sample_rate = SWAPINT(header.sample_rate);
-	header.channels = SWAPINT(header.channels);
-    }
+  header.magic = (unsigned int)0x2e736e64;
+  header.hdr_size = sizeof(header);
+  if (cst_streq(encoding,"ulaw"))
+  {
+      sample_width = 1;
+      header.encoding = 1; /* ulaw */
+  }
+  else if (cst_streq(encoding,"uchar"))
+  {
+      sample_width = 1;
+      header.encoding = 2; /* unsigned char */
+  }
+  else 
+  {
+      sample_width = 2;
+      header.encoding = 3; /* short */
+  }
+  header.data_size = sample_width * w->num_samples * w->num_channels;
+  header.sample_rate = w->sample_rate;
+  header.channels = w->num_channels;
+  if (CST_LITTLE_ENDIAN)
+  {   /* If I'm intel etc swap things, so "network byte order" */
+      header.magic = SWAPINT(header.magic);
+      header.hdr_size = SWAPINT(header.hdr_size);
+      header.data_size = SWAPINT(header.data_size);
+      header.encoding = SWAPINT(header.encoding);
+      header.sample_rate = SWAPINT(header.sample_rate);
+      header.channels = SWAPINT(header.channels);
+  }
 
-    if (write(audiofd, &header, sizeof(header)) != sizeof(header))
-    {
-	cst_errmsg("auclinet: failed to write header to server\n");
-	return CST_ERROR_FORMAT;
-    }
+  if (write(audiofd, &header, sizeof(header)) != sizeof(header))
+  {
+      cst_errmsg("auclinet: failed to write header to server\n");
+      return CST_ERROR_FORMAT;
+  }
+  const int buffsize = 128;
+  bytes = cst_alloc(unsigned char, buffsize);
+  shorts = cst_alloc(short, buffsize);
 
-    for (i=0; i < w->num_samples; i += r)
-    {
-	if (w->num_samples > i+CST_AUDIOBUFFSIZE)
-	    n = CST_AUDIOBUFFSIZE;
-	else
-	    n = w->num_samples-i;
-	if (cst_streq(encoding,"ulaw"))
-	{
-	    for (q=0; q<n; q++)
-		bytes[q] = cst_short_to_ulaw(w->samples[i+q]);
-	    r = write(audiofd,bytes,n);
-	}
-	else 
-	{
-	    for (q=0; q<n; q++)
-		if (CST_LITTLE_ENDIAN)
-		    shorts[q] = SWAPSHORT(w->samples[i+q]);
-		else
-		    shorts[q] = w->samples[i+q];
-	    r = write(audiofd,shorts,n*2);
-	    r /= 2;
-	}
-	if (r <= 0)
-	    cst_errmsg("failed to write %d samples\n",n);
-    }
+  for (i=0; i < w->num_samples; i += r)
+  {
+      if (w->num_samples > i+buffsize)
+          n = buffsize;
+      else
+          n = w->num_samples-i;
+      if (cst_streq(encoding,"ulaw"))
+      {
+          for (q=0; q<n; q++)
+              bytes[q] = cst_short_to_ulaw(w->samples[i+q]);
+          r = write(audiofd,bytes,n);
+      }
+      else 
+      {
+          for (q=0; q<n; q++)
+              if (CST_LITTLE_ENDIAN)
+                  shorts[q] = SWAPSHORT(w->samples[i+q]);
+              else
+                  shorts[q] = w->samples[i+q];
+          r = write(audiofd,shorts,n*2);
+          r /= 2;
+      }
+      if (r <= 0)
+          cst_errmsg("failed to write %d samples\n",n);
+  }
 
-    cst_socket_close(audiofd);
-
-    return CST_OK_FORMAT;
+  cst_socket_close(audiofd);
+  free(bytes);
+  free(shorts);
+  return CST_OK_FORMAT;
 }
 
 #endif

--- a/src/audio/audio.c
+++ b/src/audio/audio.c
@@ -44,273 +44,273 @@
 
 int audio_bps(cst_audiofmt fmt)
 {
-    switch (fmt)
-    {
-    case CST_AUDIO_LINEAR16:
-	return 2;
-    case CST_AUDIO_LINEAR8:
-    case CST_AUDIO_MULAW:
-	return 1;
-    }
-    return 0;
+  switch (fmt)
+  {
+  case CST_AUDIO_LINEAR16:
+      return 2;
+  case CST_AUDIO_LINEAR8:
+  case CST_AUDIO_MULAW:
+      return 1;
+  }
+  return 0;
 }
 
 cst_audiodev *audio_open(int sps, int channels, cst_audiofmt fmt)
 {
-    cst_audiodev *ad;
-    int up, down;
+  cst_audiodev *ad;
+  int up, down;
 
-    ad = AUDIO_OPEN_NATIVE(sps, channels, fmt);
-    if (ad == NULL)
-	return NULL;
+  ad = AUDIO_OPEN_NATIVE(sps, channels, fmt);
+  if (ad == NULL)
+      return NULL;
 
-    down = sps / 1000;
-    up = ad->real_sps / 1000;
+  down = sps / 1000;
+  up = ad->real_sps / 1000;
 
-    if (up != down)
-	ad->rateconv = new_rateconv(up, down, channels);
+  if (up != down)
+      ad->rateconv = new_rateconv(up, down, channels);
 
-    return ad;
+  return ad;
 }
 
 int audio_close(cst_audiodev *ad)
 {
-    if (ad->rateconv)
-	delete_rateconv(ad->rateconv);
+  if (ad->rateconv)
+      delete_rateconv(ad->rateconv);
 
-    return AUDIO_CLOSE_NATIVE(ad);
+  return AUDIO_CLOSE_NATIVE(ad);
 }
 
 int audio_write(cst_audiodev *ad,void *buff,int num_bytes)
 {
-    void *abuf = buff, *nbuf = NULL;
-    int rv, i, real_num_bytes = num_bytes;
+  void *abuf = buff, *nbuf = NULL;
+  int rv, i, real_num_bytes = num_bytes;
 
-    if (ad->rateconv)
-    {
-	short *in, *out;
-	int insize, outsize, n;
+  if (ad->rateconv)
+  {
+      short *in, *out;
+      int insize, outsize, n;
 
-	insize = real_num_bytes / 2;
-	in = (short *)buff;
+      insize = real_num_bytes / 2;
+      in = (short *)buff;
 
-	outsize = ad->rateconv->outsize;
-	nbuf = out = cst_alloc(short, outsize);
-	real_num_bytes = outsize * 2;
+      outsize = ad->rateconv->outsize;
+      nbuf = out = cst_alloc(short, outsize);
+      real_num_bytes = outsize * 2;
 
-	while ((n = cst_rateconv_in(ad->rateconv, in, insize)) > 0)
-	{
-	    in += n; 
-	    insize -= n;
-	    while ((n = cst_rateconv_out(ad->rateconv, out, outsize)) > 0)
-	    {
-		out += n; 
-		outsize -= n;
-	    }
-	}
-	real_num_bytes -= outsize * 2;
-	if (abuf != buff)
-	    cst_free(abuf);
-	abuf = nbuf;
-    }
-    if (ad->real_channels != ad->channels)
-    {
-	/* Yeah, we only do mono->stereo for now */
-	if (ad->real_channels != 2 || ad->channels != 1)
-	{
-	    cst_errmsg("audio_write: unsupported channel mapping requested (%d => %d).\n",
-		       ad->channels, ad->real_channels);
-	}
-	nbuf = cst_alloc(char, real_num_bytes * ad->real_channels / ad->channels);
+      while ((n = cst_rateconv_in(ad->rateconv, in, insize)) > 0)
+      {
+          in += n; 
+          insize -= n;
+          while ((n = cst_rateconv_out(ad->rateconv, out, outsize)) > 0)
+          {
+              out += n; 
+              outsize -= n;
+          }
+      }
+      real_num_bytes -= outsize * 2;
+      if (abuf != buff)
+          cst_free(abuf);
+      abuf = nbuf;
+  }
+  if (ad->real_channels != ad->channels)
+  {
+      /* Yeah, we only do mono->stereo for now */
+      if (ad->real_channels != 2 || ad->channels != 1)
+      {
+          cst_errmsg("audio_write: unsupported channel mapping requested (%d => %d).\n",
+                     ad->channels, ad->real_channels);
+      }
+      nbuf = cst_alloc(char, real_num_bytes * ad->real_channels / ad->channels);
 
-	if (audio_bps(ad->fmt) == 2)
-	{
-	    for (i = 0; i < real_num_bytes / 2; ++i)
-	    {
-		((short *)nbuf)[i*2] = ((short *)abuf)[i];
-		((short *)nbuf)[i*2+1] = ((short *)abuf)[i];
-	    }
-	}
-	else if (audio_bps(ad->fmt) == 1)
-	{
-	    for (i = 0; i < real_num_bytes / 2; ++i)
-	    {
-		((unsigned char *)nbuf)[i*2] = ((unsigned char *)abuf)[i];
-		((unsigned char *)nbuf)[i*2+1] = ((unsigned char *)abuf)[i];
-	    }
-	}
-	else
-	{
-	    cst_errmsg("audio_write: unknown format %d\n", ad->fmt);
-	    cst_free(nbuf);
-	    if (abuf != buff)
-		cst_free(abuf);
-	    cst_error();
-	}
+      if (audio_bps(ad->fmt) == 2)
+      {
+          for (i = 0; i < real_num_bytes / 2; ++i)
+          {
+              ((short *)nbuf)[i*2] = ((short *)abuf)[i];
+              ((short *)nbuf)[i*2+1] = ((short *)abuf)[i];
+          }
+      }
+      else if (audio_bps(ad->fmt) == 1)
+      {
+          for (i = 0; i < real_num_bytes / 2; ++i)
+          {
+              ((unsigned char *)nbuf)[i*2] = ((unsigned char *)abuf)[i];
+              ((unsigned char *)nbuf)[i*2+1] = ((unsigned char *)abuf)[i];
+          }
+      }
+      else
+      {
+          cst_errmsg("audio_write: unknown format %d\n", ad->fmt);
+          cst_free(nbuf);
+          if (abuf != buff)
+              cst_free(abuf);
+          cst_error();
+      }
 
-	if (abuf != buff)
-	    cst_free(abuf);
-	abuf = nbuf;
-	real_num_bytes = real_num_bytes * ad->real_channels / ad->channels;
-    }
-    if (ad->real_fmt != ad->fmt)
-    {
-	if (ad->real_fmt == CST_AUDIO_LINEAR16
-	    && ad->fmt == CST_AUDIO_MULAW)
-	{
-	    nbuf = cst_alloc(char, real_num_bytes * 2);
-	    for (i = 0; i < real_num_bytes; ++i)
-		((short *)nbuf)[i] = cst_ulaw_to_short(((unsigned char *)abuf)[i]);
-	    real_num_bytes *= 2;
-	}
-	else if (ad->real_fmt == CST_AUDIO_MULAW
-		 && ad->fmt == CST_AUDIO_LINEAR16)
-	{
-	    nbuf = cst_alloc(char, real_num_bytes / 2);
-	    for (i = 0; i < real_num_bytes / 2; ++i)
-		((unsigned char *)nbuf)[i] = cst_short_to_ulaw(((short *)abuf)[i]);
-	    real_num_bytes /= 2;
-	}
-	else if (ad->real_fmt == CST_AUDIO_LINEAR8
-		 && ad->fmt == CST_AUDIO_LINEAR16)
-	{
-	    nbuf = cst_alloc(char, real_num_bytes / 2);
-	    for (i = 0; i < real_num_bytes / 2; ++i)
-		((unsigned char *)nbuf)[i] = (((short *)abuf)[i] >> 8) + 128;
-	    real_num_bytes /= 2;
-	}
-	else
-	{
-	    cst_errmsg("audio_write: unknown format conversion (%d => %d) requested.\n",
-		       ad->fmt, ad->real_fmt);
-	    cst_free(nbuf);
-	    if (abuf != buff)
-		cst_free(abuf);
-	    cst_error();
-	}
-	if (abuf != buff)
-	    cst_free(abuf);
-	abuf = nbuf;
-    }
-    if (ad->byteswap && audio_bps(ad->real_fmt) == 2)
-	swap_bytes_short((short *)abuf, real_num_bytes/2);
+      if (abuf != buff)
+          cst_free(abuf);
+      abuf = nbuf;
+      real_num_bytes = real_num_bytes * ad->real_channels / ad->channels;
+  }
+  if (ad->real_fmt != ad->fmt)
+  {
+      if (ad->real_fmt == CST_AUDIO_LINEAR16
+          && ad->fmt == CST_AUDIO_MULAW)
+      {
+          nbuf = cst_alloc(char, real_num_bytes * 2);
+          for (i = 0; i < real_num_bytes; ++i)
+              ((short *)nbuf)[i] = cst_ulaw_to_short(((unsigned char *)abuf)[i]);
+          real_num_bytes *= 2;
+      }
+      else if (ad->real_fmt == CST_AUDIO_MULAW
+               && ad->fmt == CST_AUDIO_LINEAR16)
+      {
+          nbuf = cst_alloc(char, real_num_bytes / 2);
+          for (i = 0; i < real_num_bytes / 2; ++i)
+              ((unsigned char *)nbuf)[i] = cst_short_to_ulaw(((short *)abuf)[i]);
+          real_num_bytes /= 2;
+      }
+      else if (ad->real_fmt == CST_AUDIO_LINEAR8
+               && ad->fmt == CST_AUDIO_LINEAR16)
+      {
+          nbuf = cst_alloc(char, real_num_bytes / 2);
+          for (i = 0; i < real_num_bytes / 2; ++i)
+              ((unsigned char *)nbuf)[i] = (((short *)abuf)[i] >> 8) + 128;
+          real_num_bytes /= 2;
+      }
+      else
+      {
+          cst_errmsg("audio_write: unknown format conversion (%d => %d) requested.\n",
+                     ad->fmt, ad->real_fmt);
+          cst_free(nbuf);
+          if (abuf != buff)
+              cst_free(abuf);
+          cst_error();
+      }
+      if (abuf != buff)
+          cst_free(abuf);
+      abuf = nbuf;
+  }
+  if (ad->byteswap && audio_bps(ad->real_fmt) == 2)
+      swap_bytes_short((short *)abuf, real_num_bytes/2);
 
-    if (real_num_bytes)
-	rv = AUDIO_WRITE_NATIVE(ad,abuf,real_num_bytes);
-    else
-	rv = 0;
+  if (real_num_bytes)
+      rv = AUDIO_WRITE_NATIVE(ad,abuf,real_num_bytes);
+  else
+      rv = 0;
 
-    if (abuf != buff)
-	cst_free(abuf);
+  if (abuf != buff)
+      cst_free(abuf);
 
-    /* Callers expect to get the same num_bytes back as they passed
-       in.  Funny, that ... */
-    return (rv == real_num_bytes) ? num_bytes : 0;
+  /* Callers expect to get the same num_bytes back as they passed
+     in.  Funny, that ... */
+  return (rv == real_num_bytes) ? num_bytes : 0;
 }
 
 int audio_init()
 {
-    return AUDIO_INIT_NATIVE();
+  return AUDIO_INIT_NATIVE();
 }
 
 int audio_exit()
 {
-    return AUDIO_EXIT_NATIVE();
+  return AUDIO_EXIT_NATIVE();
 }
 
 int audio_drain(cst_audiodev *ad)
 {
-    return AUDIO_DRAIN_NATIVE(ad);
+  return AUDIO_DRAIN_NATIVE(ad);
 }
 
 int audio_flush(cst_audiodev *ad)
 {
-    return AUDIO_FLUSH_NATIVE(ad);
+  return AUDIO_FLUSH_NATIVE(ad);
 }
 
 int play_wave(cst_wave *w)
 {
-    cst_audiodev *ad;
-    int i,n,r;
-    int num_shorts;
+  cst_audiodev *ad;
+  int i,n,r;
+  int num_shorts;
 
-    if (!w)
-	return CST_ERROR_FORMAT;
-    
-    if ((ad = audio_open(w->sample_rate, w->num_channels,
-			 /* FIXME: should be able to determine this somehow */
-			 CST_AUDIO_LINEAR16)) == NULL)
-	return CST_ERROR_FORMAT;
-    num_shorts = w->num_samples*w->num_channels;
-    /* TODO: Fix all other play_wave functions so PortAudio works on them too */
-    #ifdef CST_AUDIO_PORTAUDIO
-    r = audio_write(ad,w->samples,num_shorts*2);
-    if (r <= 0) {
-        cst_errmsg("failed to write %d samples\n",n);
-    }
-    #else
-    for (i=0; i < num_shorts; i += r/2)
-    {
-	if (num_shorts > i+CST_AUDIOBUFFSIZE)
-	    n = CST_AUDIOBUFFSIZE;
-	else
-	    n = num_shorts-i;
-	r = audio_write(ad,&w->samples[i],n*2);
-	if (r <= 0)
-	{
-	    cst_errmsg("failed to write %d samples\n",n);
-	    break;
-	}
-    }
-    #endif
-    audio_close(ad);
+  if (!w)
+      return CST_ERROR_FORMAT;
+  
+  if ((ad = audio_open(w->sample_rate, w->num_channels,
+                       /* FIXME: should be able to determine this somehow */
+                       CST_AUDIO_LINEAR16)) == NULL)
+      return CST_ERROR_FORMAT;
+  num_shorts = w->num_samples*w->num_channels;
+  /* TODO: Fix all other play_wave functions so PortAudio works on them too */
+  #ifdef CST_AUDIO_PORTAUDIO
+  r = audio_write(ad,w->samples,num_shorts*2);
+  if (r <= 0) {
+      cst_errmsg("failed to write %d samples\n",n);
+  }
+  #else
+  for (i=0; i < num_shorts; i += r/2)
+  {
+      if (num_shorts > i+CST_AUDIOBUFFSIZE)
+          n = CST_AUDIOBUFFSIZE;
+      else
+          n = num_shorts-i;
+      r = audio_write(ad,&w->samples[i],n*2);
+      if (r <= 0)
+      {
+          cst_errmsg("failed to write %d samples\n",n);
+          break;
+      }
+  }
+  #endif
+  audio_close(ad);
 
-    return CST_OK_FORMAT;
+  return CST_OK_FORMAT;
 }
 
 int play_wave_sync(cst_wave *w, cst_relation *rel,
-		   int (*call_back)(cst_item *))
+                 int (*call_back)(cst_item *))
 {
-    int q,i,n,r;
-    cst_audiodev *ad;
-    float r_pos;
-    cst_item *item;
+  int q,i,n,r;
+  cst_audiodev *ad;
+  float r_pos;
+  cst_item *item;
 
-    if (!w)
-	return CST_ERROR_FORMAT;
-    
-    if ((ad = audio_open(w->sample_rate,w->num_channels,
-			 CST_AUDIO_LINEAR16)) == NULL)
-	return CST_ERROR_FORMAT;
+  if (!w)
+      return CST_ERROR_FORMAT;
+  
+  if ((ad = audio_open(w->sample_rate,w->num_channels,
+                       CST_AUDIO_LINEAR16)) == NULL)
+      return CST_ERROR_FORMAT;
 
-    q=0;
-    item = relation_head(rel);
-    r_pos = w->sample_rate * 0;
-    for (i=0; i < w->num_samples; i += r/2)
-    {
-	if (i >= r_pos)
-	{
-	    audio_flush(ad);
+  q=0;
+  item = relation_head(rel);
+  r_pos = w->sample_rate * 0;
+  for (i=0; i < w->num_samples; i += r/2)
+  {
+      if (i >= r_pos)
+      {
+          audio_flush(ad);
 
-	    if ((*call_back)(item) != CST_OK_FORMAT)
-		break;
-	    item = item_next(item);
-	    if (item)
-		r_pos = w->sample_rate * val_float(ffeature(item,"p.end"));
-	    else
-		r_pos = w->num_samples;
-	}
-	if (w->num_samples > i+CST_AUDIOBUFFSIZE)
-	    n = CST_AUDIOBUFFSIZE;
-	else
-	    n = w->num_samples-i;
-	r = audio_write(ad,&w->samples[i],n*2);
-	q +=r;
-	if (r <= 0)
-	    cst_errmsg("failed to write %d samples\n",n);
-    }
+          if ((*call_back)(item) != CST_OK_FORMAT)
+              break;
+          item = item_next(item);
+          if (item)
+              r_pos = w->sample_rate * val_float(ffeature(item,"p.end"));
+          else
+              r_pos = w->num_samples;
+      }
+      if (w->num_samples > i+CST_AUDIOBUFFSIZE)
+          n = CST_AUDIOBUFFSIZE;
+      else
+          n = w->num_samples-i;
+      r = audio_write(ad,&w->samples[i],n*2);
+      q +=r;
+      if (r <= 0)
+          cst_errmsg("failed to write %d samples\n",n);
+  }
 
-    audio_close(ad);
+  audio_close(ad);
 
-    return CST_OK_FORMAT;
+  return CST_OK_FORMAT;
 }

--- a/src/audio/audio.c
+++ b/src/audio/audio.c
@@ -208,6 +208,16 @@ int audio_write(cst_audiodev *ad,void *buff,int num_bytes)
     return (rv == real_num_bytes) ? num_bytes : 0;
 }
 
+int audio_init()
+{
+    return AUDIO_INIT_NATIVE();
+}
+
+int audio_exit()
+{
+    return AUDIO_EXIT_NATIVE();
+}
+
 int audio_drain(cst_audiodev *ad)
 {
     return AUDIO_DRAIN_NATIVE(ad);
@@ -231,8 +241,14 @@ int play_wave(cst_wave *w)
 			 /* FIXME: should be able to determine this somehow */
 			 CST_AUDIO_LINEAR16)) == NULL)
 	return CST_ERROR_FORMAT;
-
     num_shorts = w->num_samples*w->num_channels;
+    /* TODO: Fix all other play_wave functions so PortAudio works on them too */
+    #ifdef CST_AUDIO_PORTAUDIO
+    r = audio_write(ad,w->samples,num_shorts*2);
+    if (r <= 0) {
+        cst_errmsg("failed to write %d samples\n",n);
+    }
+    #else
     for (i=0; i < num_shorts; i += r/2)
     {
 	if (num_shorts > i+CST_AUDIOBUFFSIZE)
@@ -246,7 +262,7 @@ int play_wave(cst_wave *w)
 	    break;
 	}
     }
-
+    #endif
     audio_close(ad);
 
     return CST_OK_FORMAT;

--- a/src/audio/auserver.c
+++ b/src/audio/auserver.c
@@ -58,123 +58,133 @@
 
 static int play_wave_from_socket(snd_header *header,int audiostream)
 {
-    /* Read audio from stream and play it to audio device, converting */
-    /* it to pcm if required                                          */
-    int num_samples;
-    int sample_width;
-    cst_audiodev *audio_device;
-    int q,i,n,r;
-    unsigned char bytes[CST_AUDIOBUFFSIZE];
-    short shorts[CST_AUDIOBUFFSIZE];
-    cst_file fff;
+   /* Read audio from stream and play it to audio device, converting */
+   /* it to pcm if required                                          */
+   if (CST_AUDIOBUFFSIZE <= 0) {
+      cst_errmsg("play_wave_from_socket not supported with PortAudio\n");
+      return -1;
+   }
+   int num_samples;
+   int sample_width;
+   cst_audiodev *audio_device;
+   int q,i,n,r;
+   unsigned char *bytes;
+   short *shorts;
+   cst_file fff;
 
-    fff = cst_fopen("/tmp/awb.wav",CST_OPEN_WRITE|CST_OPEN_BINARY);
+   fff = cst_fopen("/tmp/awb.wav",CST_OPEN_WRITE|CST_OPEN_BINARY);
 
-    if ((audio_device = audio_open(header->sample_rate,1,
-				   (header->encoding == CST_SND_SHORT) ?
-				   CST_AUDIO_LINEAR16 : CST_AUDIO_LINEAR8)) == NULL)
-    {
-	cst_errmsg("play_wave_from_socket: can't open audio device\n");
-	return -1;
-    }
+   if ((audio_device = audio_open(header->sample_rate,1,
+                                  (header->encoding == CST_SND_SHORT) ?
+                                  CST_AUDIO_LINEAR16 : CST_AUDIO_LINEAR8)) == NULL)
+   {
+       cst_errmsg("play_wave_from_socket: can't open audio device\n");
+       return -1;
+   }
 
-    if (header->encoding == CST_SND_SHORT)
-	sample_width = 2;
-    else
-	sample_width = 1;
+   if (header->encoding == CST_SND_SHORT)
+       sample_width = 2;
+   else
+       sample_width = 1;
 
-    num_samples = header->data_size / sample_width;
-    /* we naively let the num_channels sort itself out */
-    for (i=0; i < num_samples; i += r/2)
-    {
-	if (num_samples > i+CST_AUDIOBUFFSIZE)
-	    n = CST_AUDIOBUFFSIZE;
-	else
-	    n = num_samples-i;
-	if (header->encoding == CST_SND_ULAW)
-	{
-	    r = read(audiostream,bytes,n);
-	    for (q=0; q<r; q++)
-		shorts[q] = cst_ulaw_to_short(bytes[q]);
-	    r *= 2;
-	}
-	else /* if (header->encoding == CST_SND_SHORT) */
-	{
-	    r = read(audiostream,shorts,n*2);
-	    if (CST_LITTLE_ENDIAN)
-		for (q=0; q<r/2; q++)
-		    shorts[q] = SWAPSHORT(shorts[q]);
-	}
-	
-	if (r <= 0)
-	{   /* I'm not getting any data from the server */
-	    audio_close(audio_device);
-	    return CST_ERROR_FORMAT;
-	}
-	
-	for (q=r; q > 0; q-=n)
-	{
-	    n = audio_write(audio_device,shorts,q);
-	    cst_fwrite(fff,shorts,2,q);
-	    if (n <= 0)
-	    {
-		audio_close(audio_device);
-		return CST_ERROR_FORMAT;
-	    }
-	}
-    }
-    audio_close(audio_device);
-    cst_fclose(fff);
-
-    return CST_OK_FORMAT;
-
+   num_samples = header->data_size / sample_width;
+   /* we naively let the num_channels sort itself out */
+   bytes = cst_alloc(unsigned char, CST_AUDIOBUFFSIZE);
+   shorts = cst_alloc(short, CST_AUDIOBUFFSIZE);
+   for (i=0; i < num_samples; i += r/2)
+   {
+       if (num_samples > i+CST_AUDIOBUFFSIZE)
+           n = CST_AUDIOBUFFSIZE;
+       else
+           n = num_samples-i;
+       if (header->encoding == CST_SND_ULAW)
+       {
+           r = read(audiostream,bytes,n);
+           for (q=0; q<r; q++)
+               shorts[q] = cst_ulaw_to_short(bytes[q]);
+           r *= 2;
+       }
+       else /* if (header->encoding == CST_SND_SHORT) */
+       {
+           r = read(audiostream,shorts,n*2);
+           if (CST_LITTLE_ENDIAN)
+               for (q=0; q<r/2; q++)
+                   shorts[q] = SWAPSHORT(shorts[q]);
+       }
+       
+       if (r <= 0)
+       {   /* I'm not getting any data from the server */
+           audio_close(audio_device);
+           free(bytes);
+           free(shorts);
+           return CST_ERROR_FORMAT;
+       }
+       
+       for (q=r; q > 0; q-=n)
+       {
+           n = audio_write(audio_device,shorts,q);
+           cst_fwrite(fff,shorts,2,q);
+           if (n <= 0)
+           {
+               audio_close(audio_device);
+							 free(bytes);
+							 free(shorts);
+               return CST_ERROR_FORMAT;
+           }
+       }
+   }
+   audio_close(audio_device);
+   cst_fclose(fff);
+	 free(bytes);
+	 free(shorts);
+   return CST_OK_FORMAT;
 }
 
 static int auserver_process_client(int client_name, int fd)
 {
-    /* Gets called for each client */
-    snd_header header;
-    int r;
+   /* Gets called for each client */
+   snd_header header;
+   int r;
 
-    printf("client %d connected, ",client_name);
-    fflush(stdout);
-    /* Get header */
-    r = read(fd,&header,sizeof(header));
-    if (r != sizeof(header))
-    {
-	cst_errmsg("socket: connection didn't give a header\n");
-	return -1;
-    }
-    if (CST_LITTLE_ENDIAN)
-    {
-	header.magic = SWAPINT(header.magic);
-	header.hdr_size = SWAPINT(header.hdr_size);
-	header.data_size = SWAPINT(header.data_size);
-	header.encoding = SWAPINT(header.encoding);
-	header.sample_rate = SWAPINT(header.sample_rate);
-	header.channels = SWAPINT(header.channels);
-    }
+   printf("client %d connected, ",client_name);
+   fflush(stdout);
+   /* Get header */
+   r = read(fd,&header,sizeof(header));
+   if (r != sizeof(header))
+   {
+       cst_errmsg("socket: connection didn't give a header\n");
+       return -1;
+   }
+   if (CST_LITTLE_ENDIAN)
+   {
+       header.magic = SWAPINT(header.magic);
+       header.hdr_size = SWAPINT(header.hdr_size);
+       header.data_size = SWAPINT(header.data_size);
+       header.encoding = SWAPINT(header.encoding);
+       header.sample_rate = SWAPINT(header.sample_rate);
+       header.channels = SWAPINT(header.channels);
+   }
 
-    if (header.magic != CST_SND_MAGIC)
-    {
-	cst_errmsg("socket: client something other than snd waveform\n");
-	return -1;
-    }
+   if (header.magic != CST_SND_MAGIC)
+   {
+       cst_errmsg("socket: client something other than snd waveform\n");
+       return -1;
+   }
 
-    printf("%d bytes at %d rate, ", header.data_size, header.sample_rate);
-    fflush(stdout);
+   printf("%d bytes at %d rate, ", header.data_size, header.sample_rate);
+   fflush(stdout);
 
-    if (play_wave_from_socket(&header,fd) == CST_OK_FORMAT)
-	printf("successful\n");
-    else
-	printf("unsuccessful\n");
-    
-    return 0;
+   if (play_wave_from_socket(&header,fd) == CST_OK_FORMAT)
+       printf("successful\n");
+   else
+       printf("unsuccessful\n");
+   
+   return 0;
 }
 
 int auserver(int port)
 {
-    return cst_socket_server("audio",port,auserver_process_client);
+   return cst_socket_server("audio",port,auserver_process_client);
 }
 
 #endif

--- a/src/audio/native_audio.h
+++ b/src/audio/native_audio.h
@@ -43,129 +43,166 @@
 
 #ifdef CST_AUDIO_COMMAND
 
+#define AUDIO_INIT_NATIVE audio_init_command
 #define AUDIO_OPEN_NATIVE audio_open_command
 #define AUDIO_CLOSE_NATIVE audio_close_command
 #define AUDIO_SET_SAMPLE_RATE_NATIVE audio_set_sample_rate_command
 #define AUDIO_WRITE_NATIVE audio_write_command
 #define AUDIO_DRAIN_NATIVE audio_drain_command
 #define AUDIO_FLUSH_NATIVE audio_flush_command
+#define AUDIO_EXIT_NATIVE audio_exit_command
 
 #endif
 
 #ifdef CST_AUDIO_SUNOS
 
+#define AUDIO_INIT_NATIVE audio_init_sun
 #define AUDIO_OPEN_NATIVE audio_open_sun
 #define AUDIO_CLOSE_NATIVE audio_close_sun
 #define AUDIO_SET_SAMPLE_RATE_NATIVE audio_set_sample_rate_sun
 #define AUDIO_WRITE_NATIVE audio_write_sun
 #define AUDIO_DRAIN_NATIVE audio_drain_sun
 #define AUDIO_FLUSH_NATIVE audio_flush_sun
-
+#define AUDIO_EXIT_NATIVE audio_exit_sun
 #endif
 
 #ifdef CST_AUDIO_LINUX
 
+#define AUDIO_INIT_NATIVE audio_init_oss
 #define AUDIO_OPEN_NATIVE audio_open_oss
 #define AUDIO_CLOSE_NATIVE audio_close_oss
 #define AUDIO_SET_SAMPLE_RATE_NATIVE audio_set_sample_rate_oss
 #define AUDIO_WRITE_NATIVE audio_write_oss
 #define AUDIO_DRAIN_NATIVE audio_drain_oss
 #define AUDIO_FLUSH_NATIVE audio_flush_oss
+#define AUDIO_EXIT_NATIVE audio_exit_oss
 
 #endif
 
 #ifdef CST_AUDIO_ALSA
 
+#define AUDIO_INIT_NATIVE audio_init_alsa
 #define AUDIO_OPEN_NATIVE audio_open_alsa
 #define AUDIO_CLOSE_NATIVE audio_close_alsa
 #define AUDIO_SET_SAMPLE_RATE_NATIVE audio_set_sample_rate_alsa
 #define AUDIO_WRITE_NATIVE audio_write_alsa
 #define AUDIO_DRAIN_NATIVE audio_drain_alsa
 #define AUDIO_FLUSH_NATIVE audio_flush_alsa
+#define AUDIO_EXIT_NATIVE audio_exit_alsa
 
 #endif
 
 #ifdef CST_AUDIO_PULSEAUDIO
 
+#define AUDIO_INIT_NATIVE audio_init_pulseaudio
 #define AUDIO_OPEN_NATIVE audio_open_pulseaudio
 #define AUDIO_CLOSE_NATIVE audio_close_pulseaudio
 #define AUDIO_SET_SAMPLE_RATE_NATIVE audio_set_sample_rate_pulseaudio
 #define AUDIO_WRITE_NATIVE audio_write_pulseaudio
 #define AUDIO_DRAIN_NATIVE audio_drain_pulseaudio
 #define AUDIO_FLUSH_NATIVE audio_flush_pulseaudio
+#define AUDIO_EXIT_NATIVE audio_exit_pulseaudio
 
 #endif
 
 #ifdef CST_AUDIO_FREEBSD
 
+#define AUDIO_INIT_NATIVE audio_init_oss
 #define AUDIO_OPEN_NATIVE audio_open_oss
 #define AUDIO_CLOSE_NATIVE audio_close_oss
 #define AUDIO_SET_SAMPLE_RATE_NATIVE audio_set_sample_rate_oss
 #define AUDIO_WRITE_NATIVE audio_write_oss
 #define AUDIO_DRAIN_NATIVE audio_drain_oss
 #define AUDIO_FLUSH_NATIVE audio_flush_oss
+#define AUDIO_EXIT_NATIVE audio_exit_oss
 
 #endif
 
 #ifdef CST_AUDIO_WINCE
 
+#define AUDIO_INIT_NATIVE audio_init_wince
 #define AUDIO_OPEN_NATIVE audio_open_wince
 #define AUDIO_CLOSE_NATIVE audio_close_wince
 #define AUDIO_SET_SAMPLE_RATE_NATIVE audio_set_sample_rate_wince
 #define AUDIO_WRITE_NATIVE audio_write_wince
 #define AUDIO_DRAIN_NATIVE audio_drain_wince
 #define AUDIO_FLUSH_NATIVE audio_flush_wince
+#define AUDIO_EXIT_NATIVE audio_exit_wince
 
 #endif
 
 #ifdef CST_AUDIO_WIN32
+
+#define AUDIO_INIT_NATIVE audio_init_wince
 #define AUDIO_OPEN_NATIVE audio_open_wince
 #define AUDIO_CLOSE_NATIVE audio_close_wince
 #define AUDIO_SET_SAMPLE_RATE_NATIVE audio_set_sample_rate_wince
 #define AUDIO_WRITE_NATIVE audio_write_wince
 #define AUDIO_DRAIN_NATIVE audio_drain_wince
 #define AUDIO_FLUSH_NATIVE audio_flush_wince
+#define AUDIO_EXIT_NATIVE audio_exit_wince
 
 #endif
 
 #ifdef CST_AUDIO_PALMOS
 
+#define AUDIO_INIT_NATIVE audio_init_palmos
 #define AUDIO_OPEN_NATIVE audio_open_palmos
 #define AUDIO_CLOSE_NATIVE audio_close_palmos
 #define AUDIO_SET_SAMPLE_RATE_NATIVE audio_set_sample_rate_palmos
 #define AUDIO_WRITE_NATIVE audio_write_palmos
 #define AUDIO_DRAIN_NATIVE audio_drain_palmos
 #define AUDIO_FLUSH_NATIVE audio_flush_palmos
+#define AUDIO_EXIT_NATIVE audio_exit_palmos
 
 #endif
 
 #ifdef CST_AUDIO_NONE
 
+#define AUDIO_INIT_NATIVE audio_init_none
 #define AUDIO_OPEN_NATIVE audio_open_none
 #define AUDIO_CLOSE_NATIVE audio_close_none
 #define AUDIO_SET_SAMPLE_RATE_NATIVE audio_set_sample_rate_none
 #define AUDIO_WRITE_NATIVE audio_write_none
 #define AUDIO_DRAIN_NATIVE audio_drain_none
 #define AUDIO_FLUSH_NATIVE audio_flush_none
+#define AUDIO_EXIT_NATIVE audio_exit_none
+
+#endif
+
+#ifdef CST_AUDIO_PORTAUDIO
+
+#define AUDIO_INIT_NATIVE audio_init_portaudio
+#define AUDIO_OPEN_NATIVE audio_open_portaudio
+#define AUDIO_CLOSE_NATIVE audio_close_portaudio
+#define AUDIO_SET_SAMPLE_RATE_NATIVE audio_set_sample_rate_portaudio
+#define AUDIO_WRITE_NATIVE audio_write_portaudio
+#define AUDIO_DRAIN_NATIVE audio_drain_portaudio
+#define AUDIO_FLUSH_NATIVE audio_flush_portaudio
+#define AUDIO_EXIT_NATIVE audio_exit_portaudio
 
 #endif
 
 #ifndef AUDIO_OPEN_NATIVE
 
+#define AUDIO_INIT_NATIVE audio_init_none
 #define AUDIO_OPEN_NATIVE audio_open_none
 #define AUDIO_CLOSE_NATIVE audio_close_none
 #define AUDIO_SET_SAMPLE_RATE_NATIVE audio_set_sample_rate_none
 #define AUDIO_WRITE_NATIVE audio_write_none
 #define AUDIO_DRAIN_NATIVE audio_drain_none
 #define AUDIO_FLUSH_NATIVE audio_flush_none
+#define AUDIO_EXIT_NATIVE audio_exit_none
 #define CST_AUDIO_NONE
 
 #endif
 
+int AUDIO_INIT_NATIVE();
 cst_audiodev *AUDIO_OPEN_NATIVE(int sps, int channels, cst_audiofmt fmt);
 int AUDIO_CLOSE_NATIVE(cst_audiodev *ad);
 int AUDIO_WRITE_NATIVE(cst_audiodev *ad,void *buff,int num_bytes);
 int AUDIO_DRAIN_NATIVE(cst_audiodev *ad);
 int AUDIO_FLUSH_NATIVE(cst_audiodev *ad);
+int AUDIO_EXIT_NATIVE();
 
 #endif

--- a/src/synth/mimic.c
+++ b/src/synth/mimic.c
@@ -43,6 +43,7 @@
 #include "cst_alloc.h"
 #include "cst_clunits.h"
 #include "cst_cg.h"
+#include "cst_audio.h"
 
 /* This is a global, which isn't ideal, this may change */
 /* It is set when mimic_set_voice_list() is called which happens in */
@@ -54,8 +55,15 @@ int mimic_lang_list_length = 0;
 int mimic_init()
 {
     cst_regex_init();
+    audio_init();
 
     return 0;
+}
+
+int mimic_exit()
+{
+	audio_exit();
+	return 0;
 }
 
 int mimic_voice_dump(cst_voice *voice, const char *filename)

--- a/testsuite/by_word_main.c
+++ b/testsuite/by_word_main.c
@@ -125,5 +125,6 @@ int main(int argc, char **argv)
 
     mimic_file_to_speech(argv[1],v,"none"); /* streaming will play */
 
+    mimic_exit();
     return 0;
 }

--- a/testsuite/kal_test_main.c
+++ b/testsuite/kal_test_main.c
@@ -82,5 +82,7 @@ int main(int argc, char **argv)
     printf("%f seconds of speech synthesized\n",durs);
 /*    muntrace(); */
 
+    mimic_exit();
+
     return 0;
 }

--- a/testsuite/multi_thread_main.c
+++ b/testsuite/multi_thread_main.c
@@ -76,6 +76,7 @@ int main() {
       printf("%d %d %f\n", omp_get_thread_num(), i, synth_text("Hello"));
     }
     
+    mimic_exit();
     return 0;
 }
       

--- a/wince/flowm_mimic.c
+++ b/wince/flowm_mimic.c
@@ -144,6 +144,7 @@ void flowm_init()
                  uttfunc_val(flowm_print_relation_callback));
     }
 
+    mimic_exit();
 #endif
     return;
 }


### PR DESCRIPTION
This pull request aims to close issues #10 and #13.

# What does it do?
- Adds an audio module "portaudio" in src/audio/au_portaudio.c. See #10 to see the discussion.
- Adds automatic detection of portaudio in configure.in and configure.
- Changes some indentation from tabs to spaces. I don't care to use one or the other, but not both in the same file :grimacing:.
- Due to some differences in the audio module, play_wave_from_socket does not work yet, although we may not need it.
- It fixes the ALSA detection in configure.in and configure scripts that failed with ALSA-1.1.0.

# Main changes:
- There is an audio_init and audio_exit function that needs to be run when mimic starts and exits.
- audio_init has been added to mimic_init. mimic_exit has been created and calls audio_exit.
- All programs calling mimic_init now call mimic_exit at the end.
- The PortAudio module opens and closes an audio stream on each write operation, so the `play_wave` function needs to be edited to pass the whole buffer of samples at once. `play_wave_sync` and `play_wave_from_socket` have not been adapted to work with PortAudio, mainly because I don't think we are using them.

# Testing
- The PortAudio module has been tested under Linux Mint 14.04 64 bits with the portaudio19-dev 19+svn20140130-1 package from the Ubuntu repositories.
- Someone (@siavasht ?) needs to test it on other platforms (Mac OS X, for instance). `brew install portaudio` is required on Mac OS to install portaudio, as far as I know.
- The ALSA detection patch in this pull request needs to be tested, for instance on Debian Sid (@julianrichen ?)
