### PR TITLE
Implement a simple signal handler for SIGINT

### DIFF
--- a/include/cst_audio.h
+++ b/include/cst_audio.h
@@ -124,4 +124,5 @@ typedef int (*cst_audio_stream_callback)(const cst_wave *w,int start,int size,
 int audio_stream_chunk(const cst_wave *w, int start, int size, 
                        int last, cst_audio_streaming_info *asi);
 
+void shutdown_audio(int signum);
 #endif

--- a/include/mimic.h
+++ b/include/mimic.h
@@ -104,9 +104,10 @@ float mimic_ts_to_speech(cst_tokenstream *ts,
 cst_utterance *mimic_do_synth(cst_utterance *u,
                               cst_voice *voice,
                               cst_uttfunc synth);
-float mimic_process_output(cst_utterance *u,
-                           const char *outtype,
-                           int append);
+int mimic_process_output(cst_utterance *u,
+                         const char *outtype,
+                         int append,
+                         float *dur);
 
 /* for voices with external voxdata */
 int mimic_mmap_clunit_voxdata(const char *voxdir, cst_voice *voice);

--- a/main/mimic_main.c
+++ b/main/mimic_main.c
@@ -42,7 +42,11 @@
 #include <string.h>
 #include <sys/time.h>
 #include <unistd.h>
+#ifdef UNDER_WINDOWS
+#include <windows.h>
+#else
 #include <signal.h>
+#endif
 
 #include "mimic.h"
 #include "mimic_version.h"
@@ -56,10 +60,22 @@ void cst_alloc_debug_summary();
 void usenglish_init(cst_voice *v);
 cst_lexicon *cmu_lex_init(void);
 
+#ifdef UNDER_WINDOWS
+BOOL WINAPI windows_signal_handler(DWORD signum)
+{
+   shutdown_audio(signum);
+   if (signum == CTRL_C_EVENT)
+      return TRUE;
+   else
+      return FALSE;
+}
+#else
 void sigint_handler(int signum)
 {
     shutdown_audio(signum);
 }
+#endif
+
 
 static void mimic_version()
 {
@@ -211,11 +227,11 @@ int main(int argc, char **argv)
     const char *voicedumpfile = NULL;
     cst_audio_streaming_info *asi;
 
-#ifndef UNDER_WINDOWS
     // Set signal handler to shutdown any playing audio on SIGINT
-    signal(SIGINT, sigint_handler);
+#ifdef UNDER_WINDOWS
+    SetConsoleCtrlHandler(windows_signal_handler, TRUE);
 #else
-    //TODO add signal handling for windows
+    signal(SIGINT, sigint_handler);
 #endif //UNDER_WINDOWS
     filename = 0;
     outtype = "play";   /* default is to play */

--- a/main/mimic_main.c
+++ b/main/mimic_main.c
@@ -211,9 +211,12 @@ int main(int argc, char **argv)
     const char *voicedumpfile = NULL;
     cst_audio_streaming_info *asi;
 
+#ifndef UNDER_WINDOWS
     // Set signal handler to shutdown any playing audio on SIGINT
     signal(SIGINT, sigint_handler);
-
+#else
+    //TODO add signal handling for windows
+#endif //UNDER_WINDOWS
     filename = 0;
     outtype = "play";   /* default is to play */
     mimic_verbose = FALSE;

--- a/main/mimic_main.c
+++ b/main/mimic_main.c
@@ -42,6 +42,7 @@
 #include <string.h>
 #include <sys/time.h>
 #include <unistd.h>
+#include <signal.h>
 
 #include "mimic.h"
 #include "mimic_version.h"
@@ -204,6 +205,9 @@ int main(int argc, char **argv)
     const char *lex_addenda_file = NULL;
     const char *voicedumpfile = NULL;
     cst_audio_streaming_info *asi;
+
+    // Set signal handler to shutdown any playing audio on SIGINT
+    signal(SIGINT, shutdown_audio);
 
     filename = 0;
     outtype = "play";   /* default is to play */

--- a/main/mimic_main.c
+++ b/main/mimic_main.c
@@ -56,6 +56,11 @@ void cst_alloc_debug_summary();
 void usenglish_init(cst_voice *v);
 cst_lexicon *cmu_lex_init(void);
 
+void sigint_handler(int signum)
+{
+    shutdown_audio(signum);
+}
+
 static void mimic_version()
 {
     printf("  Carnegie Mellon University, Copyright (c) 1999-2011, all rights reserved\n");
@@ -207,7 +212,7 @@ int main(int argc, char **argv)
     cst_audio_streaming_info *asi;
 
     // Set signal handler to shutdown any playing audio on SIGINT
-    signal(SIGINT, shutdown_audio);
+    signal(SIGINT, sigint_handler);
 
     filename = 0;
     outtype = "play";   /* default is to play */


### PR DESCRIPTION
This pull request aims to add a signal handler for SIGINT

# Functionality
When SIGINT (Ctrl+C for example) is received mimic will abort any playback and return up the stack with EINTR and exit normally. This means SIGINT will be ignored when writing to a file.

# Testing
Tested with **text** and **file** input with both **alsa** and **pulse audio** drivers.

# Caveats
Current implementation is quite simple, something in the ALSA driver requires the ALSA-buffer to be dropped before audio_write() can be exited. This required the ```play_wave()``` function to store the current alsa driver handle as a global variable for the signal handler to use.