### PR TITLE
Fix loading CG voices on windows

### DIFF
--- a/src/cg/cst_cg_load_voice.c
+++ b/src/cg/cst_cg_load_voice.c
@@ -55,7 +55,7 @@ cst_voice *cst_cg_load_voice(const char *filename,
     char *fval;
     cst_file vd;
 
-    vd = cst_fopen(filename, CST_OPEN_READ);
+    vd = cst_fopen(filename, CST_OPEN_READ|CST_OPEN_BINARY);
     if (vd == NULL)
     {
         cst_errmsg("Error load voice: can't open file %s\n", filename);


### PR DESCRIPTION
Voice files should be opened in binary mode, otherweise loading of voices generated and dumped on other systems might fail (test case that failed was a voice generated on Ubuntu 64 bit and loaded on Win10 64 bit).