### PR TITLE
Fix coverity issues in /src/audio/*

### DIFF
--- a/src/audio/auclient.c
+++ b/src/audio/auclient.c
@@ -65,7 +65,7 @@ int play_wave_client(cst_wave *w, const char *servername, int port,
     if (!w)
         return CST_ERROR_FORMAT;
 
-    if ((audiofd = cst_socket_open(servername, port)) == 0)
+    if ((audiofd = cst_socket_open(servername, port)) < 0)
         return CST_ERROR_FORMAT;
 
     header.magic = (unsigned int) 0x2e736e64;
@@ -100,6 +100,7 @@ int play_wave_client(cst_wave *w, const char *servername, int port,
 
     if (write(audiofd, &header, sizeof(header)) != sizeof(header))
     {
+        cst_socket_close(audiofd);
         cst_errmsg("auclinet: failed to write header to server\n");
         return CST_ERROR_FORMAT;
     }

--- a/src/audio/audio.c
+++ b/src/audio/audio.c
@@ -126,6 +126,9 @@ int audio_write(cst_audiodev *ad, void *buff, int num_bytes)
     }
     if (ad->real_channels != ad->channels)
     {
+        nbuf = cst_alloc(char,
+                         real_num_bytes * ad->real_channels / ad->channels);
+
         /* Yeah, we only do mono->stereo for now */
         if (ad->real_channels != 2 || ad->channels != 1)
         {
@@ -133,9 +136,6 @@ int audio_write(cst_audiodev *ad, void *buff, int num_bytes)
                 ("audio_write: unsupported channel mapping requested (%d => %d).\n",
                  ad->channels, ad->real_channels);
         }
-        nbuf =
-            cst_alloc(char,
-                      real_num_bytes * ad->real_channels / ad->channels);
 
         if (audio_bps(ad->fmt) == 2)
         {
@@ -201,9 +201,9 @@ int audio_write(cst_audiodev *ad, void *buff, int num_bytes)
             cst_errmsg
                 ("audio_write: unknown format conversion (%d => %d) requested.\n",
                  ad->fmt, ad->real_fmt);
-            cst_free(nbuf);
-            if (abuf != buff)
+            if ((abuf != nbuf) && (abuf != buff))
                 cst_free(abuf);
+            cst_free(nbuf);
             cst_error();
         }
         if (abuf != buff)

--- a/src/audio/auserver.c
+++ b/src/audio/auserver.c
@@ -74,12 +74,17 @@ static int play_wave_from_socket(snd_header * header, int audiostream)
     cst_file fff;
 
     fff = cst_fopen("/tmp/awb.wav", CST_OPEN_WRITE | CST_OPEN_BINARY);
-
+    if (fff == NULL)
+    {
+        cst_errmsg("could not open tmp/awb.wav for writing");
+        return -1;
+    }
     if ((audio_device = audio_open(header->sample_rate, 1,
                                    (header->encoding == CST_SND_SHORT) ?
                                    CST_AUDIO_LINEAR16 : CST_AUDIO_LINEAR8)) ==
         NULL)
     {
+        cst_fclose(fff);
         cst_errmsg("play_wave_from_socket: can't open audio device\n");
         return -1;
     }
@@ -116,6 +121,7 @@ static int play_wave_from_socket(snd_header * header, int audiostream)
 
         if (r <= 0)
         {                       /* I'm not getting any data from the server */
+            cst_fclose(fff);
             audio_close(audio_device);
             free(bytes);
             free(shorts);
@@ -128,6 +134,7 @@ static int play_wave_from_socket(snd_header * header, int audiostream)
             cst_fwrite(fff, shorts, 2, q);
             if (n <= 0)
             {
+                cst_fclose(fff);
                 audio_close(audio_device);
                 free(bytes);
                 free(shorts);


### PR DESCRIPTION
CIDs:
* 82169: function returns with error if audiofd is negative when opened
* 82188: audiofd is closed when returning with error
* 82206: abuf is only freed if it differs from buff and nbuf
* 82172: fff == NULL is handled when opening the file
* 82186: fff is closed whenever the function returns

Tested with ```testsuite/play_server``` and ```play_client``` and pushed to [coverity_scan](https://github.com/MycroftAI/mimic/tree/coverity_scan) branch for verification.