### PR TITLE
Fix "make clean"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,6 +55,8 @@ DIST_CLEAN = .time-stamp $(TOP)/build/ \
                 config.cache config.log config.status \
 		config/config config/system.mak FileList
 
+LOCAL_CLEAN = build
+
 HOST_ONLY_DIRS = tools main
 ALL = $(BUILD_DIRS)
 


### PR DESCRIPTION
"LOCAL_CLEAN = build" added to force removal of the built objects and libraries. This allows build process to work normally after "make clean"