### PR TITLE
apostrophe fixes

### DIFF
--- a/lang/cmulex/cmu_postlex.c
+++ b/lang/cmulex/cmu_postlex.c
@@ -60,7 +60,7 @@ static void apostrophe_s(cst_utterance *u)
 		/* needs a schwa */
 	    {
 		schwa = item_prepend(s,NULL);
-		item_set_string(schwa,"name","ax");
+		item_set_string(schwa,"name","ih");
 		item_prepend(item_as(s,"SylStructure"),schwa);
 	    }
 	    else if (cst_streq("-",phone_feature_string(ps,pname,"cvox")))

--- a/lang/cmulex/cmu_postlex.c
+++ b/lang/cmulex/cmu_postlex.c
@@ -67,14 +67,27 @@ static void apostrophe_s(cst_utterance *u)
 		item_set_string(s,"name","s");
 	}
 	else if (cst_streq("'ve", word)
-		 || cst_streq("'ll", word)
-		 || cst_streq("'d", word))
+		 || cst_streq("'ll", word))
 	{
 	    if (cst_streq("-",ffeature_string(s,"p.ph_vc")))
 	    {
 		schwa = item_prepend(s,NULL);
 		item_set_string(schwa,"name","ax");
 		item_prepend(item_as(s,"SylStructure"),schwa);
+	    }
+	}
+	else if (cst_streq("'d", word))
+	{
+	    pname = item_feat_string(item_prev(s),"name");
+	    if (cst_streq("t",pname) || cst_streq("d",pname))
+	    {
+		schwa = item_prepend(s,NULL);
+		item_set_string(schwa,"name","ih");
+		item_prepend(item_as(s,"SylStructure"),schwa);
+	    }
+	    else if (cst_streq("-",ffeature_string(s,"p.ph_vc")))
+	    {
+		item_set_string(s, "name", "t");
 	    }
 	}
     }


### PR DESCRIPTION
This is applying various fixes to the way apostrophe-based words are handled, especially in archaic texts (e.g. Shakespeare and Milton) where `'d` is used as a variation of `-ed` (`FLOW'D`, `WITNESS'D`).

This follows the rules for pronunciation of `-ed` forms, except for adjectives ("Bless'd be thy name." which is an adjective and should use `/ih d/`, vs "I am bless'd." which should use the unvoiced `/t/` form). The other place where this does not work properly is for words like "MOV'D" (MOVED) and "OPPOS'D" (OPPOSED) where the vowel takes "long" forms (/uw/ and /ow/ respectively for MOV'D and OPPOS'D).

I have tried to support `'st` for -est words like "MAK'ST" (MAKEST) by first adding `'st` to the list at `lang/usenglish/us_text.c` (line 684), but using the schwa code to add an `/ih/` vowel results in `/ih s ih t/` instead of `/ih s t/`.