### PR TITLE
Add UTF-8 support to tokenstream

### DIFF
--- a/include/cst_tokenstream.h
+++ b/include/cst_tokenstream.h
@@ -113,6 +113,11 @@ typedef struct cst_tokenstream_struct {
  * If an invalid UTF-8 character is given the returned value is 
  * undefined.
  * 
+ * If you want to understand how the classes are set, read
+ * `set_charclass_table_symbol` in `src/utils/cst_tokenstream.c`.
+ * 
+ * @see set_charclasses, set_charclass_table_symbol
+ * 
  * @param utf8char A cst_string containing a utf-8 character, that can
  *                 be 1 to 4 bytes long.
  * @param class    An integer, usually one of the `TS_CHARCLASS_*` macros
@@ -122,7 +127,7 @@ typedef struct cst_tokenstream_struct {
  * @return Returns 0 if the given character does not belong to the given
  *         class. It returns the class otherwise.
  */
-int ts_charclass(const cst_string *const c, int class, cst_tokenstream *ts);
+int ts_charclass(const cst_string *const utf8char, int class, cst_tokenstream *ts);
 
 extern const cst_string *const cst_ts_default_whitespacesymbols;
 extern const cst_string *const cst_ts_default_prepunctuationsymbols;

--- a/include/cst_tokenstream.h
+++ b/include/cst_tokenstream.h
@@ -140,8 +140,6 @@ const cst_string *ts_get(cst_tokenstream *ts);
 
 const cst_string *ts_get_quoted_token(cst_tokenstream *ts,
                                       char quote, char escape);
-/* Externally specified ts interfaces may need this */
-void private_ts_getc(cst_tokenstream *ts);
 
 void set_charclasses(cst_tokenstream *ts,
                      const cst_string *whitespace,

--- a/include/cst_tokenstream.h
+++ b/include/cst_tokenstream.h
@@ -77,11 +77,17 @@ typedef struct cst_tokenstream_struct {
     const cst_string *p_prepunctuationsymbols;
     const cst_string *p_postpunctuationsymbols;
 
-
-    cst_string charclass[256];
-    cst_string *charclass2[256];
-    cst_string **charclass3[256];
-    cst_string ***charclass4[256];
+    /* 1-byte long UTF-8 characters are in [0, 128) */
+    cst_string charclass[128];
+    /* 2-byte long UTF-8 characters have a first UTF-8 character like
+     *  110xxxxx, so 32 possibilities are only possible*/
+    cst_string *charclass2[32];
+    /* 3-byte long UTF-8 characters have a first UTF-8 character like
+     * 1110xxxx, so 16 possibilities are only possible*/
+    cst_string **charclass3[16];
+    /* 4-byte long UTF-8 characters have a first UTF-8 character like
+     * 11110xxx, so 8 possibilities are only possible*/
+    cst_string ***charclass4[8];
 
     /* To allow externally specified reading functions e.g. epub/xml */
     int (*open) (struct cst_tokenstream_struct *ts, const char *filename);
@@ -100,6 +106,22 @@ typedef struct cst_tokenstream_struct {
 #define TS_CHARCLASS_POSTPUNCT  16
 #define TS_CHARCLASS_QUOTE      32
 
+/**
+ * Receives an UTF-8 character and a class (for instance:
+ * `TS_CHARCLASS_WHITESPACE` or `TS_CHARCLASS_POSTPUNCT`) and returns
+ * whether or not the UTF-8 character given belongs to that class.
+ * If an invalid UTF-8 character is given the returned value is 
+ * undefined.
+ * 
+ * @param utf8char A cst_string containing a utf-8 character, that can
+ *                 be 1 to 4 bytes long.
+ * @param class    An integer, usually one of the `TS_CHARCLASS_*` macros
+ * @param ts       The tokenstream that has defined which characters
+ *                 belong to what classes.
+ * 
+ * @return Returns 0 if the given character does not belong to the given
+ *         class. It returns the class otherwise.
+ */
 int ts_charclass(const cst_string *const c, int class, cst_tokenstream *ts);
 
 extern const cst_string *const cst_ts_default_whitespacesymbols;

--- a/include/cst_tokenstream.h
+++ b/include/cst_tokenstream.h
@@ -52,7 +52,7 @@ typedef struct cst_tokenstream_struct {
     int eof_flag;
     cst_string *string_buffer;
 
-    int current_char;
+    cst_string current_char[5]; /* UTF-8 character: 4 bytes + '\0' */
 
     int token_pos;
     int ws_max;
@@ -77,7 +77,11 @@ typedef struct cst_tokenstream_struct {
     const cst_string *p_prepunctuationsymbols;
     const cst_string *p_postpunctuationsymbols;
 
+
     cst_string charclass[256];
+    cst_string *charclass2[256];
+    cst_string **charclass3[256];
+    cst_string ***charclass4[256];
 
     /* To allow externally specified reading functions e.g. epub/xml */
     int (*open) (struct cst_tokenstream_struct *ts, const char *filename);
@@ -96,7 +100,7 @@ typedef struct cst_tokenstream_struct {
 #define TS_CHARCLASS_POSTPUNCT  16
 #define TS_CHARCLASS_QUOTE      32
 
-#define ts_charclass(C,CLASS,TS) ((TS)->charclass[(unsigned char)C] & CLASS)
+int ts_charclass(const cst_string *const c, int class, cst_tokenstream *ts);
 
 extern const cst_string *const cst_ts_default_whitespacesymbols;
 extern const cst_string *const cst_ts_default_prepunctuationsymbols;
@@ -137,7 +141,7 @@ const cst_string *ts_get(cst_tokenstream *ts);
 const cst_string *ts_get_quoted_token(cst_tokenstream *ts,
                                       char quote, char escape);
 /* Externally specified ts interfaces may need this */
-cst_string private_ts_getc(cst_tokenstream *ts);
+void private_ts_getc(cst_tokenstream *ts);
 
 void set_charclasses(cst_tokenstream *ts,
                      const cst_string *whitespace,
@@ -145,7 +149,6 @@ void set_charclasses(cst_tokenstream *ts,
                      const cst_string *prepunctuation,
                      const cst_string *postpunctuation);
 
-int ts_read(void *buff, int size, int num, cst_tokenstream *ts);
 
 int ts_set_stream_pos(cst_tokenstream *ts, int pos);
 int ts_get_stream_pos(cst_tokenstream *ts);

--- a/src/synth/cst_synth.c
+++ b/src/synth/cst_synth.c
@@ -209,14 +209,17 @@ cst_utterance *default_tokenization(cst_utterance *u)
     text = utt_input_text(u);
     r = utt_relation_create(u, "Token");
     fd = ts_open_string(text,
-                        get_param_string(u->features, "text_whitespace",
-                                         NULL), get_param_string(u->features,
-                                                                 "text_singlecharsymbols",
-                                                                 NULL),
-                        get_param_string(u->features, "text_prepunctuation",
-                                         NULL), get_param_string(u->features,
-                                                                 "text_postpunctuation",
-                                                                 NULL));
+                        get_param_string(u->features,
+                                         "text_whitespace",
+                                         NULL),
+                        get_param_string(u->features,
+                                         "text_singlecharsymbols",
+                                         NULL),
+                        get_param_string(u->features,
+                                         "text_prepunctuation",
+                                         NULL),
+                        get_param_string(u->features,
+                                         "text_postpunctuation", NULL));
 
     while (!ts_eof(fd))
     {

--- a/src/utils/cst_tokenstream.c
+++ b/src/utils/cst_tokenstream.c
@@ -54,7 +54,7 @@ static void internal_ts_getc(cst_tokenstream *ts);
 int ts_charclass(const cst_string *const utf8char, int class,
                  cst_tokenstream *ts)
 {
-	  unsigned char c1, c2, c3, c4;
+    unsigned char c1, c2, c3, c4;
     unsigned char *c = (unsigned char *) utf8char;
     switch (cst_strlen(c))
     {
@@ -81,8 +81,7 @@ int ts_charclass(const cst_string *const utf8char, int class,
         c2 = c[1] & 0x3f;
         /* 3rd byte must be 10xxxxxx so we mask with b00111111 = 0x3f */
         c3 = c[2] & 0x3f;
-        if (ts->charclass3[c1] != NULL &&
-            ts->charclass3[c1][c2] != NULL)
+        if (ts->charclass3[c1] != NULL && ts->charclass3[c1][c2] != NULL)
         {
             return (ts->charclass3[c1][c2][c3] & class);
         }
@@ -136,14 +135,14 @@ static int set_charclass_table_symbol(cst_tokenstream *ts,
     /* For each UTF-8 character */
     for (v = utflets; v; v = val_cdr(v))
     {
-			  /* The character as an unsigned char* */
+        /* The character as an unsigned char* */
         utf8char = (const unsigned char *) val_string(val_car(v));
         /* The number of UTF-8 bytes required to express this char */
         utf8char_len = cst_strlen(utf8char);
         idx = 0;
         if (utf8char_len > 4)
         {
-					  /* Invalid UTF-8 symbol */
+            /* Invalid UTF-8 symbol */
             delete_val(utflets);
             return -1;
         }
@@ -154,7 +153,7 @@ static int set_charclass_table_symbol(cst_tokenstream *ts,
             c1 = utf8char[idx] & 0x07;
             if (cl4[c1] == NULL)
             {
-								/* It has 10xxxxx -> 2^6 = 64 options */
+                /* It has 10xxxxx -> 2^6 = 64 options */
                 cl4[c1] = cst_alloc(cst_string **, 64);
                 memset(cl4[c1], 0, 64 * sizeof(cst_string **));
             }
@@ -168,13 +167,15 @@ static int set_charclass_table_symbol(cst_tokenstream *ts,
                 cl3 = ts->charclass3;
                 /* First character: 1110xxxx */
                 c1 = utf8char[idx] & 0x0f;
-            } else {
+            }
+            else
+            {
                 /* Cont. char must be 10xxxxxx so we mask with b00111111 = 0x3f */
-							  c1 = utf8char[idx] & 0x3f;
-						}
+                c1 = utf8char[idx] & 0x3f;
+            }
             if (cl3[c1] == NULL)
             {
-								/* It has 10xxxxx -> 2^6 = 64 options */
+                /* It has 10xxxxx -> 2^6 = 64 options */
                 cl3[c1] = cst_alloc(cst_string *, 64);
                 memset(cl3[c1], 0, 64 * sizeof(cst_string *));
             }
@@ -188,13 +189,15 @@ static int set_charclass_table_symbol(cst_tokenstream *ts,
                 cl2 = ts->charclass2;
                 /* 1st byte must be 110xxxxx so we mask with b00011111 = 0x1f */
                 c1 = utf8char[idx] & 0x1f;
-            } else {
+            }
+            else
+            {
                 /* Cont. char must be 10xxxxxx so we mask with b00111111 = 0x3f */
-							  c1 = utf8char[idx] & 0x3f;
-						}
+                c1 = utf8char[idx] & 0x3f;
+            }
             if (cl2[c1] == NULL)
             {
-								/* It has 10xxxxx -> 2^6 = 64 options */
+                /* It has 10xxxxx -> 2^6 = 64 options */
                 cl2[c1] = cst_alloc(cst_string, 64);
                 memset(cl2[c1], 0, 64 * sizeof(cst_string));
             }
@@ -208,10 +211,12 @@ static int set_charclass_table_symbol(cst_tokenstream *ts,
                 cl1 = ts->charclass;
                 /* 1st byte must be 0xxxxxxx so we mask with b01111111 = 0x7f */
                 c1 = utf8char[idx] & 0x7f;
-            } else {
+            }
+            else
+            {
                 /* Cont. char must be 10xxxxxx so we mask with b00111111 = 0x3f */
-							  c1 = utf8char[idx] & 0x3f;
-						}
+                c1 = utf8char[idx] & 0x3f;
+            }
             cl1[c1] |= symbol_value;
         }
     }
@@ -222,14 +227,15 @@ static int set_charclass_table_symbol(cst_tokenstream *ts,
 static void free_tables(cst_tokenstream *ts)
 {
     int i, j, k;
-    for (i = 0; i < 32; i++) {
+    for (i = 0; i < 32; i++)
+    {
         if (ts->charclass2[i] != NULL)
         {
             cst_free(ts->charclass2[i]);
         }
-		}
-		for (i = 0; i < 16; i++)
-		{
+    }
+    for (i = 0; i < 16; i++)
+    {
         if (ts->charclass3[i] != NULL)
         {
             for (j = 0; j < 64; j++)
@@ -241,7 +247,7 @@ static void free_tables(cst_tokenstream *ts)
             }
             cst_free(ts->charclass3[i]);
         }
-		}		
+    }
     for (i = 0; i < 8; i++)
     {
         if (ts->charclass4[i] != NULL)
@@ -323,8 +329,8 @@ static void extend_buffer(cst_string **buffer, int *buffer_max)
      * requires 4 bytes and there may be an ending 0 */
     if (increment < 5)
     {
-			 /* We could set it to 5, but incrementing a power of two
-			  * seems more "alignment friendly" */
+        /* We could set it to 5, but incrementing a power of two
+         * seems more "alignment friendly" */
         increment = 8;
     }
     new_max = (*buffer_max) + increment;

--- a/src/utils/cst_tokenstream.c
+++ b/src/utils/cst_tokenstream.c
@@ -51,7 +51,20 @@ const cst_string *const cst_ts_default_postpunctuationsymbols =
 static void ts_getc(cst_tokenstream *ts);
 static void internal_ts_getc(cst_tokenstream *ts);
 
-
+/**
+ * Receives an UTF-8 character and a class (for instance:
+ * `TS_CHARCLASS_WHITESPACE` or `TS_CHARCLASS_POSTPUNCT`) and returns
+ * whether or not the UTF-8 character given belongs to that class.
+ * 
+ * @param utf8char A cst_string containing a utf-8 character, that can
+ *                 be 1 to 4 bytes long.
+ * @param class    An integer, usually one of the `TS_CHARCLASS_*` macros
+ * @param ts       The tokenstream that has defined which characters
+ *                 belong to what classes.
+ * 
+ * @return Returns 0 if the given character does not belong to the given
+ *         class. It returns the class otherwise.
+ */
 int ts_charclass(const cst_string *const utf8char, int class,
                  cst_tokenstream *ts)
 {
@@ -599,11 +612,6 @@ int ts_get_stream_size(cst_tokenstream *ts)
         return (ts->size) (ts);
     else
         return 0;
-}
-
-void private_ts_getc(cst_tokenstream *ts)
-{
-    internal_ts_getc(ts);
 }
 
 static void ts_getc(cst_tokenstream *ts)

--- a/unittests/data_utf8.txt
+++ b/unittests/data_utf8.txt
@@ -1,4 +1,7 @@
 Hello world.
 "Yahoo!" who(s)
 ¡Good News!
+Åke
+Über
+漢字
 

--- a/unittests/data_utf8.txt
+++ b/unittests/data_utf8.txt
@@ -1,0 +1,4 @@
+Hello world.
+"Yahoo!" who(s)
+¡Good News!
+

--- a/unittests/data_utf8.txt
+++ b/unittests/data_utf8.txt
@@ -1,7 +1,7 @@
-Hello world.
+Hello world.😊
 "Yahoo!" who(s)
 ¡Good News!
-Åke
+Åke€
 Über
 漢字
 

--- a/unittests/token_test_main.c
+++ b/unittests/token_test_main.c
@@ -38,8 +38,49 @@ void test_token(void)
     ts_close(fd);
 }
 
+void test_token_utf8(void)
+{
+    cst_tokenstream *fd;
+    const char *token;
+    const char *singl = "€(){}[]";    /* EURO SIGN + defaults */
+    const char *prepunc = "¿¡\"!";    /* INVERTED QUESTION MARK, INV. EXCL. MARK, ", ! */
+
+    fd = ts_open("data_utf8.txt", " \n\t", singl, prepunc, NULL);       /* defaults */
+
+    token = ts_get(fd);
+    TEST_CHECK(strcmp(token, "Hello") == 0);
+    token = ts_get(fd);
+    TEST_CHECK(strcmp(token, "world") == 0);
+    TEST_CHECK(strcmp(fd->postpunctuation, ".") == 0);
+    token = ts_get(fd);
+    TEST_CHECK(strcmp(token, "Yahoo") == 0);
+    TEST_CHECK(strcmp(fd->postpunctuation, "!\"") == 0);
+    token = ts_get(fd);
+    TEST_CHECK(strcmp(token, "who") == 0);
+    token = ts_get(fd);
+    TEST_CHECK(strcmp(token, "(") == 0);
+    token = ts_get(fd);
+    TEST_CHECK(strcmp(token, "s") == 0);
+    token = ts_get(fd);
+    TEST_CHECK(strcmp(token, ")") == 0);
+    token = ts_get(fd);
+    TEST_CHECK(strcmp(token, "Good") == 0);
+    TEST_CHECK(strcmp(fd->prepunctuation, "¡") == 0);
+    token = ts_get(fd);
+    TEST_CHECK(strcmp(token, "News") == 0);
+    TEST_CHECK(strcmp(fd->postpunctuation, "!") == 0);
+    token = ts_get(fd);
+    TEST_CHECK(strcmp(token, "") == 0);
+    TEST_CHECK(ts_eof(fd));
+    ts_close(fd);
+}
+
 TEST_LIST =
 {
-    {"tokens", test_token},
-    {0}
+    {
+    "tokens", test_token},
+    {
+    "tokens_utf8", test_token_utf8},
+    {
+    0}
 };

--- a/unittests/token_test_main.c
+++ b/unittests/token_test_main.c
@@ -42,16 +42,18 @@ void test_token_utf8(void)
 {
     cst_tokenstream *fd;
     const char *token;
-    const char *singl = "€(){}[]";    /* EURO SIGN + defaults */
+    const char *singl = "€(){}[]😊";    /* EURO SIGN + defaults + emoji */
     const char *prepunc = "¿¡\"!";    /* INVERTED QUESTION MARK, INV. EXCL. MARK, ", ! */
-
-    fd = ts_open("data_utf8.txt", " \n\t", singl, prepunc, NULL);       /* defaults */
+    const char *postpunc = "\"'`.,:;!?(){}[]";
+    fd = ts_open("data_utf8.txt", " \n\t", singl, prepunc, postpunc);
 
     token = ts_get(fd);
     TEST_CHECK(strcmp(token, "Hello") == 0);
     token = ts_get(fd);
     TEST_CHECK(strcmp(token, "world") == 0);
     TEST_CHECK(strcmp(fd->postpunctuation, ".") == 0);
+    token = ts_get(fd);
+    TEST_CHECK(strcmp(token, "😊") == 0);
     token = ts_get(fd);
     TEST_CHECK(strcmp(token, "Yahoo") == 0);
     TEST_CHECK(strcmp(fd->postpunctuation, "!\"") == 0);
@@ -71,6 +73,8 @@ void test_token_utf8(void)
     TEST_CHECK(strcmp(fd->postpunctuation, "!") == 0);
     token = ts_get(fd);
     TEST_CHECK(strcmp(token, "Åke") == 0);
+    token = ts_get(fd);
+    TEST_CHECK(strcmp(token, "€") == 0);
     token = ts_get(fd);
     TEST_CHECK(strcmp(token, "Über") == 0);
     token = ts_get(fd);

--- a/unittests/token_test_main.c
+++ b/unittests/token_test_main.c
@@ -70,6 +70,12 @@ void test_token_utf8(void)
     TEST_CHECK(strcmp(token, "News") == 0);
     TEST_CHECK(strcmp(fd->postpunctuation, "!") == 0);
     token = ts_get(fd);
+    TEST_CHECK(strcmp(token, "Åke") == 0);
+    token = ts_get(fd);
+    TEST_CHECK(strcmp(token, "Über") == 0);
+    token = ts_get(fd);
+    TEST_CHECK(strcmp(token, "漢字") == 0);
+    token = ts_get(fd);
     TEST_CHECK(strcmp(token, "") == 0);
     TEST_CHECK(ts_eof(fd));
     ts_close(fd);


### PR DESCRIPTION
I was working on the wiki to add multilanguage support to mimic. My first frustration was related to the lack of UTF-8 support in the first step of the language analysis: [the tokenizer](https://github.com/MycroftAI/mimic/wiki/Creating-a-new-voice-for-mimic#step-1-tokenizer), so I finally decided to *do the right thing* and try to add UTF-8 support to tokenstreams.

This pull request enables the use of UTF-8 sequences to mark word boundaries and punctuation characters. This includes support for Spanish reverse exclamation marks "¡" and interrogation marks "¿" (these symbols mark in Spanish the beginning of an exclamation or interrogation respectively), as well as the use of the "DEVANAGARI DANDA" character ("।") as punctuation in indic languages. Additionally, this makes it trivial to support typographic quotation marks.


It is my first pull request with a significant piece of C code, so it may be below mimic desired C coding quality standards. Feel free to make all comments you want.

Main implementation changes:
- We move from `1 character = 1 byte` to `1 character = either {1, 2, 3, 4} bytes`.
- The tokenstream uses a Look Up Table (LUT) to know if a character is a whitespace, a punctuation mark, etc. The LUT for each character `charclass` required 256 bytes, one for each possible character. Unicode allows for many more characters. so now it starts with 4 tables of 256 bytes each:
    - `charclass` is used with 1 byte characters.
    - `charclass2` is used for 2-byte characters
    - `charclass3` is used for 3-byte characters
    - `charclass4` is used with 4-byte characters.

`charclass` behaves like the original LUT table. `charclass2` has room for up to 256 `charclass`-like tables inside it, that are allocated only if required. `charclass3` has room for up to 256 `charclass2`-like tables, that are allocated only if required, etc.

This approach is (in my opinion) a reasonable tradeoff between:
 - A list (slow to look up)
 - A huge table for all unicode code points (wastes memory)
 - A red-black tree implementation (more coding required)


I have added a UTF-8 unit test, to check things are not broken in the future, although more robust tests should be written.

