### PR TITLE
Minor build changes

### DIFF
--- a/.time-stamp
+++ b/.time-stamp
@@ -1,8 +1,0 @@
-Festival Lite
-flite
-2.0.0
-Dec 2014
-release
-awb
-leith
-Wed Dec 24 08:46:02 EST 2014

--- a/Makefile
+++ b/Makefile
@@ -71,9 +71,6 @@ endif
 config/config: config/config.in config.status
 	./config.status
 
-configure: configure.in
-	autoconf
-
 backup: time-stamp
 	@ $(RM) -f $(TOP)/FileList
 	@ $(MAKE) file-list

--- a/Makefile
+++ b/Makefile
@@ -126,7 +126,7 @@ voices: ./bin/mimic_cmu_us_awb ./bin/mimic_cmu_us_rms ./bin/mimic_cmu_us_rms
 	./bin/mimic_cmu_us_rms -voicedump voices/cmu_us_rms.mimicvox
 	./bin/mimic_cmu_us_slt -voicedump voices/cmu_us_slt.mimicvox
 
-test:
+test: all
 	@ $(MAKE) --no-print-directory -C unittests
 	@ $(MAKE) --no-print-directory -C testsuite
 

--- a/Makefile
+++ b/Makefile
@@ -127,5 +127,6 @@ voices: ./bin/mimic_cmu_us_awb ./bin/mimic_cmu_us_rms ./bin/mimic_cmu_us_rms
 	./bin/mimic_cmu_us_slt -voicedump voices/cmu_us_slt.mimicvox
 
 test:
-	@ $(MAKE) --no-print-directory -C testsuite test
+	@ $(MAKE) --no-print-directory -C unittests
+	@ $(MAKE) --no-print-directory -C testsuite
 

--- a/Makefile
+++ b/Makefile
@@ -46,8 +46,8 @@ DIRNAME=
 BUILD_DIRS = include src lang doc
 ALL_DIRS=config $(BUILD_DIRS) testsuite \
          wince windows android \
-         tools main 
-CONFIG=configure configure.in config.sub config.guess \
+         tools main unittests
+CONFIG=configure configure.ac config.sub config.guess \
        missing install-sh mkinstalldirs
 WINDOWS = Exports.def mimic.sln mimicDll.vcproj
 FILES = Makefile README ACKNOWLEDGEMENTS COPYING $(CONFIG) $(WINDOWS)
@@ -124,6 +124,6 @@ voices: ./bin/mimic_cmu_us_awb ./bin/mimic_cmu_us_rms ./bin/mimic_cmu_us_rms
 	./bin/mimic_cmu_us_slt -voicedump voices/cmu_us_slt.mimicvox
 
 test: all
-	@ $(MAKE) --no-print-directory -C unittests
-	@ $(MAKE) --no-print-directory -C testsuite
+	@ $(MAKE) run_unit_tests --no-print-directory -C unittests
+	@ $(MAKE) run_more_tests --no-print-directory -C testsuite
 

--- a/config/common_make_rules
+++ b/config/common_make_rules
@@ -114,8 +114,8 @@ $(LIBDIR)/%.so: $(LIBDIR)/%.shared.a
 	@ echo making $@
 	@ rm -rf shared_os && mkdir shared_os
 	@ rm -f $@ $@.${PROJECT_VERSION} $@.${PROJECT_SHLIB_VERSION} 
-	@ (cd shared_os && ar x ../$<)
-	@ (cd shared_os && $(CC) -shared -Wl,-soname,`basename $@`.${PROJECT_SHLIB_VERSION} -o ../$@.${PROJECT_VERSION} *.os)
+	@ (cd shared_os && ar x $<)
+	@ (cd shared_os && $(CC) -shared -Wl,-soname,`basename $@`.${PROJECT_SHLIB_VERSION} -o $@.${PROJECT_VERSION} *.os)
 	@ (cd $(LIBDIR) && ln -s `basename $@.${PROJECT_VERSION}` `basename $@.${PROJECT_SHLIB_VERSION}` )
 	@ (cd $(LIBDIR) && ln -s `basename $@.${PROJECT_SHLIB_VERSION}` `basename $@` )
 	@ rm -rf shared_os

--- a/config/common_make_rules
+++ b/config/common_make_rules
@@ -132,6 +132,8 @@ endif
 clean:
 	@ echo make clean in $(DIRNAME) ...
 	@ rm -rf .build_lib .build_so *.gcda *.gcno *.gcov *.o *.os *.a *~ $(LOCAL_CLEAN)
+	@ rm -rf $(OBJDIR)/*
+
 ifdef ALL_DIRS
 	@ set -e; for i in $(ALL_DIRS) ; \
 	do \

--- a/configure
+++ b/configure
@@ -631,10 +631,10 @@ FL_LANG
 AUDIOLIBS
 AUDIODEFS
 AUDIODRIVER
-PORTAUDIO_LIBS
-PORTAUDIO_CFLAGS
 ALSA_LIBS
 ALSA_CFLAGS
+PORTAUDIO_LIBS
+PORTAUDIO_CFLAGS
 STDIOTYPE
 MMAPTYPE
 SHFLAGS
@@ -748,10 +748,10 @@ CPP
 PKG_CONFIG
 PKG_CONFIG_PATH
 PKG_CONFIG_LIBDIR
-ALSA_CFLAGS
-ALSA_LIBS
 PORTAUDIO_CFLAGS
-PORTAUDIO_LIBS'
+PORTAUDIO_LIBS
+ALSA_CFLAGS
+ALSA_LIBS'
 
 
 # Initialize some variables set by options.
@@ -1397,12 +1397,12 @@ Some influential environment variables:
               directories to add to pkg-config's search path
   PKG_CONFIG_LIBDIR
               path overriding pkg-config's built-in search path
-  ALSA_CFLAGS C compiler flags for ALSA, overriding pkg-config
-  ALSA_LIBS   linker flags for ALSA, overriding pkg-config
   PORTAUDIO_CFLAGS
               C compiler flags for PORTAUDIO, overriding pkg-config
   PORTAUDIO_LIBS
               linker flags for PORTAUDIO, overriding pkg-config
+  ALSA_CFLAGS C compiler flags for ALSA, overriding pkg-config
+  ALSA_LIBS   linker flags for ALSA, overriding pkg-config
 
 Use these variables to override the choices made by `configure' or to help
 it to find libraries and programs with nonstandard names/locations.
@@ -4523,80 +4523,6 @@ fi
 
 
 pkg_failed=no
-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for ALSA" >&5
-$as_echo_n "checking for ALSA... " >&6; }
-
-if test -n "$ALSA_CFLAGS"; then
-    pkg_cv_ALSA_CFLAGS="$ALSA_CFLAGS"
- elif test -n "$PKG_CONFIG"; then
-    if test -n "$PKG_CONFIG" && \
-    { { $as_echo "$as_me:${as_lineno-$LINENO}: \$PKG_CONFIG --exists --print-errors \"alsa >= 1.0.11\""; } >&5
-  ($PKG_CONFIG --exists --print-errors "alsa >= 1.0.11") 2>&5
-  ac_status=$?
-  $as_echo "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
-  test $ac_status = 0; }; then
-  pkg_cv_ALSA_CFLAGS=`$PKG_CONFIG --cflags "alsa >= 1.0.11" 2>/dev/null`
-		      test "x$?" != "x0" && pkg_failed=yes
-else
-  pkg_failed=yes
-fi
- else
-    pkg_failed=untried
-fi
-if test -n "$ALSA_LIBS"; then
-    pkg_cv_ALSA_LIBS="$ALSA_LIBS"
- elif test -n "$PKG_CONFIG"; then
-    if test -n "$PKG_CONFIG" && \
-    { { $as_echo "$as_me:${as_lineno-$LINENO}: \$PKG_CONFIG --exists --print-errors \"alsa >= 1.0.11\""; } >&5
-  ($PKG_CONFIG --exists --print-errors "alsa >= 1.0.11") 2>&5
-  ac_status=$?
-  $as_echo "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
-  test $ac_status = 0; }; then
-  pkg_cv_ALSA_LIBS=`$PKG_CONFIG --libs "alsa >= 1.0.11" 2>/dev/null`
-		      test "x$?" != "x0" && pkg_failed=yes
-else
-  pkg_failed=yes
-fi
- else
-    pkg_failed=untried
-fi
-
-
-
-if test $pkg_failed = yes; then
-   	{ $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
-$as_echo "no" >&6; }
-
-if $PKG_CONFIG --atleast-pkgconfig-version 0.20; then
-        _pkg_short_errors_supported=yes
-else
-        _pkg_short_errors_supported=no
-fi
-        if test $_pkg_short_errors_supported = yes; then
-	        ALSA_PKG_ERRORS=`$PKG_CONFIG --short-errors --print-errors --cflags --libs "alsa >= 1.0.11" 2>&1`
-        else
-	        ALSA_PKG_ERRORS=`$PKG_CONFIG --print-errors --cflags --libs "alsa >= 1.0.11" 2>&1`
-        fi
-	# Put the nasty error message in config.log where it belongs
-	echo "$ALSA_PKG_ERRORS" >&5
-
-
-elif test $pkg_failed = untried; then
-     	{ $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
-$as_echo "no" >&6; }
-
-else
-	ALSA_CFLAGS=$pkg_cv_ALSA_CFLAGS
-	ALSA_LIBS=$pkg_cv_ALSA_LIBS
-        { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-$as_echo "yes" >&6; }
-	AUDIODRIVER="alsa"
-                   AUDIODEFS="-DCST_AUDIO_ALSA ${ALSA_CFLAGS}"
-                   AUDIOLIBS="${ALSA_LIBS}"
-fi
-
-
-pkg_failed=no
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking for PORTAUDIO" >&5
 $as_echo_n "checking for PORTAUDIO... " >&6; }
 
@@ -4667,6 +4593,80 @@ $as_echo "yes" >&6; }
 	AUDIODRIVER="portaudio"
                    AUDIODEFS="-DCST_AUDIO_PORTAUDIO ${PORTAUDIO_CFLAGS}"
                    AUDIOLIBS="${PORTAUDIO_LIBS}"
+fi
+
+
+pkg_failed=no
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for ALSA" >&5
+$as_echo_n "checking for ALSA... " >&6; }
+
+if test -n "$ALSA_CFLAGS"; then
+    pkg_cv_ALSA_CFLAGS="$ALSA_CFLAGS"
+ elif test -n "$PKG_CONFIG"; then
+    if test -n "$PKG_CONFIG" && \
+    { { $as_echo "$as_me:${as_lineno-$LINENO}: \$PKG_CONFIG --exists --print-errors \"alsa >= 1.0.11\""; } >&5
+  ($PKG_CONFIG --exists --print-errors "alsa >= 1.0.11") 2>&5
+  ac_status=$?
+  $as_echo "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
+  test $ac_status = 0; }; then
+  pkg_cv_ALSA_CFLAGS=`$PKG_CONFIG --cflags "alsa >= 1.0.11" 2>/dev/null`
+		      test "x$?" != "x0" && pkg_failed=yes
+else
+  pkg_failed=yes
+fi
+ else
+    pkg_failed=untried
+fi
+if test -n "$ALSA_LIBS"; then
+    pkg_cv_ALSA_LIBS="$ALSA_LIBS"
+ elif test -n "$PKG_CONFIG"; then
+    if test -n "$PKG_CONFIG" && \
+    { { $as_echo "$as_me:${as_lineno-$LINENO}: \$PKG_CONFIG --exists --print-errors \"alsa >= 1.0.11\""; } >&5
+  ($PKG_CONFIG --exists --print-errors "alsa >= 1.0.11") 2>&5
+  ac_status=$?
+  $as_echo "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
+  test $ac_status = 0; }; then
+  pkg_cv_ALSA_LIBS=`$PKG_CONFIG --libs "alsa >= 1.0.11" 2>/dev/null`
+		      test "x$?" != "x0" && pkg_failed=yes
+else
+  pkg_failed=yes
+fi
+ else
+    pkg_failed=untried
+fi
+
+
+
+if test $pkg_failed = yes; then
+   	{ $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
+
+if $PKG_CONFIG --atleast-pkgconfig-version 0.20; then
+        _pkg_short_errors_supported=yes
+else
+        _pkg_short_errors_supported=no
+fi
+        if test $_pkg_short_errors_supported = yes; then
+	        ALSA_PKG_ERRORS=`$PKG_CONFIG --short-errors --print-errors --cflags --libs "alsa >= 1.0.11" 2>&1`
+        else
+	        ALSA_PKG_ERRORS=`$PKG_CONFIG --print-errors --cflags --libs "alsa >= 1.0.11" 2>&1`
+        fi
+	# Put the nasty error message in config.log where it belongs
+	echo "$ALSA_PKG_ERRORS" >&5
+
+
+elif test $pkg_failed = untried; then
+     	{ $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
+
+else
+	ALSA_CFLAGS=$pkg_cv_ALSA_CFLAGS
+	ALSA_LIBS=$pkg_cv_ALSA_LIBS
+        { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+$as_echo "yes" >&6; }
+	AUDIODRIVER="alsa"
+                   AUDIODEFS="-DCST_AUDIO_ALSA ${ALSA_CFLAGS}"
+                   AUDIOLIBS="${ALSA_LIBS}"
 fi
 
 for ac_header in mmsystem.h

--- a/configure.ac
+++ b/configure.ac
@@ -398,18 +398,18 @@ AC_CHECK_HEADER(sys/audioio.h,
               [AUDIODRIVER="sun"
                AUDIODEFS=-DCST_AUDIO_SUNOS])
 
-dnl Check for ALSA sound library
-PKG_CHECK_MODULES([ALSA], [alsa >= 1.0.11],
-                  [AUDIODRIVER="alsa"
-                   AUDIODEFS="-DCST_AUDIO_ALSA ${ALSA_CFLAGS}"
-                   AUDIOLIBS="${ALSA_LIBS}"],
-                  [m4_ignore])
-
 dnl Check PortAudio is at least (v19-dev)
 PKG_CHECK_MODULES([PORTAUDIO], [portaudio-2.0 >= 19],
                   [AUDIODRIVER="portaudio"
                    AUDIODEFS="-DCST_AUDIO_PORTAUDIO ${PORTAUDIO_CFLAGS}"
                    AUDIOLIBS="${PORTAUDIO_LIBS}"],
+                  [m4_ignore])
+
+dnl Check for ALSA sound library
+PKG_CHECK_MODULES([ALSA], [alsa >= 1.0.11],
+                  [AUDIODRIVER="alsa"
+                   AUDIODEFS="-DCST_AUDIO_ALSA ${ALSA_CFLAGS}"
+                   AUDIOLIBS="${ALSA_LIBS}"],
                   [m4_ignore])
 
 AC_CHECK_HEADERS(mmsystem.h,

--- a/run_testsuite.sh
+++ b/run_testsuite.sh
@@ -2,6 +2,5 @@
 
 ./configure --enable-gcov || exit 1
 make || exit 1
-(cd unittests && make && ./run_all_tests)
-
+make test || exit 1
 

--- a/testsuite/Makefile
+++ b/testsuite/Makefile
@@ -80,8 +80,13 @@ multi_thread: multi_thread_main.c
 		$(CFLAGS) -I$(TOP)/include $(MIMICLIBFLAGS) $(LDFLAGS) \
 		-l mimic_cmu_us_slt -lmimic_cmulex -lmimic_usenglish \
 		-lmimic -lm -lasound -lgomp
-do_thread_test: multi_thread
-#	This shouldn't segfault
-	export OMP_NUM_THREADS=100 && ./multi_thread
 
+run_more_tests: $(MAIN_EXECS) multi_thread
+	export LD_LIBRARY_PATH="$(LIBDIR)"; \
+	export OMP_NUM_THREADS=100 && ./multi_thread || \
+	  (echo "Multi thread test failed"; exit 1); \
+# TODO: The other tests are not so automatic and need to be reviewed
+#for exec in $(MAIN_EXECS); do \
+#./$$exec || err=1; \
+#done; \
 

--- a/unittests/Makefile
+++ b/unittests/Makefile
@@ -66,12 +66,22 @@ LOCAL_CLEAN = $(MAIN_EXECS)
 
 include $(TOP)/config/common_make_rules
 
+
 voice_select_test: voice_select_test_main.c $(MIMIC_LIBS)
 	$(CC) $(CFLAGS) $(INCLUDES) -o $@ $< $($(@:=_LIBS)) $(MIMICLIBFLAGS) $(LDFLAGS) 
+
+run_unit_tests: $(MAIN_EXECS)
+	export LD_LIBRARY_PATH="$(LIBDIR)"; \
+	err=0; \
+	for exec in $(MAIN_EXECS); do \
+        ./$$exec || err=1; \
+        done; \
+	[ "x$$err" = "x0" ] || (echo "Some unit tests failed"; exit 1)
 
 MAIN_O = $(SRCS:%=%_main.o)
 $(MAIN_O) : %_main.o : %_main.c
 	$(CC) $(CFLAGS) -o $@ $< 
+
 $(ALL) : %$(EXEEXT) : %_main.o $(MIMICLIBS)
 	$(CC) $(CFLAGS) -o $@ $@_main.o $($(@:=_LIBS)) $(MIMICLIBFLAGS) $(LDFLAGS)
 

--- a/unittests/lex_test_main.c
+++ b/unittests/lex_test_main.c
@@ -85,7 +85,7 @@ void test_activism(void)
 void test_chronicles(void)
 {
     cmu_lex_init();
-    lookup_and_test(&cmu_lex, "chronicles", NULL, "k r aa1 n ax0 k ax0 l z");
+    lookup_and_test(&cmu_lex, "chronicles", NULL, "k r aa1 n ih0 k ax0 l z");
 }
 
 void test_project(void)

--- a/unittests/run_all_tests
+++ b/unittests/run_all_tests
@@ -1,1 +1,0 @@
-find . -name \*_test -exec {} \;


### PR DESCRIPTION
# What it does

Fixes a couple of minor issues with the build system
- test target now compiles the tests (what it was supposed to do as far as I could determine)
- `.time-stamp` no longer under version control
- Alsa preferred over Port Audio
- `make configure` seems unnecessary (but I may be wrong) and is removed