### PR TITLE
Remove OSS linux audio driver

### DIFF
--- a/configure
+++ b/configure
@@ -5960,3 +5960,8 @@ if test -n "$ac_unrecognized_opts" && test "$enable_option_checking" != no; then
 $as_echo "$as_me: WARNING: unrecognized options: $ac_unrecognized_opts" >&2;}
 fi
 
+
+if [ "$AUDIODRIVER" == "none" ] && [ "$with_audio" != "none" ] ; then
+    { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: No audio driver could be determined, and no sound output will be possible. Mimic will work but only be able to write output to disk." >&5
+$as_echo "$as_me: WARNING: No audio driver could be determined, and no sound output will be possible. Mimic will work but only be able to write output to disk." >&2;}
+fi

--- a/configure
+++ b/configure
@@ -4506,13 +4506,6 @@ fi
 
 
 AUDIODRIVER=none
-ac_fn_c_check_header_mongrel "$LINENO" "sys/soundcard.h" "ac_cv_header_sys_soundcard_h" "$ac_includes_default"
-if test "x$ac_cv_header_sys_soundcard_h" = xyes; then :
-  AUDIODRIVER="oss"
-               AUDIODEFS=-DCST_AUDIO_LINUX
-fi
-
-
 ac_fn_c_check_header_mongrel "$LINENO" "machine/soundcard.h" "ac_cv_header_machine_soundcard_h" "$ac_includes_default"
 if test "x$ac_cv_header_machine_soundcard_h" = xyes; then :
   AUDIODRIVER="oss"
@@ -4727,10 +4720,6 @@ fi
 
 if test "x$AUDIODEFS" = x; then
     case "$AUDIODRIVER" in
-	linux|oss)
-	    AUDIODRIVER=oss
-	    AUDIODEFS=-DCST_AUDIO_LINUX
-	    ;;
 	alsa)
             AUDIODRIVER="alsa"
 	    AUDIODEFS="-DCST_AUDIO_ALSA ${ALSA_CFLAGS}"

--- a/configure.ac
+++ b/configure.ac
@@ -391,9 +391,6 @@ dnl
 dnl determine audio type or use none if none supported on this platform
 dnl
 AUDIODRIVER=none
-AC_CHECK_HEADER(sys/soundcard.h,
-              [AUDIODRIVER="oss"
-               AUDIODEFS=-DCST_AUDIO_LINUX])
 AC_CHECK_HEADER(machine/soundcard.h,
               [AUDIODRIVER="oss"
                AUDIODEFS=-DCST_AUDIO_FREEBSD])
@@ -458,10 +455,6 @@ AC_ARG_WITH( audio,
 
 if test "x$AUDIODEFS" = x; then
     case "$AUDIODRIVER" in
-	linux|oss)
-	    AUDIODRIVER=oss
-	    AUDIODEFS=-DCST_AUDIO_LINUX
-	    ;;
 	alsa)
             AUDIODRIVER="alsa"
 	    AUDIODEFS="-DCST_AUDIO_ALSA ${ALSA_CFLAGS}"

--- a/configure.ac
+++ b/configure.ac
@@ -520,3 +520,7 @@ AC_SUBST(FL_LANGVOX)
 
 AC_CONFIG_FILES([config/config config/system.mak])
 AC_OUTPUT
+
+if [[ "$AUDIODRIVER" == "none" ] && [ "$with_audio" != "none" ]] ; then
+    AC_MSG_WARN([No audio driver could be determined, and no sound output will be possible. Mimic will work but only be able to write output to disk.])
+fi

--- a/src/audio/au_oss.c
+++ b/src/audio/au_oss.c
@@ -48,12 +48,6 @@
 #include "cst_wave.h"
 #include "cst_audio.h"
 
-#ifdef CST_AUDIO_LINUX
-/* Linux/voxware audio specific */
-#include <sys/ioctl.h>
-#include <sys/soundcard.h>
-#include <sys/types.h>
-#endif
 #ifdef CST_AUDIO_FREEBSD
 /* probably Net and Open too */
 #include <machine/soundcard.h>

--- a/src/audio/native_audio.h
+++ b/src/audio/native_audio.h
@@ -66,19 +66,6 @@
 #define AUDIO_EXIT_NATIVE audio_exit_sun
 #endif
 
-#ifdef CST_AUDIO_LINUX
-
-#define AUDIO_INIT_NATIVE audio_init_oss
-#define AUDIO_OPEN_NATIVE audio_open_oss
-#define AUDIO_CLOSE_NATIVE audio_close_oss
-#define AUDIO_SET_SAMPLE_RATE_NATIVE audio_set_sample_rate_oss
-#define AUDIO_WRITE_NATIVE audio_write_oss
-#define AUDIO_DRAIN_NATIVE audio_drain_oss
-#define AUDIO_FLUSH_NATIVE audio_flush_oss
-#define AUDIO_EXIT_NATIVE audio_exit_oss
-
-#endif
-
 #ifdef CST_AUDIO_ALSA
 
 #define AUDIO_INIT_NATIVE audio_init_alsa


### PR DESCRIPTION
Removes *OSS* as a valid audio driver under Linux (*OSS* can still be used on *BSD) as it has been depreciated for a while and the detection is a bit wonky as described in #47. 

Also included is a warning message if the configure script couldn't determine a suitable sound driver.