### PR TITLE
Pay no attention - Testing failing unittests

### DIFF
--- a/unittests/run_all_tests
+++ b/unittests/run_all_tests
@@ -1,1 +1,8 @@
-find . -name \*_test -exec {} \;
+#!/usr/bin/env bash
+
+set -e
+FILES=./*_test
+for f in $FILES
+do
+    $f
+done


### PR DESCRIPTION
run_all_tests now returns an non-zero exit status