### PR TITLE
Fix integer sizes on read/write

### DIFF
--- a/include/cst_cart.h
+++ b/include/cst_cart.h
@@ -40,6 +40,7 @@
 #ifndef _CST_CART_H__
 #define _CST_CART_H__
 
+#include <stdint.h>
 #include "cst_file.h"
 #include "cst_val.h"
 #include "cst_features.h"
@@ -59,7 +60,7 @@ typedef struct cst_cart_node_struct {
     unsigned char feat;
     unsigned char op;
     /* yes is always the next node */
-    unsigned short no_node;     /* or answer index */
+    uint16_t no_node;     /* or answer index */
     const cst_val *val;
 } cst_cart_node;
 

--- a/include/cst_cg.h
+++ b/include/cst_cg.h
@@ -45,6 +45,7 @@
 /*************************************************************************/
 #ifndef _CST_CG_H__
 #define _CST_CG_H__
+#include <stdint.h>
 
 #include "cst_cart.h"
 #include "cst_track.h"
@@ -58,28 +59,28 @@ typedef struct cst_cg_db_struct {
        voice too (in cst_cg_dump_voice and cst_cg_map) */
     const char *name;
     const char *const *types;
-    int num_types;
+    int32_t num_types;
 
-    int sample_rate;
+    int32_t sample_rate;
 
     float f0_mean, f0_stddev;
 
     /* Cluster trees */
     const cst_cart *const *f0_trees;
 
-    int num_param_models;
+    int32_t num_param_models;
     const cst_cart ***param_trees;
 
     const cst_cart *spamf0_accent_tree; /* spam accent tree */
     const cst_cart *spamf0_phrase_tree; /* spam phrase tree */
 
     /* Model params e.g. mceps, deltas intersliced with stddevs */
-    int *num_channels;
-    int *num_frames;
-    const unsigned short ***model_vectors;
+    int32_t *num_channels;
+    int32_t *num_frames;
+    const uint16_t ***model_vectors;
 
-    int num_channels_spamf0_accent;
-    int num_frames_spamf0_accent;
+    int32_t num_channels_spamf0_accent;
+    int32_t num_frames_spamf0_accent;
     const float *const *spamf0_accent_vectors;
 
     /* Currently shared between different models */
@@ -89,7 +90,7 @@ typedef struct cst_cg_db_struct {
     float frame_advance;
 
     /* duration models (cart + phonedurs) */
-    int num_dur_models;
+    int32_t num_dur_models;
     const dur_stat ***dur_stats;
     const cst_cart **dur_cart;
 
@@ -97,25 +98,25 @@ typedef struct cst_cg_db_struct {
     const char *const *const *phone_states;
 
     /* Other parameters */
-    int do_mlpg;                /* implies deltas are in the model_vectors */
+    int32_t do_mlpg;       /* implies deltas are in the model_vectors */
     float *dynwin;
-    int dynwinsize;
+    int32_t dynwinsize;
 
     float mlsa_alpha;
     float mlsa_beta;
 
-    int multimodel;
-    int mixed_excitation;
+    int32_t multimodel;
+    int32_t mixed_excitation;
 
     /* filters for Mixed Excitation */
-    int ME_num;
-    int ME_order;
+    int32_t ME_num;
+    int32_t ME_order;
     const double *const *me_h;
 
-    int spamf0;
+    int32_t spamf0;
     float gain;
 
-    int freeable;               /* doesn't get dumped, but 1 when this a freeable struct */
+    int32_t freeable;               /* doesn't get dumped, but 1 when this a freeable struct */
 
 } cst_cg_db;
 

--- a/include/cst_endian.h
+++ b/include/cst_endian.h
@@ -37,11 +37,14 @@
 /*    endianness                                                         */
 /*                                                                       */
 /*************************************************************************/
+
+#include <stdint.h>
+
 #ifndef __CST_ENDIAN_H__
 #define __CST_ENDIAN_H__
 
 /* This gets set to 1 and we test where the on bit is to determine byteorder */
-extern const int cst_endian_loc;
+extern const int32_t cst_endian_loc;
 /* Sun, HP, SGI Mips, M68000, PowerPC */
 #define CST_BIG_ENDIAN (((char *)&cst_endian_loc)[0] == 0)
 /* Intel, Alpha, DEC Mips, Vax, ARM, Other MIPS (Casio, Ben Nanonote etc) */
@@ -52,19 +55,14 @@ extern const int cst_endian_loc;
 #define BYTE_ORDER_BIG "10"
 #define BYTE_ORDER_LITTLE "01"
 
-#define SWAPINT(x) ((((unsigned int)x) & 0xff) << 24 | \
-        (((unsigned int)x) & 0xff00) << 8 | \
-	(((unsigned int)x) & 0xff0000) >> 8 | \
-        (((unsigned int)x) & 0xff000000) >> 24)
-/* For m68k we want to be a little more explicit */
-#define SWAPLONG(x) ((((unsigned long)x) & 0xff) << 24 | \
-        (((unsigned long)x) & 0xff00) << 8 | \
-	(((unsigned long)x) & 0xff0000) >> 8 | \
-        (((unsigned long)x) & 0xff000000) >> 24)
-#define SWAPSHORT(x) ((((unsigned short)x) & 0xff) << 8 | \
-        (((unsigned short)x) & 0xff00) >> 8)
+#define SWAPINT(x) ((((uint32_t)x) & 0xff) << 24 | \
+        (((uint32_t)x) & 0xff00) << 8 | \
+	(((uint32_t)x) & 0xff0000) >> 8 | \
+        (((uint32_t)x) & 0xff000000) >> 24)
+#define SWAPSHORT(x) ((((uint16_t)x) & 0xff) << 8 | \
+        (((uint16_t)x) & 0xff00) >> 8)
 
-void swap_bytes_short(short *b, int n);
+void swap_bytes_short(int16_t *b, size_t n);
 
 void swapdouble(double *d);
 void swapfloat(float *f);

--- a/include/cst_endian.h
+++ b/include/cst_endian.h
@@ -55,11 +55,11 @@ extern const int32_t cst_endian_loc;
 #define BYTE_ORDER_BIG "10"
 #define BYTE_ORDER_LITTLE "01"
 
-#define SWAPINT(x) ((((uint32_t)x) & 0xff) << 24 | \
+#define SWAPINT32(x) ((((uint32_t)x) & 0xff) << 24 | \
         (((uint32_t)x) & 0xff00) << 8 | \
 	(((uint32_t)x) & 0xff0000) >> 8 | \
         (((uint32_t)x) & 0xff000000) >> 24)
-#define SWAPSHORT(x) ((((uint16_t)x) & 0xff) << 8 | \
+#define SWAPINT16(x) ((((uint16_t)x) & 0xff) << 8 | \
         (((uint16_t)x) & 0xff00) >> 8)
 
 void swap_bytes_short(int16_t *b, size_t n);

--- a/include/cst_wave.h
+++ b/include/cst_wave.h
@@ -56,11 +56,11 @@ typedef struct cst_wave_struct {
 
 typedef struct cst_wave_header_struct {
     const char *type;
-    int hsize;
-    int num_bytes;
-    int sample_rate;
-    int num_samples;
-    int num_channels;
+    int32_t hsize;
+    int32_t num_bytes;
+    int32_t sample_rate;
+    int32_t num_samples;
+    int32_t num_channels;
 } cst_wave_header;
 
 cst_wave *new_wave();
@@ -135,22 +135,22 @@ int cst_rateconv_out(cst_rateconv *filt, short *outptr, int max);
 
 /* Sun/Next header, short and sweet, note its always BIG_ENDIAN though */
 typedef struct {
-    unsigned int magic;         /* magic number */
-    unsigned int hdr_size;      /* size of this header */
-    int data_size;              /* length of data (optional) */
-    unsigned int encoding;      /* data encoding format */
-    unsigned int sample_rate;   /* samples per second */
-    unsigned int channels;      /* number of interleaved channels */
+    uint32_t magic;         /* magic number */
+    uint32_t hdr_size;      /* size of this header */
+    int32_t data_size;              /* length of data (optional) */
+    uint32_t encoding;      /* data encoding format */
+    uint32_t sample_rate;   /* samples per second */
+    uint32_t channels;      /* number of interleaved channels */
 } snd_header;
 
-#define CST_SND_MAGIC (unsigned int)0x2e736e64
+#define CST_SND_MAGIC (uint32_t)0x2e736e64
 #define CST_SND_ULAW  1
 #define CST_SND_UCHAR 2
 #define CST_SND_SHORT 3
 
 /* Convertion functions */
-unsigned char cst_short_to_ulaw(short sample);
-short cst_ulaw_to_short(unsigned char ulawbyte);
+unsigned char cst_short_to_ulaw(int16_t sample);
+int16_t cst_ulaw_to_short(unsigned char ulawbyte);
 
 #define CST_G721_LEADIN 8
 unsigned char *cst_g721_decode(int *actual_size, int size,

--- a/src/audio/auclient.c
+++ b/src/audio/auclient.c
@@ -68,7 +68,7 @@ int play_wave_client(cst_wave *w, const char *servername, int port,
     if ((audiofd = cst_socket_open(servername, port)) < 0)
         return CST_ERROR_FORMAT;
 
-    header.magic = (unsigned int) 0x2e736e64;
+    header.magic = (uint32_t) 0x2e736e64;
     header.hdr_size = sizeof(header);
     if (cst_streq(encoding, "ulaw"))
     {
@@ -90,12 +90,12 @@ int play_wave_client(cst_wave *w, const char *servername, int port,
     header.channels = w->num_channels;
     if (CST_LITTLE_ENDIAN)
     {                           /* If I'm intel etc swap things, so "network byte order" */
-        header.magic = SWAPINT(header.magic);
-        header.hdr_size = SWAPINT(header.hdr_size);
-        header.data_size = SWAPINT(header.data_size);
-        header.encoding = SWAPINT(header.encoding);
-        header.sample_rate = SWAPINT(header.sample_rate);
-        header.channels = SWAPINT(header.channels);
+        header.magic = SWAPINT32(header.magic);
+        header.hdr_size = SWAPINT32(header.hdr_size);
+        header.data_size = SWAPINT32(header.data_size);
+        header.encoding = SWAPINT32(header.encoding);
+        header.sample_rate = SWAPINT32(header.sample_rate);
+        header.channels = SWAPINT32(header.channels);
     }
 
     if (write(audiofd, &header, sizeof(header)) != sizeof(header))
@@ -106,7 +106,7 @@ int play_wave_client(cst_wave *w, const char *servername, int port,
     }
     const int buffsize = 128;
     bytes = cst_alloc(unsigned char, buffsize);
-    shorts = cst_alloc(short, buffsize);
+    shorts = cst_alloc(int16_t, buffsize);
 
     for (i = 0; i < w->num_samples; i += r)
     {
@@ -124,7 +124,7 @@ int play_wave_client(cst_wave *w, const char *servername, int port,
         {
             for (q = 0; q < n; q++)
                 if (CST_LITTLE_ENDIAN)
-                    shorts[q] = SWAPSHORT(w->samples[i + q]);
+                    shorts[q] = SWAPINT16(w->samples[i + q]);
                 else
                     shorts[q] = w->samples[i + q];
             r = write(audiofd, shorts, n * 2);

--- a/src/audio/audio.c
+++ b/src/audio/audio.c
@@ -269,7 +269,9 @@ static void audio_write_buffer(cst_audiodev *ad, void *buff,
                 n = CST_AUDIOBUFFSIZE;
             else
                 n = num_shorts - i;
-            r = audio_write(ad, buff + i * bytes_per_short, n * 2);
+            /* buff casted to char because a 1 unit buff increment must
+             * be one byte */
+            r = audio_write(ad, ((char*)buff) + i * bytes_per_short, n * 2);
             if (r <= 0)
             {
                 cst_errmsg("failed to write %d samples\n", n);

--- a/src/audio/auserver.c
+++ b/src/audio/auserver.c
@@ -116,7 +116,7 @@ static int play_wave_from_socket(snd_header * header, int audiostream)
             r = read(audiostream, shorts, n * 2);
             if (CST_LITTLE_ENDIAN)
                 for (q = 0; q < r / 2; q++)
-                    shorts[q] = SWAPSHORT(shorts[q]);
+                    shorts[q] = SWAPINT16(shorts[q]);
         }
 
         if (r <= 0)
@@ -166,12 +166,12 @@ static int auserver_process_client(int client_name, int fd)
     }
     if (CST_LITTLE_ENDIAN)
     {
-        header.magic = SWAPINT(header.magic);
-        header.hdr_size = SWAPINT(header.hdr_size);
-        header.data_size = SWAPINT(header.data_size);
-        header.encoding = SWAPINT(header.encoding);
-        header.sample_rate = SWAPINT(header.sample_rate);
-        header.channels = SWAPINT(header.channels);
+        header.magic = SWAPINT32(header.magic);
+        header.hdr_size = SWAPINT32(header.hdr_size);
+        header.data_size = SWAPINT32(header.data_size);
+        header.encoding = SWAPINT32(header.encoding);
+        header.sample_rate = SWAPINT32(header.sample_rate);
+        header.channels = SWAPINT32(header.channels);
     }
 
     if (header.magic != CST_SND_MAGIC)

--- a/src/audio/auserver.c
+++ b/src/audio/auserver.c
@@ -97,7 +97,7 @@ static int play_wave_from_socket(snd_header * header, int audiostream)
     num_samples = header->data_size / sample_width;
     /* we naively let the num_channels sort itself out */
     bytes = cst_alloc(unsigned char, CST_AUDIOBUFFSIZE);
-    shorts = cst_alloc(short, CST_AUDIOBUFFSIZE);
+    shorts = cst_alloc(int16_t, CST_AUDIOBUFFSIZE);
     for (i = 0; i < num_samples; i += r / 2)
     {
         if (num_samples > i + CST_AUDIOBUFFSIZE)

--- a/src/cg/cst_cg_dump_voice.c
+++ b/src/cg/cst_cg_dump_voice.c
@@ -50,14 +50,14 @@ static void cst_cg_write_header(cst_file fd)
     const char *header = cg_voice_header_string;
 
     cst_fwrite(fd, header, 1, cst_strlen(header) + 1);
-    cst_fwrite(fd, &cst_endian_loc, sizeof(int), 1);    /* for byte order check */
+    cst_fwrite(fd, &cst_endian_loc, sizeof(int32_t), 1);    /* for byte order check */
 
 }
 
 static void cst_cg_write_padded(cst_file fd, const void *data, int numbytes)
 {
     /* We used to do 4-byte alignments. but that's not necessary now */
-    cst_fwrite(fd, &numbytes, sizeof(int), 1);
+    cst_fwrite(fd, &numbytes, sizeof(int32_t), 1);
     cst_fwrite(fd, data, 1, numbytes);
 }
 
@@ -70,7 +70,7 @@ static void cst_cg_write_db_types(cst_file fd, const cst_cg_db *db)
     while (db->types[n])
         n++;
 
-    cst_fwrite(fd, &n, sizeof(int), 1);
+    cst_fwrite(fd, &n, sizeof(int32_t), 1);
 
     for (i = 0; i < n; i++)
         cst_cg_write_padded(fd, (void *) (db->types[i]),
@@ -88,13 +88,13 @@ static void cst_cg_write_tree_nodes(cst_file fd, const cst_cart_node * nodes)
     while (nodes[num_nodes].val != 0)
         num_nodes++;
 
-    cst_fwrite(fd, &num_nodes, sizeof(int), 1);
+    cst_fwrite(fd, &num_nodes, sizeof(int32_t), 1);
     for (i = 0; i < num_nodes; i++)
     {
         cst_fwrite(fd, &nodes[i].feat, sizeof(char), 1);
         cst_fwrite(fd, &nodes[i].op, sizeof(char), 1);
-        cst_fwrite(fd, &nodes[i].no_node, sizeof(short), 1);
-        cst_fwrite(fd, &nodes[i].val->c.a.type, sizeof(short), 1);
+        cst_fwrite(fd, &nodes[i].no_node, sizeof(int16_t), 1);
+        cst_fwrite(fd, &nodes[i].val->c.a.type, sizeof(int16_t), 1);
         if (nodes[i].val->c.a.type == CST_VAL_TYPE_STRING)
         {
             cst_cg_write_padded(fd, nodes[i].val->c.a.v.vval,
@@ -103,7 +103,7 @@ static void cst_cg_write_tree_nodes(cst_file fd, const cst_cart_node * nodes)
         else if (nodes[i].val->c.a.type == CST_VAL_TYPE_INT)
         {
             an_int = nodes[i].val->c.a.v.ival;
-            cst_fwrite(fd, &an_int, sizeof(int), 1);
+            cst_fwrite(fd, &an_int, sizeof(int32_t), 1);
         }
         else if (nodes[i].val->c.a.type == CST_VAL_TYPE_FLOAT)
         {
@@ -112,7 +112,7 @@ static void cst_cg_write_tree_nodes(cst_file fd, const cst_cart_node * nodes)
         }
         else
         {                       /* its not going to work without more code ... */
-            cst_fwrite(fd, &nodes[i].val->c.a.v.ival, sizeof(int), 1);
+            cst_fwrite(fd, &nodes[i].val->c.a.v.ival, sizeof(int32_t), 1);
         }
     }
 }
@@ -125,7 +125,7 @@ static void cst_cg_write_tree_feats(cst_file fd, const char *const *feats)
     i = 0;
     while (feats[i])
         i++;
-    cst_fwrite(fd, &i, sizeof(int), 1);
+    cst_fwrite(fd, &i, sizeof(int32_t), 1);
 
     for (i = 0; feats[i]; i++)
         cst_cg_write_padded(fd, (void *) (feats[i]), strlen(feats[i]) + 1);
@@ -145,7 +145,7 @@ static void cst_cg_write_tree_array(cst_file fd, const cst_cart *const *trees)
 
     while (trees && trees[i])
         i++;
-    cst_fwrite(fd, &i, sizeof(int), 1);
+    cst_fwrite(fd, &i, sizeof(int32_t), 1);
 
     for (i = 0; trees && trees[i]; i++)
         cst_cg_write_tree(fd, trees[i]);
@@ -164,7 +164,7 @@ static void cst_cg_write_2d_array(cst_file fd, void **data, int rows,
     int i;
     int columnsize = cols * unitsize;
 
-    cst_fwrite(fd, &rows, sizeof(int), 1);
+    cst_fwrite(fd, &rows, sizeof(int32_t), 1);
 
     for (i = 0; i < rows; i++)
         cst_cg_write_array(fd, data[i], columnsize);
@@ -180,7 +180,7 @@ static void cst_cg_write_dur_stats(cst_file fd, const dur_stat * const *ds)
     while (ds[numstats])
         numstats++;
 
-    cst_fwrite(fd, &numstats, sizeof(int), 1);
+    cst_fwrite(fd, &numstats, sizeof(int32_t), 1);
 
     /* Write the string resources */
     for (i = 0; i < numstats; i++)
@@ -203,14 +203,14 @@ static void cst_cg_write_phone_states(cst_file fd,
     count = 0;
     while (ps[count])
         count++;
-    cst_fwrite(fd, &count, sizeof(int), 1);
+    cst_fwrite(fd, &count, sizeof(int32_t), 1);
 
     for (i = 0; i < count; i++)
     {
         count2 = 0;
         while (ps[i][count2])
             count2++;
-        cst_fwrite(fd, &count2, sizeof(int), 1);
+        cst_fwrite(fd, &count2, sizeof(int32_t), 1);
 
         for (j = 0; j < count2; j++)
             cst_cg_write_padded(fd, ps[i][j], strlen(ps[i][j]) + 1);
@@ -278,8 +278,8 @@ int cst_cg_dump_voice(const cst_voice *v, const cst_string *filename)
     cst_cg_write_padded(fd, (void *) db->name, cst_strlen(db->name) + 1);
     cst_cg_write_db_types(fd, db);
 
-    cst_fwrite(fd, &db->num_types, sizeof(int), 1);
-    cst_fwrite(fd, &db->sample_rate, sizeof(int), 1);
+    cst_fwrite(fd, &db->num_types, sizeof(int32_t), 1);
+    cst_fwrite(fd, &db->sample_rate, sizeof(int32_t), 1);
     cst_fwrite(fd, &db->f0_mean, sizeof(float), 1);
     cst_fwrite(fd, &db->f0_stddev, sizeof(float), 1);
 
@@ -288,7 +288,7 @@ int cst_cg_dump_voice(const cst_voice *v, const cst_string *filename)
     for (pm = 0; pm < db->num_param_models; pm++)
         cst_cg_write_tree_array(fd, db->param_trees[pm]);
 
-    cst_fwrite(fd, &db->spamf0, sizeof(int), 1);
+    cst_fwrite(fd, &db->spamf0, sizeof(int32_t), 1);
     if (db->spamf0)
     {
         cst_cg_write_tree(fd, db->spamf0_accent_tree);
@@ -297,17 +297,17 @@ int cst_cg_dump_voice(const cst_voice *v, const cst_string *filename)
 
     for (pm = 0; pm < db->num_param_models; pm++)
     {
-        cst_fwrite(fd, &db->num_channels[pm], sizeof(int), 1);
-        cst_fwrite(fd, &db->num_frames[pm], sizeof(int), 1);
+        cst_fwrite(fd, &db->num_channels[pm], sizeof(int32_t), 1);
+        cst_fwrite(fd, &db->num_frames[pm], sizeof(int32_t), 1);
         cst_cg_write_2d_array(fd, (void *) db->model_vectors[pm],
                               db->num_frames[pm], db->num_channels[pm],
-                              sizeof(unsigned short));
+                              sizeof(uint16_t));
     }
 
     if (db->spamf0)
     {
-        cst_fwrite(fd, &db->num_channels_spamf0_accent, sizeof(int), 1);
-        cst_fwrite(fd, &db->num_frames_spamf0_accent, sizeof(int), 1);
+        cst_fwrite(fd, &db->num_channels_spamf0_accent, sizeof(int32_t), 1);
+        cst_fwrite(fd, &db->num_frames_spamf0_accent, sizeof(int32_t), 1);
         cst_cg_write_2d_array(fd, (void *) db->spamf0_accent_vectors,
                               db->num_frames_spamf0_accent,
                               db->num_channels_spamf0_accent, sizeof(float));
@@ -328,22 +328,22 @@ int cst_cg_dump_voice(const cst_voice *v, const cst_string *filename)
 
     cst_cg_write_phone_states(fd, db->phone_states);
 
-    cst_fwrite(fd, &db->do_mlpg, sizeof(int), 1);
+    cst_fwrite(fd, &db->do_mlpg, sizeof(int32_t), 1);
     cst_cg_write_array(fd, db->dynwin, db->dynwinsize * sizeof(float));
-    cst_fwrite(fd, &db->dynwinsize, sizeof(int), 1);
+    cst_fwrite(fd, &db->dynwinsize, sizeof(int32_t), 1);
 
     cst_fwrite(fd, &db->mlsa_alpha, sizeof(float), 1);
     cst_fwrite(fd, &db->mlsa_beta, sizeof(float), 1);
 
-    cst_fwrite(fd, &db->multimodel, sizeof(int), 1);
-    cst_fwrite(fd, &db->mixed_excitation, sizeof(int), 1);
+    cst_fwrite(fd, &db->multimodel, sizeof(int32_t), 1);
+    cst_fwrite(fd, &db->mixed_excitation, sizeof(int32_t), 1);
 
-    cst_fwrite(fd, &db->ME_num, sizeof(int), 1);
-    cst_fwrite(fd, &db->ME_order, sizeof(int), 1);
+    cst_fwrite(fd, &db->ME_num, sizeof(int32_t), 1);
+    cst_fwrite(fd, &db->ME_order, sizeof(int32_t), 1);
     cst_cg_write_2d_array(fd, (void *) db->me_h, db->ME_num, db->ME_order,
                           sizeof(double));
 
-    cst_fwrite(fd, &db->spamf0, sizeof(int), 1);
+    cst_fwrite(fd, &db->spamf0, sizeof(int32_t), 1);
     cst_fwrite(fd, &db->gain, sizeof(float), 1);
 
     cst_fclose(fd);

--- a/src/cg/cst_cg_dump_voice.c
+++ b/src/cg/cst_cg_dump_voice.c
@@ -80,8 +80,8 @@ static void cst_cg_write_db_types(cst_file fd, const cst_cg_db *db)
 /* Write the nodes of a cart tree */
 static void cst_cg_write_tree_nodes(cst_file fd, const cst_cart_node * nodes)
 {
-    int num_nodes, i;
-    int an_int;
+    int32_t num_nodes, i;
+    int32_t an_int;
     float a_float;
 
     num_nodes = 0;
@@ -93,7 +93,7 @@ static void cst_cg_write_tree_nodes(cst_file fd, const cst_cart_node * nodes)
     {
         cst_fwrite(fd, &nodes[i].feat, sizeof(char), 1);
         cst_fwrite(fd, &nodes[i].op, sizeof(char), 1);
-        cst_fwrite(fd, &nodes[i].no_node, sizeof(int16_t), 1);
+        cst_fwrite(fd, &nodes[i].no_node, sizeof(uint16_t), 1);
         cst_fwrite(fd, &nodes[i].val->c.a.type, sizeof(int16_t), 1);
         if (nodes[i].val->c.a.type == CST_VAL_TYPE_STRING)
         {

--- a/src/cg/cst_cg_map.c
+++ b/src/cg/cst_cg_map.c
@@ -37,6 +37,7 @@
 /*  A clustergen generic voice, that can load from a file                */
 /*                                                                       */
 /*************************************************************************/
+#include <stdlib.h>
 #include "cst_string.h"
 #include "cst_cg_map.h"
 
@@ -45,7 +46,8 @@ const char *const cg_voice_header_string = "CMU_FLITE_CG_VOXDATA-v2.0";
 int cst_cg_read_header(cst_file fd)
 {
     char header[200];
-    int n, endianness;
+    size_t n;
+    int32_t endianness;
 
     n = cst_fread(fd, header, sizeof(char),
                   cst_strlen(cg_voice_header_string) + 1);
@@ -56,7 +58,7 @@ int cst_cg_read_header(cst_file fd)
     if (!cst_streq(header, cg_voice_header_string))
         return -1;
 
-    cst_fread(fd, &endianness, sizeof(int), 1); /* for byte order check */
+    cst_fread(fd, &endianness, sizeof(int32_t), 1); /* for byte order check */
     if (endianness != cst_endian_loc)
         return -1;              /* dumped with other byte order */
 
@@ -223,8 +225,8 @@ cst_cart_node *cst_read_tree_nodes(cst_file fd)
     {
         cst_fread(fd, &nodes[i].feat, sizeof(char), 1);
         cst_fread(fd, &nodes[i].op, sizeof(char), 1);
-        cst_fread(fd, &nodes[i].no_node, sizeof(short), 1);
-        cst_fread(fd, &vtype, sizeof(short), 1);
+        cst_fread(fd, &nodes[i].no_node, sizeof(int16_t), 1);
+        cst_fread(fd, &vtype, sizeof(int16_t), 1);
         if (vtype == CST_VAL_TYPE_STRING)
         {
             str = cst_read_padded(fd, &temp);
@@ -368,12 +370,12 @@ void cst_read_voice_feature(cst_file fd, char **fname, char **fval)
     *fval = cst_read_padded(fd, &temp);
 }
 
-int cst_read_int(cst_file fd)
+int32_t cst_read_int(cst_file fd)
 {
-    int val;
-    int n;
+    int32_t val;
+    size_t n;
 
-    n = cst_fread(fd, &val, sizeof(int), 1);
+    n = cst_fread(fd, &val, sizeof(int32_t), 1);
     if (n != 1)
         return 0;
     return val;

--- a/src/cg/cst_cg_map.c
+++ b/src/cg/cst_cg_map.c
@@ -82,8 +82,8 @@ cst_cg_db *cst_cg_load_db(cst_voice *vox, cst_file fd)
     db->name = cst_read_string(fd);
     db->types = (const char **) cst_read_db_types(fd);
 
-    db->num_types = cst_read_int(fd);
-    db->sample_rate = cst_read_int(fd);
+    db->num_types = cst_read_int32(fd);
+    db->sample_rate = cst_read_int32(fd);
     db->f0_mean = cst_read_float(fd);
     db->f0_stddev = cst_read_float(fd);
 
@@ -95,7 +95,7 @@ cst_cg_db *cst_cg_load_db(cst_voice *vox, cst_file fd)
     for (i = 0; i < db->num_param_models; i++)
         db->param_trees[i] = (const cst_cart **) cst_read_tree_array(fd);
 
-    db->spamf0 = cst_read_int(fd);
+    db->spamf0 = cst_read_int32(fd);
     if (db->spamf0)
     {
         db->spamf0_accent_tree = cst_read_tree(fd);
@@ -108,8 +108,8 @@ cst_cg_db *cst_cg_load_db(cst_voice *vox, cst_file fd)
         cst_alloc(const unsigned short **, db->num_param_models);
     for (i = 0; i < db->num_param_models; i++)
     {
-        db->num_channels[i] = cst_read_int(fd);
-        db->num_frames[i] = cst_read_int(fd);
+        db->num_channels[i] = cst_read_int32(fd);
+        db->num_frames[i] = cst_read_int32(fd);
         db->model_vectors[i] =
             (const unsigned short **) cst_read_2d_array(fd);
     }
@@ -126,8 +126,8 @@ cst_cg_db *cst_cg_load_db(cst_voice *vox, cst_file fd)
 
     if (db->spamf0)
     {
-        db->num_channels_spamf0_accent = cst_read_int(fd);
-        db->num_frames_spamf0_accent = cst_read_int(fd);
+        db->num_channels_spamf0_accent = cst_read_int32(fd);
+        db->num_frames_spamf0_accent = cst_read_int32(fd);
         db->spamf0_accent_vectors =
             (const float *const *) cst_read_2d_array(fd);
     }
@@ -149,21 +149,21 @@ cst_cg_db *cst_cg_load_db(cst_voice *vox, cst_file fd)
 
     db->phone_states = (const char *const *const *) cst_read_phone_states(fd);
 
-    db->do_mlpg = cst_read_int(fd);
+    db->do_mlpg = cst_read_int32(fd);
     db->dynwin = cst_read_array(fd);
-    db->dynwinsize = cst_read_int(fd);
+    db->dynwinsize = cst_read_int32(fd);
 
     db->mlsa_alpha = cst_read_float(fd);
     db->mlsa_beta = cst_read_float(fd);
 
-    db->multimodel = cst_read_int(fd);
-    db->mixed_excitation = cst_read_int(fd);
+    db->multimodel = cst_read_int32(fd);
+    db->mixed_excitation = cst_read_int32(fd);
 
-    db->ME_num = cst_read_int(fd);
-    db->ME_order = cst_read_int(fd);
+    db->ME_num = cst_read_int32(fd);
+    db->ME_order = cst_read_int32(fd);
     db->me_h = (const double *const *) cst_read_2d_array(fd);
 
-    db->spamf0 = cst_read_int(fd);      /* yes, twice, its above too */
+    db->spamf0 = cst_read_int32(fd);      /* yes, twice, its above too */
     db->gain = cst_read_float(fd);
 
     return db;
@@ -181,7 +181,7 @@ void *cst_read_padded(cst_file fd, int *numbytes)
     void *ret;
     int n;
 
-    *numbytes = cst_read_int(fd);
+    *numbytes = cst_read_int32(fd);
     ret = (void *) cst_alloc(char, *numbytes);
     n = cst_fread(fd, ret, sizeof(char), *numbytes);
     if (n != (*numbytes))
@@ -198,7 +198,7 @@ char **cst_read_db_types(cst_file fd)
     int numtypes;
     int i;
 
-    numtypes = cst_read_int(fd);
+    numtypes = cst_read_int32(fd);
     types = cst_alloc(char *, numtypes + 1);
 
     for (i = 0; i < numtypes; i++)
@@ -218,7 +218,7 @@ cst_cart_node *cst_read_tree_nodes(cst_file fd)
     short vtype;
     char *str;
 
-    num_nodes = cst_read_int(fd);
+    num_nodes = cst_read_int32(fd);
     nodes = cst_alloc(cst_cart_node, num_nodes + 1);
 
     for (i = 0; i < num_nodes; i++)
@@ -234,11 +234,11 @@ cst_cart_node *cst_read_tree_nodes(cst_file fd)
             cst_free(str);
         }
         else if (vtype == CST_VAL_TYPE_INT)
-            nodes[i].val = int_val(cst_read_int(fd));
+            nodes[i].val = int_val(cst_read_int32(fd));
         else if (vtype == CST_VAL_TYPE_FLOAT)
             nodes[i].val = float_val(cst_read_float(fd));
         else
-            nodes[i].val = int_val(cst_read_int(fd));
+            nodes[i].val = int_val(cst_read_int32(fd));
     }
     nodes[i].val = NULL;
 
@@ -251,7 +251,7 @@ char **cst_read_tree_feats(cst_file fd)
     int numfeats;
     int i;
 
-    numfeats = cst_read_int(fd);
+    numfeats = cst_read_int32(fd);
     feats = cst_alloc(char *, numfeats + 1);
 
     for (i = 0; i < numfeats; i++)
@@ -278,7 +278,7 @@ cst_cart **cst_read_tree_array(cst_file fd)
     int numtrees;
     int i;
 
-    numtrees = cst_read_int(fd);
+    numtrees = cst_read_int32(fd);
 
     if (numtrees > 0)
     {
@@ -306,7 +306,7 @@ void **cst_read_2d_array(cst_file fd)
     int i;
     void **arrayrows = NULL;
 
-    numrows = cst_read_int(fd);
+    numrows = cst_read_int32(fd);
 
     if (numrows > 0)
     {
@@ -325,7 +325,7 @@ dur_stat **cst_read_dur_stats(cst_file fd)
     int i, temp;
     dur_stat **ds;
 
-    numstats = cst_read_int(fd);
+    numstats = cst_read_int32(fd);
     ds = cst_alloc(dur_stat *, (1 + numstats));
 
     /* load structuer values */
@@ -346,11 +346,11 @@ char ***cst_read_phone_states(cst_file fd)
     int i, j, count1, count2, temp;
     char ***ps;
 
-    count1 = cst_read_int(fd);
+    count1 = cst_read_int32(fd);
     ps = cst_alloc(char **, count1 + 1);
     for (i = 0; i < count1; i++)
     {
-        count2 = cst_read_int(fd);
+        count2 = cst_read_int32(fd);
         ps[i] = cst_alloc(char *, count2 + 1);
         for (j = 0; j < count2; j++)
         {
@@ -370,7 +370,7 @@ void cst_read_voice_feature(cst_file fd, char **fname, char **fval)
     *fval = cst_read_padded(fd, &temp);
 }
 
-int32_t cst_read_int(cst_file fd)
+int32_t cst_read_int32(cst_file fd)
 {
     int32_t val;
     size_t n;

--- a/src/cg/cst_cg_map.h
+++ b/src/cg/cst_cg_map.h
@@ -68,7 +68,7 @@ dur_stat **cst_read_dur_stats(cst_file fd);
 char ***cst_read_phone_states(cst_file fd);
 
 void cst_read_voice_feature(cst_file fd, char **fname, char **fval);
-int cst_read_int(cst_file fd);
+int cst_read_int32(cst_file fd);
 float cst_read_float(cst_file fd);
 
 extern const char *const cg_voice_header_string;

--- a/src/lexicon/cst_lts.c
+++ b/src/lexicon/cst_lts.c
@@ -212,7 +212,7 @@ static cst_lts_phone apply_model(cst_lts_letter * vals, cst_lts_addr start,
             nstate = state.qfalse;
         /* This should really happen at compilation time */
         if (CST_BIG_ENDIAN)
-            nstate = SWAPSHORT(nstate);
+            nstate = SWAPINT16(nstate);
 
         cst_lts_get_state(&state, model, nstate, sizeof_cst_lts_rule);
     }

--- a/src/speech/cst_wave_io.c
+++ b/src/speech/cst_wave_io.c
@@ -152,8 +152,9 @@ int cst_wave_append_riff(cst_wave *w, const char *filename)
     cst_file fd;
     cst_wave_header hdr;
     char info[4];
-    int d_int;
-    int rv, num_bytes, n, sample_rate;
+    int32_t d_int;
+    int32_t num_bytes, n, sample_rate;
+    int rv;
 
     if ((fd =
          cst_fopen(filename,
@@ -173,20 +174,20 @@ int cst_wave_append_riff(cst_wave *w, const char *filename)
     cst_fread(fd, info, 1, 4);
     cst_fread(fd, &d_int, 4, 1);
     if (CST_BIG_ENDIAN)
-        d_int = SWAPINT(d_int);
-    hdr.num_samples = d_int / sizeof(short);
+        d_int = SWAPINT32(d_int);
+    hdr.num_samples = d_int / sizeof(int16_t);
 
     cst_fseek(fd,
               cst_ftell(fd) + (hdr.hsize - 16) +
-              (hdr.num_samples * hdr.num_channels * sizeof(short)),
+              (hdr.num_samples * hdr.num_channels * sizeof(int16_t)),
               CST_SEEK_ABSOLUTE);
 
     if (CST_BIG_ENDIAN)
     {
-        short *xdata = cst_alloc(short, cst_wave_num_channels(w) *
+        int16_t *xdata = cst_alloc(int16_t, cst_wave_num_channels(w) *
                                  cst_wave_num_samples(w));
         memmove(xdata, cst_wave_samples(w),
-                sizeof(short) * cst_wave_num_channels(w) *
+                sizeof(int16_t) * cst_wave_num_channels(w) *
                 cst_wave_num_samples(w));
         swap_bytes_short(xdata,
                          cst_wave_num_channels(w) * cst_wave_num_samples(w));
@@ -203,20 +204,20 @@ int cst_wave_append_riff(cst_wave *w, const char *filename)
     cst_fseek(fd, 4, CST_SEEK_ABSOLUTE);
     num_bytes = hdr.num_bytes + (n * sizeof(int16_t));
     if (CST_BIG_ENDIAN)
-        num_bytes = SWAPINT(num_bytes);
+        num_bytes = SWAPINT32(num_bytes);
     cst_fwrite(fd, &num_bytes, 4, 1);   /* num bytes in whole file */
     cst_fseek(fd, 4 + 4 + 4 + 4 + 4 + 2 + 2, CST_SEEK_ABSOLUTE);
     sample_rate = w->sample_rate;
     if (CST_BIG_ENDIAN)
-        sample_rate = SWAPINT(sample_rate);
+        sample_rate = SWAPINT32(sample_rate);
     cst_fwrite(fd, &sample_rate, 4, 1); /* sample rate */
     cst_fseek(fd, 4 + 4 + 4 + 4 + 4 + 2 + 2 + 4 + 4 + 2 + 2 + 4,
               CST_SEEK_ABSOLUTE);
     num_bytes =
-        (sizeof(short) * cst_wave_num_channels(w) * cst_wave_num_samples(w)) +
-        (sizeof(short) * hdr.num_channels * hdr.num_samples);
+        (sizeof(int16_t) * cst_wave_num_channels(w) * cst_wave_num_samples(w)) +
+        (sizeof(int16_t) * hdr.num_channels * hdr.num_samples);
     if (CST_BIG_ENDIAN)
-        num_bytes = SWAPINT(num_bytes);
+        num_bytes = SWAPINT32(num_bytes);
     cst_fwrite(fd, &num_bytes, 4, 1);   /* num bytes in data */
     cst_fclose(fd);
 
@@ -243,16 +244,16 @@ int cst_wave_save_riff(cst_wave *w, const char *filename)
 int cst_wave_save_riff_fd(cst_wave *w, cst_file fd)
 {
     const char *info;
-    short d_short;
-    int d_int, n;
-    int num_bytes;
+    int16_t d_short;
+    int32_t d_int, n;
+    int32_t num_bytes;
 
     info = "RIFF";
     cst_fwrite(fd, info, 4, 1);
     num_bytes = (cst_wave_num_samples(w)
-                 * cst_wave_num_channels(w) * sizeof(short)) + 8 + 16 + 12;
+                 * cst_wave_num_channels(w) * sizeof(int16_t)) + 8 + 16 + 12;
     if (CST_BIG_ENDIAN)
-        num_bytes = SWAPINT(num_bytes);
+        num_bytes = SWAPINT32(num_bytes);
     cst_fwrite(fd, &num_bytes, 4, 1);   /* num bytes in whole file */
     info = "WAVE";
     cst_fwrite(fd, info, 1, 4);
@@ -260,37 +261,37 @@ int cst_wave_save_riff_fd(cst_wave *w, cst_file fd)
     cst_fwrite(fd, info, 1, 4);
     num_bytes = 16;             /* size of header */
     if (CST_BIG_ENDIAN)
-        num_bytes = SWAPINT(num_bytes);
+        num_bytes = SWAPINT32(num_bytes);
     cst_fwrite(fd, &num_bytes, 4, 1);
     d_short = RIFF_FORMAT_PCM;  /* sample type */
     if (CST_BIG_ENDIAN)
-        d_short = SWAPSHORT(d_short);
+        d_short = SWAPINT16(d_short);
     cst_fwrite(fd, &d_short, 2, 1);
     d_short = cst_wave_num_channels(w); /* number of channels */
     if (CST_BIG_ENDIAN)
-        d_short = SWAPSHORT(d_short);
+        d_short = SWAPINT16(d_short);
     cst_fwrite(fd, &d_short, 2, 1);
     d_int = cst_wave_sample_rate(w);    /* sample rate */
     if (CST_BIG_ENDIAN)
-        d_int = SWAPINT(d_int);
+        d_int = SWAPINT32(d_int);
     cst_fwrite(fd, &d_int, 4, 1);
-    d_int = (cst_wave_sample_rate(w) * cst_wave_num_channels(w) * sizeof(short));       /* average bytes per second */
+    d_int = (cst_wave_sample_rate(w) * cst_wave_num_channels(w) * sizeof(int16_t));       /* average bytes per second */
     if (CST_BIG_ENDIAN)
-        d_int = SWAPINT(d_int);
+        d_int = SWAPINT32(d_int);
     cst_fwrite(fd, &d_int, 4, 1);
-    d_short = (cst_wave_num_channels(w) * sizeof(short));       /* block align */
+    d_short = (cst_wave_num_channels(w) * sizeof(int16_t));       /* block align */
     if (CST_BIG_ENDIAN)
-        d_short = SWAPSHORT(d_short);
+        d_short = SWAPINT16(d_short);
     cst_fwrite(fd, &d_short, 2, 1);
     d_short = 2 * 8;            /* bits per sample */
     if (CST_BIG_ENDIAN)
-        d_short = SWAPSHORT(d_short);
+        d_short = SWAPINT16(d_short);
     cst_fwrite(fd, &d_short, 2, 1);
     info = "data";
     cst_fwrite(fd, info, 1, 4);
-    d_int = (cst_wave_num_channels(w) * cst_wave_num_samples(w) * sizeof(short));       /* bytes in data */
+    d_int = (cst_wave_num_channels(w) * cst_wave_num_samples(w) * sizeof(int16_t));       /* bytes in data */
     if (CST_BIG_ENDIAN)
-        d_int = SWAPINT(d_int);
+        d_int = SWAPINT32(d_int);
     cst_fwrite(fd, &d_int, 4, 1);
 
     if (CST_BIG_ENDIAN)
@@ -379,8 +380,8 @@ int cst_wave_load_riff(cst_wave *w, const char *filename)
 int cst_wave_load_riff_header(cst_wave_header *header, cst_file fd)
 {
     char info[4];
-    short d_short;
-    int d_int;
+    int16_t d_short;
+    int32_t d_int;
 
     if (cst_fread(fd, info, 1, 4) != 4)
         return CST_WRONG_FORMAT;
@@ -389,7 +390,7 @@ int cst_wave_load_riff_header(cst_wave_header *header, cst_file fd)
 
     cst_fread(fd, &d_int, 4, 1);
     if (CST_BIG_ENDIAN)
-        d_int = SWAPINT(d_int);
+        d_int = SWAPINT32(d_int);
     header->num_bytes = d_int;
 
     if ((cst_fread(fd, info, 1, 4) != 4) || (strncmp(info, "WAVE", 4) != 0))
@@ -400,11 +401,11 @@ int cst_wave_load_riff_header(cst_wave_header *header, cst_file fd)
 
     cst_fread(fd, &d_int, 4, 1);
     if (CST_BIG_ENDIAN)
-        d_int = SWAPINT(d_int);
+        d_int = SWAPINT32(d_int);
     header->hsize = d_int;
     cst_fread(fd, &d_short, 2, 1);
     if (CST_BIG_ENDIAN)
-        d_short = SWAPSHORT(d_short);
+        d_short = SWAPINT16(d_short);
 
     if (d_short != RIFF_FORMAT_PCM)
     {
@@ -413,13 +414,13 @@ int cst_wave_load_riff_header(cst_wave_header *header, cst_file fd)
     }
     cst_fread(fd, &d_short, 2, 1);
     if (CST_BIG_ENDIAN)
-        d_short = SWAPSHORT(d_short);
+        d_short = SWAPINT16(d_short);
 
     header->num_channels = d_short;
 
     cst_fread(fd, &d_int, 4, 1);
     if (CST_BIG_ENDIAN)
-        d_int = SWAPINT(d_int);
+        d_int = SWAPINT32(d_int);
     header->sample_rate = d_int;
     cst_fread(fd, &d_int, 4, 1);        /* avg bytes per second */
     cst_fread(fd, &d_short, 2, 1);      /* block align */
@@ -433,9 +434,9 @@ int cst_wave_load_riff_fd(cst_wave *w, cst_file fd)
     cst_wave_header hdr;
     int rv;
     char info[4];
-    int d_int, d;
-    int data_length;
-    int samples;
+    int32_t d_int, d;
+    int32_t data_length;
+    int32_t samples;
 
     rv = cst_wave_load_riff_header(&hdr, fd);
     if (rv != CST_OK_FORMAT)
@@ -452,22 +453,22 @@ int cst_wave_load_riff_fd(cst_wave *w, cst_file fd)
         {
             cst_fread(fd, &d_int, 4, 1);
             if (CST_BIG_ENDIAN)
-                d_int = SWAPINT(d_int);
-            samples = d_int / sizeof(short);
+                d_int = SWAPINT32(d_int);
+            samples = d_int / sizeof(int16_t);
             break;
         }
         else if (strncmp(info, "fact", 4) == 0)
         {
             cst_fread(fd, &d_int, 4, 1);
             if (CST_BIG_ENDIAN)
-                d_int = SWAPINT(d_int);
+                d_int = SWAPINT32(d_int);
             cst_fseek(fd, cst_ftell(fd) + d_int, CST_SEEK_ABSOLUTE);
         }
         else if (strncmp(info, "clm ", 4) == 0)
         {                       /* another random chunk type -- resample puts this one in */
             cst_fread(fd, &d_int, 4, 1);
             if (CST_BIG_ENDIAN)
-                d_int = SWAPINT(d_int);
+                d_int = SWAPINT32(d_int);
             cst_fseek(fd, cst_ftell(fd) + d_int, CST_SEEK_ABSOLUTE);
         }
         else

--- a/src/speech/cst_wave_io.c
+++ b/src/speech/cst_wave_io.c
@@ -138,7 +138,7 @@ int cst_wave_save_raw(cst_wave *w, const char *filename)
 int cst_wave_save_raw_fd(cst_wave *w, cst_file fd)
 {
     if (cst_fwrite(fd, cst_wave_samples(w),
-                   sizeof(short),
+                   sizeof(int16_t),
                    cst_wave_num_samples(w)) == cst_wave_num_samples(w))
         return 0;
     else
@@ -190,18 +190,18 @@ int cst_wave_append_riff(cst_wave *w, const char *filename)
                 cst_wave_num_samples(w));
         swap_bytes_short(xdata,
                          cst_wave_num_channels(w) * cst_wave_num_samples(w));
-        n = cst_fwrite(fd, xdata, sizeof(short),
+        n = cst_fwrite(fd, xdata, sizeof(int16_t),
                        cst_wave_num_channels(w) * cst_wave_num_samples(w));
         cst_free(xdata);
     }
     else
     {
-        n = cst_fwrite(fd, cst_wave_samples(w), sizeof(short),
+        n = cst_fwrite(fd, cst_wave_samples(w), sizeof(int16_t),
                        cst_wave_num_channels(w) * cst_wave_num_samples(w));
     }
 
     cst_fseek(fd, 4, CST_SEEK_ABSOLUTE);
-    num_bytes = hdr.num_bytes + (n * sizeof(short));
+    num_bytes = hdr.num_bytes + (n * sizeof(int16_t));
     if (CST_BIG_ENDIAN)
         num_bytes = SWAPINT(num_bytes);
     cst_fwrite(fd, &num_bytes, 4, 1);   /* num bytes in whole file */
@@ -302,13 +302,13 @@ int cst_wave_save_riff_fd(cst_wave *w, cst_file fd)
                 cst_wave_num_samples(w));
         swap_bytes_short(xdata,
                          cst_wave_num_channels(w) * cst_wave_num_samples(w));
-        n = cst_fwrite(fd, xdata, sizeof(short),
+        n = cst_fwrite(fd, xdata, sizeof(int16_t),
                        cst_wave_num_channels(w) * cst_wave_num_samples(w));
         cst_free(xdata);
     }
     else
     {
-        n = cst_fwrite(fd, cst_wave_samples(w), sizeof(short),
+        n = cst_fwrite(fd, cst_wave_samples(w), sizeof(int16_t),
                        cst_wave_num_channels(w) * cst_wave_num_samples(w));
     }
 
@@ -344,9 +344,9 @@ int cst_wave_load_raw_fd(cst_wave *w, cst_file fd,
     long size;
 
     /* Won't work on pipes, tough luck... */
-    size = cst_filesize(fd) / sizeof(short);
+    size = cst_filesize(fd) / sizeof(int16_t);
     cst_wave_resize(w, size, 1);
-    if (cst_fread(fd, w->samples, sizeof(short), size) != size)
+    if (cst_fread(fd, w->samples, sizeof(int16_t), size) != size)
         return -1;
 
     w->sample_rate = sample_rate;
@@ -484,7 +484,7 @@ int cst_wave_load_riff_fd(cst_wave *w, cst_file fd)
     cst_wave_resize(w, samples / hdr.num_channels, hdr.num_channels);
 
     if ((d =
-         cst_fread(fd, w->samples, sizeof(short),
+         cst_fread(fd, w->samples, sizeof(int16_t),
                    data_length)) != data_length)
     {
         cst_errmsg

--- a/src/utils/cst_endian.c
+++ b/src/utils/cst_endian.c
@@ -49,7 +49,7 @@ void swap_bytes_short(int16_t *b, size_t n)
     size_t i;
 
     for (i = 0; i < n; i++)
-        b[i] = SWAPSHORT(b[i]);
+        b[i] = SWAPINT16(b[i]);
 }
 
 void swapdouble(double *dbl)
@@ -57,8 +57,8 @@ void swapdouble(double *dbl)
     /* cast to int, as access as flt may cause FPE on some machines */
     int32_t t;
     int32_t *dd = (int32_t *) dbl;
-    t = SWAPINT(dd[0]);
-    dd[0] = SWAPINT(dd[1]);
+    t = SWAPINT32(dd[0]);
+    dd[0] = SWAPINT32(dd[1]);
     dd[1] = t;
 }
 
@@ -66,5 +66,5 @@ void swapfloat(float *flt)
 {
     /* cast to int, as access as flt may cause FPE on some machines */
     int32_t *ff = (int32_t *) flt;
-    ff[0] = SWAPINT(ff[0]);
+    ff[0] = SWAPINT32(ff[0]);
 }

--- a/src/utils/cst_endian.c
+++ b/src/utils/cst_endian.c
@@ -38,14 +38,15 @@
 /*                                                                       */
 /*************************************************************************/
 #include <stdlib.h>
+#include <stdint.h>
 #include "cst_alloc.h"
 #include "cst_endian.h"
 
-const int cst_endian_loc = 1;
+const int32_t cst_endian_loc = 1;
 
-void swap_bytes_short(short *b, int n)
+void swap_bytes_short(int16_t *b, size_t n)
 {
-    int i;
+    size_t i;
 
     for (i = 0; i < n; i++)
         b[i] = SWAPSHORT(b[i]);
@@ -54,8 +55,8 @@ void swap_bytes_short(short *b, int n)
 void swapdouble(double *dbl)
 {
     /* cast to int, as access as flt may cause FPE on some machines */
-    int t;
-    int *dd = (int *) dbl;
+    int32_t t;
+    int32_t *dd = (int32_t *) dbl;
     t = SWAPINT(dd[0]);
     dd[0] = SWAPINT(dd[1]);
     dd[1] = t;
@@ -64,6 +65,6 @@ void swapdouble(double *dbl)
 void swapfloat(float *flt)
 {
     /* cast to int, as access as flt may cause FPE on some machines */
-    int *ff = (int *) flt;
+    int32_t *ff = (int32_t *) flt;
     ff[0] = SWAPINT(ff[0]);
 }

--- a/testsuite/bin2ascii_main.c
+++ b/testsuite/bin2ascii_main.c
@@ -37,6 +37,7 @@
 /*  Convert binary to ascii files (for tracks)                           */
 /*************************************************************************/
 #include <stdio.h>
+#include <stdint.h>
 #include "cst_wave.h"
 #include "cst_tokenstream.h"
 #include "cst_args.h"
@@ -50,7 +51,7 @@ int main(int argc, char **argv)
     const char *datatype;
     FILE *fd;
     int channels;
-    int d_int;
+    int32_t d_int;
     float d_flt;
     double d_dbl;
     int swap = FALSE;
@@ -83,7 +84,7 @@ int main(int argc, char **argv)
                     if (n != 1)
                         break;
                     if (swap)
-                        d_int = SWAPINT(d_int);
+                        d_int = SWAPINT32(d_int);
                     printf("%d ", d_int);
                 }
                 else if (cst_streq(datatype, "float"))


### PR DESCRIPTION
This PR starts addressing #32 by replacing variable length types such as int by their fixed size equivalents. mimic (flite) was mainly written with x86 size conventions in mind.

More work is still needed.
