### PR TITLE
Unit tests for wave functions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,7 +78,7 @@ unittests/lex_test
 unittests/nums_test
 unittests/voice_select_test
 unittests/lts_test
-
+unittests/wave_test
 # temporary files for building cmulex
 _festsuite
 lang/cmulex/festival

--- a/include/cst_wave.h
+++ b/include/cst_wave.h
@@ -66,7 +66,7 @@ typedef struct cst_wave_header_struct {
 cst_wave *new_wave();
 cst_wave *copy_wave(const cst_wave *w);
 void delete_wave(cst_wave *val);
-cst_wave *concat_wave(cst_wave *dest, const cst_wave *src);
+int concat_wave(cst_wave *dest, const cst_wave *src);
 
 #define cst_wave_num_samples(w) (w?w->num_samples:0)
 #define cst_wave_num_channels(w) (w?w->num_channels:0)
@@ -95,7 +95,7 @@ int cst_wave_load_riff_fd(cst_wave *w, cst_file fd);
 int cst_wave_load_raw_fd(cst_wave *w, cst_file fd,
                          const char *bo, int sample_rate);
 
-void cst_wave_resize(cst_wave *w, int samples, int num_channels);
+int cst_wave_resize(cst_wave *w, int samples, int num_channels);
 void cst_wave_resample(cst_wave *w, int sample_rate);
 void cst_wave_rescale(cst_wave *w, int factor);
 

--- a/src/cg/cst_mlsa.c
+++ b/src/cg/cst_mlsa.c
@@ -131,7 +131,11 @@ static cst_wave *synthesis_body(const cst_track *params,        /* f0 + mcep */
 
     /* synthesize waveforms by MLSA filter */
     wave = new_wave();
-    cst_wave_resize(wave, params->num_frames * framel, 1);
+    if (cst_wave_resize(wave, params->num_frames * framel, 1) < 0)
+    {
+        delete_wave(wave);
+        return NULL;
+    }
     wave->sample_rate = fs;
 
     mcep = cst_alloc(double, num_mcep + 1);

--- a/src/synth/cst_ssml.c
+++ b/src/synth/cst_ssml.c
@@ -338,9 +338,11 @@ static float mimic_ssml_to_speech_ts(cst_tokenstream *ts,
         !cst_streq(outtype, "none") && !cst_streq(outtype, "stream"))
     {
         w = new_wave();
-        cst_wave_resize(w, 0, 1);
-        cst_wave_set_sample_rate(w, 16000);
-        cst_wave_save_riff(w, outtype); /* an empty wave */
+        if (cst_wave_resize(w, 0, 1) == 0)
+        {
+            cst_wave_set_sample_rate(w, 16000);
+            cst_wave_save_riff(w, outtype); /* an empty wave */
+        }
         delete_wave(w);
     }
 
@@ -432,6 +434,8 @@ static float mimic_ssml_to_speech_ts(cst_tokenstream *ts,
             if (utt)
                 delete_utterance(utt);
             utt = utt_synth_wave(copy_wave(wave), current_voice);
+            if (utt == NULL)
+               goto cleanup;
             if (utt_user_callback)
                 utt = (utt_user_callback) (utt);
             mimic_process_output(utt, outtype, TRUE, &new_durs);
@@ -505,9 +509,11 @@ float mimic_ssml_file_to_speech(const char *filename,
         !cst_streq(outtype, "none") && !cst_streq(outtype, "stream"))
     {
         w = new_wave();
-        cst_wave_resize(w, 0, 1);
-        cst_wave_set_sample_rate(w, 16000);
-        cst_wave_save_riff(w, outtype); /* an empty wave */
+        if (cst_wave_resize(w, 0, 1) == 0)
+        {
+            cst_wave_set_sample_rate(w, 16000);
+            cst_wave_save_riff(w, outtype); /* an empty wave */
+        }
         delete_wave(w);
     }
 
@@ -550,9 +556,11 @@ float mimic_ssml_text_to_speech(const char *text,
         !cst_streq(outtype, "none") && !cst_streq(outtype, "stream"))
     {
         w = new_wave();
-        cst_wave_resize(w, 0, 1);
-        cst_wave_set_sample_rate(w, 16000);
-        cst_wave_save_riff(w, outtype); /* an empty wave */
+        if (cst_wave_resize(w, 0, 1) == 0)
+        {
+            cst_wave_set_sample_rate(w, 16000);
+            cst_wave_save_riff(w, outtype); /* an empty wave */
+        }
         delete_wave(w);
     }
 

--- a/src/synth/cst_synth.c
+++ b/src/synth/cst_synth.c
@@ -118,6 +118,9 @@ cst_utterance *utt_synth_wave(cst_wave *w, cst_voice *v)
     cst_utterance *u;
     const cst_val *streaming_info_val;
     cst_audio_streaming_info *asi = NULL;
+    
+    if (w == NULL)
+       return NULL;
 
     u = new_utterance();
     utt_init(u, v);

--- a/src/synth/mimic.c
+++ b/src/synth/mimic.c
@@ -285,9 +285,11 @@ float mimic_ts_to_speech(cst_tokenstream *ts,
         !cst_streq(outtype, "none") && !cst_streq(outtype, "stream"))
     {
         w = new_wave();
-        cst_wave_resize(w, 0, 1);
-        cst_wave_set_sample_rate(w, 16000);
-        cst_wave_save_riff(w, outtype); /* an empty wave */
+        if (cst_wave_resize(w, 0, 1) == 0)
+        {
+            cst_wave_set_sample_rate(w, 16000);
+            cst_wave_save_riff(w, outtype); /* an empty wave */
+        }
         delete_wave(w);
     }
 

--- a/src/wavesynth/cst_sigpr.c
+++ b/src/wavesynth/cst_sigpr.c
@@ -54,7 +54,11 @@ cst_wave *lpc_resynth(cst_lpcres *lpcres)
 
     /* Get a new wave to build the signal into */
     w = new_wave();
-    cst_wave_resize(w, lpcres->num_samples, 1);
+    if (cst_wave_resize(w, lpcres->num_samples, 1) < 0)
+    {
+        delete_wave(w);
+        return NULL;
+    }
     w->sample_rate = lpcres->sample_rate;
     /* outbuf is a circular buffer with past relevant samples in it */
     outbuf = cst_alloc(float, 1 + lpcres->num_channels);
@@ -108,7 +112,11 @@ cst_wave *lpc_resynth_windows(cst_lpcres *lpcres)
 
     /* Get a new wave to build the signal into */
     w = new_wave();
-    cst_wave_resize(w, lpcres->num_samples, 1);
+    if (cst_wave_resize(w, lpcres->num_samples, 1) < 0)
+    {
+        delete_wave(w);
+        return NULL;
+    }
     w->sample_rate = lpcres->sample_rate;
     /* outbuf is a circular buffer with past relevant samples in it */
     outbuf = cst_alloc(float, 1 + lpcres->num_channels);
@@ -198,7 +206,11 @@ cst_wave *lpc_resynth_fixedpoint(cst_lpcres *lpcres)
 
     /* Get a new wave to build the signal into */
     w = new_wave();
-    cst_wave_resize(w, lpcres->num_samples, 1);
+    if (cst_wave_resize(w, lpcres->num_samples, 1) < 0)
+    {
+        delete_wave(w);
+        return NULL;
+    }
     w->sample_rate = lpcres->sample_rate;
     /* outbuf is a circular buffer with past relevant samples in it */
     outbuf = cst_alloc(int, 1 + lpcres->num_channels);
@@ -280,7 +292,11 @@ cst_wave *lpc_resynth_sfp(cst_lpcres *lpcres)
 
     /* Get a new wave to build the signal into */
     w = new_wave();
-    cst_wave_resize(w, lpcres->num_samples, 1);
+    if (cst_wave_resize(w, lpcres->num_samples, 1) < 0)
+    {
+        delete_wave(w);
+        return NULL;
+    }
     w->sample_rate = lpcres->sample_rate;
     /* outbuf is a circular buffer with past relevant samples in it */
     outbuf = cst_alloc(int, 1 + lpcres->num_channels);

--- a/unittests/Makefile
+++ b/unittests/Makefile
@@ -72,7 +72,7 @@ run_unit_tests: $(MAIN_EXECS)
 	export LD_LIBRARY_PATH="$(LIBDIR)"; \
 	err=0; \
 	for exec in $(MAIN_EXECS); do \
-        ./$$exec || err=1; \
+        ./$$exec 2> /dev/null || err=1; \
         done; \
 	[ "x$$err" = "x0" ] || (echo "Some unit tests failed"; exit 1)
 

--- a/unittests/Makefile
+++ b/unittests/Makefile
@@ -41,7 +41,8 @@ ALL_DIRS=
 DATAFILES=data.one
 SRCS = token_test_main.c hrg_test_main.c \
        regex_test_main.c nums_test_main.c \
-       lex_test_main.c lts_test_main.c
+       lex_test_main.c lts_test_main.c \
+       voice_select_test_main.c wave_test_main.c
        
 
 OTHERS = 
@@ -62,22 +63,15 @@ wave_test_LIBS = $(TOP)/main/mimic_lang_list.o $(TOP)/main/mimic_voice_list.o -l
 #kal_test_LIBS = -lmimic_cmu_us_kal -lmimic_usenglish -lmimic_cmulex \
 #	          /home/awb/src/malloc/gmalloc.o
 
-ALL = $(MAIN_EXECS) voice_select_test wave_test
+ALL = $(MAIN_EXECS)
 LOCAL_CLEAN = $(MAIN_EXECS)
 
 include $(TOP)/config/common_make_rules
-
-wave_test: wave_test_main.c $(MIMIC_LIBS)
-	$(CC) $(CFLAGS) $(INCLUDES) -o $@ $< $($(@:=_LIBS)) $(MIMICLIBFLAGS) $(LDFLAGS) 
-
-voice_select_test: voice_select_test_main.c $(MIMIC_LIBS)
-	$(CC) $(CFLAGS) $(INCLUDES) -o $@ $< $($(@:=_LIBS)) $(MIMICLIBFLAGS) $(LDFLAGS) 
 
 run_unit_tests: $(MAIN_EXECS)
 	export LD_LIBRARY_PATH="$(LIBDIR)"; \
 	err=0; \
 	for exec in $(MAIN_EXECS); do \
-	echo $(exec) \
         ./$$exec || err=1; \
         done; \
 	[ "x$$err" = "x0" ] || (echo "Some unit tests failed"; exit 1)

--- a/unittests/Makefile
+++ b/unittests/Makefile
@@ -58,14 +58,17 @@ lex_lookup_LIBS = -lmimic_cmulex
 ldom_time_LIBS = -L/home/awb/data/ldom/time_mimic/mimic/lib -lcmu_time_awb -lmimic_usenglish -lmimic_cmulex
 by_word_LIBS = -lmimic_cmu_us_kal -lmimic_usenglish -lmimic_cmulex
 voice_select_test_LIBS = $(TOP)/main/mimic_lang_list.o $(TOP)/main/mimic_voice_list.o -lmimic_cmu_us_kal -lmimic_cmu_time_awb -lmimic_cmu_us_kal16 -lmimic_cmu_us_awb -lmimic_cmu_us_rms -lmimic_cmu_us_slt -lmimic_vid_gb_ap -lmimic_usenglish -lmimic_cmu_indic_lang -lmimic_cmu_grapheme_lang -lmimic_cmulex -lmimic_cmu_indic_lex -lmimic_cmu_grapheme_lex -lmimic  -lm 
+wave_test_LIBS = $(TOP)/main/mimic_lang_list.o $(TOP)/main/mimic_voice_list.o -lmimic_cmu_us_kal -lmimic_cmu_time_awb -lmimic_cmu_us_kal16 -lmimic_cmu_us_awb -lmimic_cmu_us_rms -lmimic_cmu_us_slt -lmimic_vid_gb_ap -lmimic_usenglish -lmimic_cmu_indic_lang -lmimic_cmu_grapheme_lang -lmimic_cmulex -lmimic_cmu_indic_lex -lmimic_cmu_grapheme_lex -lmimic  -lm 
 #kal_test_LIBS = -lmimic_cmu_us_kal -lmimic_usenglish -lmimic_cmulex \
 #	          /home/awb/src/malloc/gmalloc.o
 
-ALL = $(MAIN_EXECS) voice_select_test
+ALL = $(MAIN_EXECS) voice_select_test wave_test
 LOCAL_CLEAN = $(MAIN_EXECS)
 
 include $(TOP)/config/common_make_rules
 
+wave_test: wave_test_main.c $(MIMIC_LIBS)
+	$(CC) $(CFLAGS) $(INCLUDES) -o $@ $< $($(@:=_LIBS)) $(MIMICLIBFLAGS) $(LDFLAGS) 
 
 voice_select_test: voice_select_test_main.c $(MIMIC_LIBS)
 	$(CC) $(CFLAGS) $(INCLUDES) -o $@ $< $($(@:=_LIBS)) $(MIMICLIBFLAGS) $(LDFLAGS) 
@@ -74,6 +77,7 @@ run_unit_tests: $(MAIN_EXECS)
 	export LD_LIBRARY_PATH="$(LIBDIR)"; \
 	err=0; \
 	for exec in $(MAIN_EXECS); do \
+	echo $(exec) \
         ./$$exec || err=1; \
         done; \
 	[ "x$$err" = "x0" ] || (echo "Some unit tests failed"; exit 1)

--- a/unittests/wave_test_main.c
+++ b/unittests/wave_test_main.c
@@ -1,0 +1,123 @@
+#include "cutest.h"
+#include <stdio.h>
+#include <string.h>
+#include <stdbool.h>
+#include <cst_wave.h>
+#include <mimic.h>
+
+cst_val *mimic_set_voice_list(const char *voxdir);
+
+void *mimic_set_lang_list(void);
+
+void common_init(void)
+{
+    mimic_init();
+    mimic_set_lang_list();
+
+    if (mimic_voice_list == NULL)
+        mimic_set_voice_list("../voices");
+}
+
+
+void test_copy(void)
+{
+   cst_voice *v = NULL;
+   cst_wave *w1, *w2;
+   common_init();
+   v = mimic_voice_select("rms");
+   w1 = mimic_text_to_wave("Hello", v);
+   w2 = copy_wave(w1);
+   TEST_CHECK(w1 != w2);
+   TEST_CHECK(w1->num_samples == w2->num_samples);
+   TEST_CHECK(w1->sample_rate == w2->sample_rate);
+   TEST_CHECK(w1->num_channels == w2->num_channels);
+   TEST_CHECK(w1->samples != w2->samples);
+   TEST_CHECK(w1->samples[0] == w2->samples[0]);
+   TEST_CHECK(w1->samples[10] == w2->samples[10]);
+   TEST_CHECK(w1->samples[20] == w2->samples[20]);
+   delete_wave(w1);
+   delete_wave(w2);
+}
+
+void test_concat(void)
+{
+   unsigned int original_len;
+   cst_wave *w1, *w2;
+   cst_voice *v;
+   common_init();
+   v = mimic_voice_select("rms");
+   w1 = mimic_text_to_wave("Hello", v);
+   w2 = mimic_text_to_wave("There", v);
+   original_len = w1->num_samples;
+   concat_wave(w1, w2);
+   TEST_CHECK(w1->num_samples == w2->num_samples + original_len);
+   delete_wave(w1);
+   delete_wave(w2);
+
+   w1 = mimic_text_to_wave("Hello", v);
+   w2 = mimic_text_to_wave("There", v);
+   
+   w2->sample_rate *= 2; // create sample rate mismatch
+   concat_wave(w1, w2);
+   TEST_CHECK(w1->num_samples != w2->num_samples + original_len);
+   delete_wave(w1);
+   delete_wave(w2);
+
+   w1 = mimic_text_to_wave("Hello", v);
+   w2 = mimic_text_to_wave("There", v);
+   
+   w2->num_channels *= 2; // create channel number mismatch
+   concat_wave(w1, w2);
+   TEST_CHECK(w1->num_samples != w2->num_samples + original_len);
+   delete_wave(w1);
+   delete_wave(w2);
+}
+
+void test_create(void)
+{
+   cst_wave *w = NULL;
+   w = new_wave();
+   TEST_CHECK(w != NULL);
+   TEST_CHECK(w->num_samples == 0);
+   TEST_CHECK(w->type == NULL);
+   delete_wave(w);
+}
+
+void test_delete(void)
+{
+   delete_wave(NULL);
+}
+
+void test_resize(void)
+{
+   cst_wave *w = new_wave();
+   cst_wave_resize(w, 200, 2);
+   TEST_CHECK(w->num_samples == 200);
+   TEST_CHECK(w->num_channels = 2);
+   TEST_CHECK(cst_wave_resize(NULL, 200, 2) < 0);
+   delete_wave(w);
+}
+
+void test_rescale(void)
+{
+   int i;
+   cst_wave *w = new_wave();
+   cst_wave_resize(w, 10, 2);
+   for (i = 0; i < 10; i++)
+      w->samples[i] = 10 + i;
+   cst_wave_rescale(w, 65536 * 2); //scale x2
+   for (i = 0; i < 10; i++)
+      TEST_CHECK(w->samples[i] == (10 + i) * 2);
+   delete_wave(w);
+}
+
+TEST_LIST =
+{
+    {"create wave", test_create},
+    {"delete wave", test_delete},
+    {"resize wave", test_resize},
+    {"rescale wave", test_rescale},
+    {"copy wave", test_copy},
+    {"concatenate waves", test_concat},
+    {0}
+};


### PR DESCRIPTION
* To be able to test properly the cst_exit() had to be removed from the cst_wave.c and a return status is sent instead.
* `unittests/Makefile` did not run all tests, now they are all active