### PR TITLE
Fix termination from SIGINT when running with -l

### DIFF
--- a/include/mimic.h
+++ b/include/mimic.h
@@ -77,16 +77,16 @@ extern "C" {
     cst_voice *mimic_voice_select(const char *name);
     cst_voice *mimic_voice_load(const char *voice_filename);
     int mimic_voice_dump(cst_voice *voice, const char *voice_filename);
-    float mimic_file_to_speech(const char *filename,
-                               cst_voice *voice, const char *outtype);
-    float mimic_text_to_speech(const char *text,
-                               cst_voice *voice, const char *outtype);
-    float mimic_phones_to_speech(const char *text,
-                                 cst_voice *voice, const char *outtype);
-    float mimic_ssml_file_to_speech(const char *filename,
-                                    cst_voice *voice, const char *outtype);
-    float mimic_ssml_text_to_speech(const char *text, cst_voice *voice,
-                                    const char *outtype);
+    int mimic_file_to_speech(const char *filename, cst_voice *voice,
+                             const char *outtype, float *dur);
+    int mimic_text_to_speech(const char *text, cst_voice *voice,
+                             const char *outtype, float *dur);
+    int mimic_phones_to_speech(const char *text, cst_voice *voice,
+                               const char *outtype, float *dur);
+    int mimic_ssml_file_to_speech(const char *filename, cst_voice *voice,
+                                    const char *outtype, float *dur);
+    int mimic_ssml_text_to_speech(const char *text, cst_voice *voice,
+                                    const char *outtype, float *dur);
     int mimic_voice_add_lex_addenda(cst_voice *v, const cst_string *lexfile);
 
 /* Lower lever user functions */
@@ -94,8 +94,8 @@ extern "C" {
     cst_utterance *mimic_synth_text(const char *text, cst_voice *voice);
     cst_utterance *mimic_synth_phones(const char *phones, cst_voice *voice);
 
-    float mimic_ts_to_speech(cst_tokenstream *ts,
-                             cst_voice *voice, const char *outtype);
+    int mimic_ts_to_speech(cst_tokenstream *ts, cst_voice *voice,
+                           const char *outtype, float *dur);
     cst_utterance *mimic_do_synth(cst_utterance *u,
                                   cst_voice *voice, cst_uttfunc synth);
     int mimic_process_output(cst_utterance *u,

--- a/main/mimic_main.c
+++ b/main/mimic_main.c
@@ -212,6 +212,7 @@ int main(int argc, char **argv)
     cst_voice *desired_voice = 0;
     const char *voicedir = NULL;
     int i;
+	int err;
     float durs;
     double time_start, time_end;
     int mimic_verbose, mimic_loop, mimic_bench;
@@ -419,20 +420,20 @@ int main(int argc, char **argv)
     time_start = (double) (tv.tv_sec) + (((double) tv.tv_usec) / 1000000.0);
 
     if (explicit_phones)
-        durs = mimic_phones_to_speech(filename, v, outtype);
+        err = mimic_phones_to_speech(filename, v, outtype, &durs);
     else if ((strchr(filename, ' ') && !explicit_filename) || explicit_text)
     {
         if (ssml_mode)
-            durs = mimic_ssml_text_to_speech(filename, v, outtype);
+            err = mimic_ssml_text_to_speech(filename, v, outtype, &durs);
         else
-            durs = mimic_text_to_speech(filename, v, outtype);
+            err = mimic_text_to_speech(filename, v, outtype, &durs);
     }
     else
     {
         if (ssml_mode)
-            durs = mimic_ssml_file_to_speech(filename, v, outtype);
+            err = mimic_ssml_file_to_speech(filename, v, outtype, &durs);
         else
-            durs = mimic_file_to_speech(filename, v, outtype);
+            err = mimic_file_to_speech(filename, v, outtype, &durs);
     }
 
     gettimeofday(&tv, NULL);
@@ -443,7 +444,8 @@ int main(int argc, char **argv)
              durs / (float) (time_end - time_start), durs,
              (float) (time_end - time_start));
 
-    if (mimic_loop || (mimic_bench && bench_iter++ < ITER_MAX))
+    if ((mimic_loop || (mimic_bench && bench_iter++ < ITER_MAX))
+			&& err == 0)
         goto loop;
 
     delete_features(extra_feats);

--- a/main/mimic_time_main.c
+++ b/main/mimic_time_main.c
@@ -63,6 +63,7 @@ int main(int argc, char **argv)
     cst_voice *v;
     char thetime[1024];
     char b[3];
+	float durs;
     int hour, min;
     cst_regex *timex;
     char *output = "play";
@@ -98,7 +99,7 @@ int main(int argc, char **argv)
             time_tod(hour, min));
 
     printf("%s\n", thetime);
-    mimic_text_to_speech(thetime, v, output);
+    mimic_text_to_speech(thetime, v, output, &durs);
 
     mimic_exit();
 

--- a/src/synth/cst_ssml.c
+++ b/src/synth/cst_ssml.c
@@ -61,6 +61,7 @@
 
 #include "mimic.h"
 #include "cst_tokenstream.h"
+#include "errno.h"
 
 static const char *const ssml_singlecharsymbols_general = "<>&/\";";
 static const char *const ssml_singlecharsymbols_inattr = "=>;/\"";
@@ -288,8 +289,8 @@ static cst_utterance *ssml_apply_tag(const char *tag,
     return u;
 }
 
-static float mimic_ssml_to_speech_ts(cst_tokenstream *ts,
-                                     cst_voice *voice, const char *outtype)
+static float mimic_ssml_to_speech_ts(cst_tokenstream *ts, cst_voice *voice,
+                                     const char *outtype, float *durs)
 {
     /* This is a very ugly function, that might be better written with gotos */
     /* This just doesn't seem to be properly functions -- perhaps a proper */
@@ -305,7 +306,6 @@ static float mimic_ssml_to_speech_ts(cst_tokenstream *ts,
     int num_tokens;
     cst_breakfunc breakfunc = default_utt_break;
     cst_uttfunc utt_user_callback = 0;
-    float durs = 0.0;
     cst_item *t;
     cst_voice *current_voice;
     int ssml_eou = 0;
@@ -313,6 +313,10 @@ static float mimic_ssml_to_speech_ts(cst_tokenstream *ts,
     cst_wave *w;
     int err;
 
+    if ((durs == NULL) || (voice == NULL) || (ts == NULL) || (outtype == NULL))
+    {
+        return -EINVAL;
+    }
     ssml_feats = new_features();
     feat_set(ssml_feats, "current_voice", userdata_val(voice));
     feat_set(ssml_feats, "default_voice", userdata_val(voice));
@@ -410,7 +414,7 @@ static float mimic_ssml_to_speech_ts(cst_tokenstream *ts,
                 err = mimic_process_output(utt, outtype, TRUE, &new_durs);
                 if (err < 0)
                     goto cleanup;
-                durs += new_durs;
+                *durs += new_durs;
                 delete_utterance(utt);
                 utt = NULL;
             }
@@ -441,7 +445,7 @@ static float mimic_ssml_to_speech_ts(cst_tokenstream *ts,
             mimic_process_output(utt, outtype, TRUE, &new_durs);
             if (err < 0)
                 goto cleanup;
-            durs += new_durs;
+            *durs += new_durs;
             delete_utterance(utt);
             utt = NULL;
 
@@ -474,17 +478,22 @@ static float mimic_ssml_to_speech_ts(cst_tokenstream *ts,
     delete_utterance(utt);
     delete_features(ssml_feats);
     delete_features(ssml_word_feats);
-    return durs;
+    return err;
 }
 
-float mimic_ssml_file_to_speech(const char *filename,
-                                cst_voice *voice, const char *outtype)
+int mimic_ssml_file_to_speech(const char *filename, cst_voice *voice,
+                                 const char *outtype, float *dur)
 {
     cst_tokenstream *ts;
     int fp;
+    int err;
     cst_wave *w;
-    float d;
 
+    if ((dur == NULL) || (voice == NULL)
+            || (filename == NULL) || (outtype == NULL))
+    {
+        return -EINVAL;
+    }
     if ((ts = ts_open(filename,
                       get_param_string(voice->features, "text_whitespace",
                                        NULL),
@@ -497,7 +506,7 @@ float mimic_ssml_file_to_speech(const char *filename,
                                        NULL))) == NULL)
     {
         cst_errmsg("failed to open file \"%s\" for ssml reading\n", filename);
-        return 1;
+        return -ENOENT;
     }
     fp = get_param_int(voice->features, "file_start_position", 0);
     if (fp > 0)
@@ -517,21 +526,26 @@ float mimic_ssml_file_to_speech(const char *filename,
         delete_wave(w);
     }
 
-    d = mimic_ssml_to_speech_ts(ts, voice, outtype);
+    err = mimic_ssml_to_speech_ts(ts, voice, outtype, dur);
 
     ts_close(ts);
 
-    return d;
+    return err;
 
 }
 
-float mimic_ssml_text_to_speech(const char *text,
-                                cst_voice *voice, const char *outtype)
+int mimic_ssml_text_to_speech(const char *text, cst_voice *voice,
+                                const char *outtype, float *dur)
 {
     cst_tokenstream *ts;
     int fp;
+    int err;
     cst_wave *w;
-    float d;
+
+    if ((dur == NULL) || (voice == NULL) || (text == NULL) || (outtype == NULL))
+    {
+        return -EINVAL;
+    }
 
     if ((ts = ts_open_string(text,
                              get_param_string(voice->features,
@@ -544,7 +558,7 @@ float mimic_ssml_text_to_speech(const char *text,
                                               "text_postpunctuation",
                                               NULL))) == NULL)
     {
-        return 1;
+        return -EINVAL;
     }
     fp = get_param_int(voice->features, "file_start_position", 0);
     if (fp > 0)
@@ -564,10 +578,10 @@ float mimic_ssml_text_to_speech(const char *text,
         delete_wave(w);
     }
 
-    d = mimic_ssml_to_speech_ts(ts, voice, outtype);
+    err = mimic_ssml_to_speech_ts(ts, voice, outtype, dur);
 
     ts_close(ts);
 
-    return d;
+    return err;
 
 }

--- a/src/synth/mimic.c
+++ b/src/synth/mimic.c
@@ -232,8 +232,8 @@ cst_wave *mimic_text_to_wave(const char *text, cst_voice *voice)
     return w;
 }
 
-float mimic_file_to_speech(const char *filename,
-                           cst_voice *voice, const char *outtype)
+int mimic_file_to_speech(const char *filename, cst_voice *voice,
+                         const char *outtype, float *dur)
 {
     cst_tokenstream *ts;
 
@@ -251,11 +251,11 @@ float mimic_file_to_speech(const char *filename,
         cst_errmsg("failed to open file \"%s\" for reading\n", filename);
         return 1;
     }
-    return mimic_ts_to_speech(ts, voice, outtype);
+    return mimic_ts_to_speech(ts, voice, outtype, dur);
 }
 
-float mimic_ts_to_speech(cst_tokenstream *ts,
-                         cst_voice *voice, const char *outtype)
+int mimic_ts_to_speech(cst_tokenstream *ts, cst_voice *voice,
+                       const char *outtype, float *dur)
 {
     int err;
     cst_utterance *utt;
@@ -352,33 +352,44 @@ float mimic_ts_to_speech(cst_tokenstream *ts,
     if (utt)
         delete_utterance(utt);
     ts_close(ts);
-    return durs;
+    return err;
 }
 
-float mimic_text_to_speech(const char *text,
-                           cst_voice *voice, const char *outtype)
+int mimic_text_to_speech(const char *text, cst_voice *voice,
+                         const char *outtype, float *dur)
 {
-    cst_utterance *u;
-    float dur;
+    int ret;
 
-    u = mimic_synth_text(text, voice);
-    mimic_process_output(u, outtype, FALSE, &dur);
-    delete_utterance(u);
-
-    return dur;
+    if ((dur == NULL) || (voice == NULL) || (text == NULL) || (outtype == NULL))
+    {
+        ret = -EINVAL;
+    }
+    else
+    {
+        cst_utterance *u;
+        u = mimic_synth_text(text, voice);
+        ret = mimic_process_output(u, outtype, FALSE, dur);
+        delete_utterance(u);
+    }
+    return ret;
 }
 
-float mimic_phones_to_speech(const char *text,
-                             cst_voice *voice, const char *outtype)
+int mimic_phones_to_speech(const char *text, cst_voice *voice,
+                           const char *outtype, float *dur)
 {
-    cst_utterance *u;
-    float dur;
-
-    u = mimic_synth_phones(text, voice);
-    mimic_process_output(u, outtype, FALSE, &dur);
-    delete_utterance(u);
-
-    return dur;
+    int ret;
+    if ((dur == NULL) || (voice == NULL) || (text == NULL) || (outtype == NULL))
+    {
+        ret = -EINVAL;
+    }
+    else
+    {
+        cst_utterance *u;
+        u = mimic_synth_phones(text, voice);
+        ret = mimic_process_output(u, outtype, FALSE, dur);
+        delete_utterance(u);
+    }
+    return ret;
 }
 
 int mimic_process_output(cst_utterance *u, const char *outtype,

--- a/testsuite/by_word_main.c
+++ b/testsuite/by_word_main.c
@@ -109,6 +109,7 @@ int main(int argc, char **argv)
 {
     cst_voice *v;
     cst_audio_streaming_info *asi;
+	float durs;
 
     if (argc != 2)
     {
@@ -124,7 +125,7 @@ int main(int argc, char **argv)
     asi->asc = audio_stream_chunk_by_word;
     feat_set(v->features, "streaming_info", audio_streaming_info_val(asi));
 
-    mimic_file_to_speech(argv[1], v, "none");   /* streaming will play */
+    mimic_file_to_speech(argv[1], v, "none", &durs);  /* streaming will play */
 
     mimic_exit();
     return 0;

--- a/testsuite/multi_thread_main.c
+++ b/testsuite/multi_thread_main.c
@@ -70,7 +70,7 @@ void init()
 float synth_text(char *text)
 {
     float dur;
-    dur = mimic_text_to_speech(text, voice, "none");
+    mimic_text_to_speech(text, voice, "none", &dur);
     return dur;
 }
 


### PR DESCRIPTION
Error code is now returned by `x_to_speech()` functions. I considered using `errno` but as this seems to be intended mainly for syscalls and system library functions I used a return value instead. If `errno` would be preferred I can go that way instead. The advantage of using `errno` would be keeping the API the same.

Fixes #64 