### PR TITLE
Rename libmimic* to libttsmimic 

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -12,19 +12,19 @@ pkginclude_HEADERS =
 langheader_HEADERS =
 lib_LTLIBRARIES =
 
-lib_LTLIBRARIES += libmimic.la
-libmimic_la_SOURCES = 
-libmimic_la_CFLAGS = 
-libmimic_la_LDFLAGS = -no-undefined
-libmimic_la_LIBADD = 
+lib_LTLIBRARIES += libttsmimic.la
+libttsmimic_la_SOURCES = 
+libttsmimic_la_CFLAGS = 
+libttsmimic_la_LDFLAGS = -no-undefined
+libttsmimic_la_LIBADD = 
 
-libmimic_lang_all_langs_la_SOURCES = main/mimic_lang_list.c
-libmimic_lang_all_langs_la_LDFLAGS = -no-undefined
-libmimic_lang_all_langs_la_LIBADD = libmimic.la
+libttsmimic_lang_all_langs_la_SOURCES = main/mimic_lang_list.c
+libttsmimic_lang_all_langs_la_LDFLAGS = -no-undefined
+libttsmimic_lang_all_langs_la_LIBADD = libttsmimic.la
 
-libmimic_lang_all_voices_la_SOURCES = main/mimic_voice_list.c
-libmimic_lang_all_voices_la_LDFLAGS = -no-undefined
-libmimic_lang_all_voices_la_LIBADD = libmimic.la
+libttsmimic_lang_all_voices_la_SOURCES = main/mimic_voice_list.c
+libttsmimic_lang_all_voices_la_LDFLAGS = -no-undefined
+libttsmimic_lang_all_voices_la_LIBADD = libttsmimic.la
 TESTS = 
 
 pkgconfiginstalldir = $(libdir)/pkgconfig
@@ -32,15 +32,15 @@ pkgconfiginstall_DATA = mimic.pc
 
 ################## START: LANG_USENGLISH #################################
 if LANG_USENGLISH
-    lib_LTLIBRARIES += libmimic_lang_usenglish.la
-    libmimic_lang_all_langs_la_LIBADD += libmimic_lang_usenglish.la
+    lib_LTLIBRARIES += libttsmimic_lang_usenglish.la
+    libttsmimic_lang_all_langs_la_LIBADD += libttsmimic_lang_usenglish.la
 endif
 
 EXTRA_DIST += \
   lang/usenglish/make_us_regexes \
   lang/usenglish/us_pos.tree
 
-libmimic_lang_usenglish_la_SOURCES = \
+libttsmimic_lang_usenglish_la_SOURCES = \
   lang/usenglish/us_aswd.c \
   lang/usenglish/us_dur_stats.c \
   lang/usenglish/us_durz_cart.c \
@@ -64,8 +64,8 @@ libmimic_lang_usenglish_la_SOURCES = \
   lang/usenglish/us_pos_cart.h \
   lang/usenglish/us_text.c
 
-libmimic_lang_usenglish_la_LDFLAGS = -no-undefined
-libmimic_lang_usenglish_la_LIBADD = libmimic.la
+libttsmimic_lang_usenglish_la_LDFLAGS = -no-undefined
+libttsmimic_lang_usenglish_la_LIBADD = libttsmimic.la
 
 
 langheader_HEADERS += \
@@ -88,19 +88,19 @@ langheader_HEADERS += \
 
 #################### START:  LANG_INDIC ##################################
 if LANG_INDIC_ANALYSIS
-  lib_LTLIBRARIES += libmimic_lang_cmu_grapheme_lang.la \
-                     libmimic_lang_cmu_indic_lang.la
-  libmimic_lang_all_langs_la_LIBADD += libmimic_lang_cmu_grapheme_lang.la \
-                                       libmimic_lang_cmu_indic_lang.la
+  lib_LTLIBRARIES += libttsmimic_lang_cmu_grapheme_lang.la \
+                     libttsmimic_lang_cmu_indic_lang.la
+  libttsmimic_lang_all_langs_la_LIBADD += libttsmimic_lang_cmu_grapheme_lang.la \
+                                       libttsmimic_lang_cmu_indic_lang.la
 endif
 
 langheader_HEADERS += \
     lang/cmu_grapheme_lang/cmu_grapheme_lang.h
 
-libmimic_lang_cmu_grapheme_lang_la_LDFLAGS = -no-undefined
-libmimic_lang_cmu_grapheme_lang_la_LIBADD = libmimic.la
+libttsmimic_lang_cmu_grapheme_lang_la_LDFLAGS = -no-undefined
+libttsmimic_lang_cmu_grapheme_lang_la_LIBADD = libttsmimic.la
 
-libmimic_lang_cmu_grapheme_lang_la_SOURCES = \
+libttsmimic_lang_cmu_grapheme_lang_la_SOURCES = \
   lang/cmu_grapheme_lang/cmu_grapheme_phrasing_cart.h \
   lang/cmu_grapheme_lang/cmu_grapheme_lang.c \
   lang/cmu_grapheme_lang/cmu_grapheme_phrasing_cart.c \
@@ -112,9 +112,9 @@ langheader_HEADERS += \
   lang/cmu_indic_lang/cmu_indic_lang.h
 
 
-libmimic_lang_cmu_indic_lang_la_LDFLAGS = -no-undefined
-libmimic_lang_cmu_indic_lang_la_LIBADD = libmimic.la libmimic_lang_usenglish.la
-libmimic_lang_cmu_indic_lang_la_SOURCES = \
+libttsmimic_lang_cmu_indic_lang_la_LDFLAGS = -no-undefined
+libttsmimic_lang_cmu_indic_lang_la_LIBADD = libttsmimic.la libttsmimic_lang_usenglish.la
+libttsmimic_lang_cmu_indic_lang_la_SOURCES = \
   lang/cmu_indic_lang/cmu_indic_lang.c \
   lang/cmu_indic_lang/cmu_indic_phoneset.c \
   lang/cmu_indic_lang/cmu_indic_phrasing_cart.h \
@@ -125,13 +125,13 @@ libmimic_lang_cmu_indic_lang_la_SOURCES = \
 
 ############## START: LEX_CMULEX #########################################
 if LEX_CMULEX
-    lib_LTLIBRARIES += libmimic_lang_cmulex.la
-    libmimic_lang_all_langs_la_LIBADD += libmimic_lang_cmulex.la
+    lib_LTLIBRARIES += libttsmimic_lang_cmulex.la
+    libttsmimic_lang_all_langs_la_LIBADD += libttsmimic_lang_cmulex.la
 endif
 
-libmimic_lang_cmulex_la_LDFLAGS = -no-undefined
-libmimic_lang_cmulex_la_LIBADD = libmimic.la
-libmimic_lang_cmulex_la_SOURCES = \
+libttsmimic_lang_cmulex_la_LDFLAGS = -no-undefined
+libttsmimic_lang_cmulex_la_LIBADD = libttsmimic.la
+libttsmimic_lang_cmulex_la_SOURCES = \
   lang/cmulex/cmu_lex.c \
   lang/cmulex/cmu_lex_data.c \
   lang/cmulex/cmu_lex_entries.c \
@@ -156,18 +156,18 @@ langheader_HEADERS += \
 
 ############# START: Lexicon for indic: #################################
 if LEX_INDIC
-    lib_LTLIBRARIES += libmimic_lang_cmu_indic_lex.la \
-                       libmimic_lang_cmu_grapheme_lex.la
-    libmimic_lang_all_langs_la_LIBADD += libmimic_lang_cmu_indic_lex.la \
-                                         libmimic_lang_cmu_grapheme_lex.la
+    lib_LTLIBRARIES += libttsmimic_lang_cmu_indic_lex.la \
+                       libttsmimic_lang_cmu_grapheme_lex.la
+    libttsmimic_lang_all_langs_la_LIBADD += libttsmimic_lang_cmu_indic_lex.la \
+                                         libttsmimic_lang_cmu_grapheme_lex.la
 endif
 
 langheader_HEADERS += \
   lang/cmu_grapheme_lex/cmu_grapheme_lex.h
 
-libmimic_lang_cmu_grapheme_lex_la_LDFLAGS = -no-undefined
-libmimic_lang_cmu_grapheme_lex_la_LIBADD = libmimic.la
-libmimic_lang_cmu_grapheme_lex_la_SOURCES = \
+libttsmimic_lang_cmu_grapheme_lex_la_LDFLAGS = -no-undefined
+libttsmimic_lang_cmu_grapheme_lex_la_LIBADD = libttsmimic.la
+libttsmimic_lang_cmu_grapheme_lex_la_SOURCES = \
   lang/cmu_grapheme_lex/cmu_grapheme_lex.c \
   lang/cmu_grapheme_lex/grapheme_unitran_tables.c
 
@@ -176,11 +176,11 @@ libmimic_lang_cmu_grapheme_lex_la_SOURCES = \
 #         -b ${TOP}/tools/make_ug.scm \
 #            ${FESTVOXDIR}/src/grapheme/unicode_sampa_mapping.scm '(doit)'
 
-libmimic_lang_cmu_indic_lex_la_LDFLAGS = -no-undefined
-libmimic_lang_cmu_indic_lex_la_LIBADD = libmimic.la \
-                                        libmimic_lang_cmulex.la \
-                                        libmimic_lang_cmu_indic_lang.la
-libmimic_lang_cmu_indic_lex_la_SOURCES = \
+libttsmimic_lang_cmu_indic_lex_la_LDFLAGS = -no-undefined
+libttsmimic_lang_cmu_indic_lex_la_LIBADD = libttsmimic.la \
+                                        libttsmimic_lang_cmulex.la \
+                                        libttsmimic_lang_cmu_indic_lang.la
+libttsmimic_lang_cmu_indic_lex_la_SOURCES = \
   lang/cmu_indic_lex/cmu_indic_lex.c
 
 langheader_HEADERS += \
@@ -189,12 +189,12 @@ langheader_HEADERS += \
 # END: Lexicon for indic ####################
 
 if VOICE_CMU_US_KAL
-    lib_LTLIBRARIES += libmimic_lang_cmu_us_kal.la
-    libmimic_lang_all_voices_la_LIBADD += libmimic_lang_cmu_us_kal.la
+    lib_LTLIBRARIES += libttsmimic_lang_cmu_us_kal.la
+    libttsmimic_lang_all_voices_la_LIBADD += libttsmimic_lang_cmu_us_kal.la
 endif
 
-libmimic_lang_cmu_us_kal_la_LDFLAGS = -no-undefined
-libmimic_lang_cmu_us_kal_la_SOURCES = \
+libttsmimic_lang_cmu_us_kal_la_LDFLAGS = -no-undefined
+libttsmimic_lang_cmu_us_kal_la_SOURCES = \
   lang/cmu_us_kal/cmu_us_kal.c \
   lang/cmu_us_kal/cmu_us_kal_diphone.c \
   lang/cmu_us_kal/cmu_us_kal_lpc.c \
@@ -203,25 +203,25 @@ libmimic_lang_cmu_us_kal_la_SOURCES = \
   lang/cmu_us_kal/cmu_us_kal_ressize.c \
   lang/cmu_us_kal/voxdefs.h
 
-libmimic_lang_cmu_us_kal_la_CFLAGS = \
+libttsmimic_lang_cmu_us_kal_la_CFLAGS = \
   -I$(top_srcdir)/lang/usenglish \
   -I$(top_srcdir)/lang/cmulex
 
-libmimic_lang_cmu_us_kal_la_LIBADD = \
-  libmimic.la \
-  libmimic_lang_cmulex.la \
-  libmimic_lang_usenglish.la
+libttsmimic_lang_cmu_us_kal_la_LIBADD = \
+  libttsmimic.la \
+  libttsmimic_lang_cmulex.la \
+  libttsmimic_lang_usenglish.la
 
 
 ############
 
 if VOICE_CMU_TIME_AWB
-    lib_LTLIBRARIES += libmimic_lang_cmu_time_awb.la
-    libmimic_lang_all_voices_la_LIBADD += libmimic_lang_cmu_time_awb.la
+    lib_LTLIBRARIES += libttsmimic_lang_cmu_time_awb.la
+    libttsmimic_lang_all_voices_la_LIBADD += libttsmimic_lang_cmu_time_awb.la
 endif
 
-libmimic_lang_cmu_time_awb_la_LDFLAGS = -no-undefined
-libmimic_lang_cmu_time_awb_la_SOURCES = \
+libttsmimic_lang_cmu_time_awb_la_LDFLAGS = -no-undefined
+libttsmimic_lang_cmu_time_awb_la_SOURCES = \
   lang/cmu_time_awb/cmu_time_awb.c \
   lang/cmu_time_awb/cmu_time_awb_cart.c \
   lang/cmu_time_awb/cmu_time_awb_clunits.c \
@@ -230,24 +230,24 @@ libmimic_lang_cmu_time_awb_la_SOURCES = \
   lang/cmu_time_awb/cmu_time_awb_mcep.c \
   lang/cmu_time_awb/voxdefs.h
 
-libmimic_lang_cmu_time_awb_la_CFLAGS = \
+libttsmimic_lang_cmu_time_awb_la_CFLAGS = \
   -I$(top_srcdir)/lang/usenglish \
   -I$(top_srcdir)/lang/cmulex
 
-libmimic_lang_cmu_time_awb_la_LIBADD = \
-  libmimic.la \
-  libmimic_lang_cmulex.la \
-  libmimic_lang_usenglish.la
+libttsmimic_lang_cmu_time_awb_la_LIBADD = \
+  libttsmimic.la \
+  libttsmimic_lang_cmulex.la \
+  libttsmimic_lang_usenglish.la
 
 ##########
 
 if VOICE_CMU_US_KAL16
-    lib_LTLIBRARIES += libmimic_lang_cmu_us_kal16.la
-    libmimic_lang_all_voices_la_LIBADD += libmimic_lang_cmu_us_kal16.la
+    lib_LTLIBRARIES += libttsmimic_lang_cmu_us_kal16.la
+    libttsmimic_lang_all_voices_la_LIBADD += libttsmimic_lang_cmu_us_kal16.la
 endif
 
-libmimic_lang_cmu_us_kal16_la_LDFLAGS = -no-undefined
-libmimic_lang_cmu_us_kal16_la_SOURCES = \
+libttsmimic_lang_cmu_us_kal16_la_LDFLAGS = -no-undefined
+libttsmimic_lang_cmu_us_kal16_la_SOURCES = \
   lang/cmu_us_kal16/cmu_us_kal16.c \
   lang/cmu_us_kal16/cmu_us_kal16_diphone.c \
   lang/cmu_us_kal16/cmu_us_kal16_lpc.c \
@@ -255,25 +255,25 @@ libmimic_lang_cmu_us_kal16_la_SOURCES = \
   lang/cmu_us_kal16/cmu_us_kal16_residx.c \
   lang/cmu_us_kal16/voxdefs.h
 
-libmimic_lang_cmu_us_kal16_la_CFLAGS = \
+libttsmimic_lang_cmu_us_kal16_la_CFLAGS = \
   -I$(top_srcdir)/lang/usenglish \
   -I$(top_srcdir)/lang/cmulex
 
 
-libmimic_lang_cmu_us_kal16_la_LIBADD = \
-  libmimic.la \
-  libmimic_lang_cmulex.la \
-  libmimic_lang_usenglish.la
+libttsmimic_lang_cmu_us_kal16_la_LIBADD = \
+  libttsmimic.la \
+  libttsmimic_lang_cmulex.la \
+  libttsmimic_lang_usenglish.la
 
 ####################
 
 if VOICE_CMU_US_AWB
-    lib_LTLIBRARIES += libmimic_lang_cmu_us_awb.la
-    libmimic_lang_all_voices_la_LIBADD += libmimic_lang_cmu_us_awb.la
+    lib_LTLIBRARIES += libttsmimic_lang_cmu_us_awb.la
+    libttsmimic_lang_all_voices_la_LIBADD += libttsmimic_lang_cmu_us_awb.la
 endif
 
-libmimic_lang_cmu_us_awb_la_LDFLAGS = -no-undefined
-libmimic_lang_cmu_us_awb_la_SOURCES = \
+libttsmimic_lang_cmu_us_awb_la_LDFLAGS = -no-undefined
+libttsmimic_lang_cmu_us_awb_la_SOURCES = \
   lang/cmu_us_awb/cmu_us_awb.c \
   lang/cmu_us_awb/cmu_us_awb_cg.c \
   lang/cmu_us_awb/cmu_us_awb_cg_durmodel.c \
@@ -291,25 +291,25 @@ libmimic_lang_cmu_us_awb_la_SOURCES = \
   lang/cmu_us_awb/cmu_us_awb_spamf0_phrase.h \
   lang/cmu_us_awb/voxdefs.h
 
-libmimic_lang_cmu_us_awb_la_CFLAGS = \
+libttsmimic_lang_cmu_us_awb_la_CFLAGS = \
   -I$(top_srcdir)/lang/usenglish \
   -I$(top_srcdir)/lang/cmulex
 
-libmimic_lang_cmu_us_awb_la_LIBADD = \
-  libmimic.la \
-  libmimic_lang_cmulex.la \
-  libmimic_lang_usenglish.la
+libttsmimic_lang_cmu_us_awb_la_LIBADD = \
+  libttsmimic.la \
+  libttsmimic_lang_cmulex.la \
+  libttsmimic_lang_usenglish.la
 
 
 ###########
 
 if VOICE_CMU_US_RMS
-    lib_LTLIBRARIES += libmimic_lang_cmu_us_rms.la
-    libmimic_lang_all_voices_la_LIBADD += libmimic_lang_cmu_us_rms.la
+    lib_LTLIBRARIES += libttsmimic_lang_cmu_us_rms.la
+    libttsmimic_lang_all_voices_la_LIBADD += libttsmimic_lang_cmu_us_rms.la
 endif
 
-libmimic_lang_cmu_us_rms_la_LDFLAGS = -no-undefined
-libmimic_lang_cmu_us_rms_la_SOURCES = \
+libttsmimic_lang_cmu_us_rms_la_LDFLAGS = -no-undefined
+libttsmimic_lang_cmu_us_rms_la_SOURCES = \
   lang/cmu_us_rms/cmu_us_rms.c \
   lang/cmu_us_rms/cmu_us_rms_cg.c \
   lang/cmu_us_rms/cmu_us_rms_cg_durmodel.c \
@@ -327,24 +327,24 @@ libmimic_lang_cmu_us_rms_la_SOURCES = \
   lang/cmu_us_rms/cmu_us_rms_spamf0_phrase.h \
   lang/cmu_us_rms/voxdefs.h
 
-libmimic_lang_cmu_us_rms_la_CFLAGS = \
+libttsmimic_lang_cmu_us_rms_la_CFLAGS = \
   -I$(top_srcdir)/lang/usenglish \
   -I$(top_srcdir)/lang/cmulex
 
-libmimic_lang_cmu_us_rms_la_LIBADD = \
-  libmimic.la \
-  libmimic_lang_cmulex.la \
-  libmimic_lang_usenglish.la
+libttsmimic_lang_cmu_us_rms_la_LIBADD = \
+  libttsmimic.la \
+  libttsmimic_lang_cmulex.la \
+  libttsmimic_lang_usenglish.la
 
 ###############
 
 if VOICE_CMU_US_SLT
-    lib_LTLIBRARIES += libmimic_lang_cmu_us_slt.la
-    libmimic_lang_all_voices_la_LIBADD += libmimic_lang_cmu_us_slt.la
+    lib_LTLIBRARIES += libttsmimic_lang_cmu_us_slt.la
+    libttsmimic_lang_all_voices_la_LIBADD += libttsmimic_lang_cmu_us_slt.la
 endif
 
-libmimic_lang_cmu_us_slt_la_LDFLAGS = -no-undefined
-libmimic_lang_cmu_us_slt_la_SOURCES = \
+libttsmimic_lang_cmu_us_slt_la_LDFLAGS = -no-undefined
+libttsmimic_lang_cmu_us_slt_la_SOURCES = \
   lang/cmu_us_slt/cmu_us_slt.c \
   lang/cmu_us_slt/cmu_us_slt_cg.c \
   lang/cmu_us_slt/cmu_us_slt_cg_durmodel.c \
@@ -362,25 +362,25 @@ libmimic_lang_cmu_us_slt_la_SOURCES = \
   lang/cmu_us_slt/cmu_us_slt_spamf0_phrase.h \
   lang/cmu_us_slt/voxdefs.h
 
-libmimic_lang_cmu_us_slt_la_CFLAGS = \
+libttsmimic_lang_cmu_us_slt_la_CFLAGS = \
   -I$(top_srcdir)/lang/usenglish \
   -I$(top_srcdir)/lang/cmulex
 
-libmimic_lang_cmu_us_slt_la_LIBADD = \
-  libmimic.la \
-  libmimic_lang_cmulex.la \
-  libmimic_lang_usenglish.la
+libttsmimic_lang_cmu_us_slt_la_LIBADD = \
+  libttsmimic.la \
+  libttsmimic_lang_cmulex.la \
+  libttsmimic_lang_usenglish.la
 
 
 ###########
 
 if VOICE_VID_GB_AP
-    lib_LTLIBRARIES += libmimic_lang_vid_gb_ap.la
-    libmimic_lang_all_voices_la_LIBADD += libmimic_lang_vid_gb_ap.la
+    lib_LTLIBRARIES += libttsmimic_lang_vid_gb_ap.la
+    libttsmimic_lang_all_voices_la_LIBADD += libttsmimic_lang_vid_gb_ap.la
 endif
 
-libmimic_lang_vid_gb_ap_la_LDFLAGS = -no-undefined
-libmimic_lang_vid_gb_ap_la_SOURCES = \
+libttsmimic_lang_vid_gb_ap_la_LDFLAGS = -no-undefined
+libttsmimic_lang_vid_gb_ap_la_SOURCES = \
   lang/vid_gb_ap/vid_gb_ap.c \
   lang/vid_gb_ap/vid_gb_ap_cg_01_mcep_trees.c \
   lang/vid_gb_ap/vid_gb_ap_cg_01_mcep_trees.h \
@@ -403,14 +403,14 @@ libmimic_lang_vid_gb_ap_la_SOURCES = \
   lang/vid_gb_ap/vid_gb_ap_cg_phonestate.c \
   lang/vid_gb_ap/voxdefs.h
 
-libmimic_lang_vid_gb_ap_la_CFLAGS = \
+libttsmimic_lang_vid_gb_ap_la_CFLAGS = \
   -I$(top_srcdir)/lang/usenglish \
   -I$(top_srcdir)/lang/cmulex
 
-libmimic_lang_vid_gb_ap_la_LIBADD = \
-  libmimic.la \
-  libmimic_lang_cmulex.la \
-  libmimic_lang_usenglish.la
+libttsmimic_lang_vid_gb_ap_la_LIBADD = \
+  libttsmimic.la \
+  libttsmimic_lang_cmulex.la \
+  libttsmimic_lang_usenglish.la
 
 ######### END VOICES ######################################
 
@@ -432,13 +432,13 @@ src_audio_SOURCES = \
   src/audio/au_wince.c \
   src/audio/native_audio.h
 
-libmimic_la_CFLAGS += $(AUDIODEFS)
-libmimic_la_SOURCES += $(src_audio_SOURCES)
+libttsmimic_la_CFLAGS += $(AUDIODEFS)
+libttsmimic_la_SOURCES += $(src_audio_SOURCES)
 
-libmimic_la_LIBADD += $(AUDIOLIBS)
+libttsmimic_la_LIBADD += $(AUDIOLIBS)
 
 ###### src/cg ##################
-libmimic_la_SOURCES += \
+libttsmimic_la_SOURCES += \
   src/cg/cst_mlsa.h \
   src/cg/cst_mlpg.h \
   src/cg/cst_vc.h \
@@ -454,7 +454,7 @@ libmimic_la_SOURCES += \
   src/cg/cst_spamf0.c
 
 ####### src/hrg ###############
-libmimic_la_SOURCES += \
+libttsmimic_la_SOURCES += \
   src/hrg/cst_utterance.c \
   src/hrg/cst_relation.c \
   src/hrg/cst_item.c \
@@ -463,14 +463,14 @@ libmimic_la_SOURCES += \
 
 ###### src/lexicon #########
 
-libmimic_la_SOURCES += \
+libttsmimic_la_SOURCES += \
   src/lexicon/cst_lexicon.c \
   src/lexicon/cst_lts.c \
   src/lexicon/cst_lts_rewrites.c
 
 
 ###### src/regex ########
-libmimic_la_SOURCES += \
+libttsmimic_la_SOURCES += \
   src/regex/cst_regex.c \
   src/regex/cst_regex_defs.h \
   src/regex/regexp.c \
@@ -480,7 +480,7 @@ libmimic_la_SOURCES += \
 #	./make_cst_regexes $(BINDIR) >cst_regex_defs.h
 
 ###### src/speech #########
-libmimic_la_SOURCES += \
+libttsmimic_la_SOURCES += \
   src/speech/cst_lpcres.c \
   src/speech/cst_track.c \
   src/speech/cst_track_io.c \
@@ -495,13 +495,13 @@ libmimic_la_SOURCES += \
   src/speech/rateconv.c
 
 ###### src/stats #########
-libmimic_la_SOURCES += \
+libttsmimic_la_SOURCES += \
   src/stats/cst_cart.c \
   src/stats/cst_ss.c \
   src/stats/cst_viterbi.c
 
 ###### src/synth #########
-libmimic_la_SOURCES += \
+libttsmimic_la_SOURCES += \
   src/synth/cst_ffeatures.c \
   src/synth/cst_phoneset.c \
   src/synth/cst_ssml.c \
@@ -511,7 +511,7 @@ libmimic_la_SOURCES += \
   src/synth/mimic.c
 
 ###### src/utils #########
-libmimic_la_SOURCES += \
+libttsmimic_la_SOURCES += \
   src/utils/cst_alloc.c \
   src/utils/cst_args.c \
   src/utils/cst_endian.c \
@@ -531,7 +531,7 @@ libmimic_la_SOURCES += \
   src/utils/cst_wchar.c
 
 ###### src/wavesynth #########
-libmimic_la_SOURCES += \
+libttsmimic_la_SOURCES += \
   src/wavesynth/cst_clunits.c \
   src/wavesynth/cst_diphone.c \
   src/wavesynth/cst_reflpc.c \
@@ -541,7 +541,7 @@ libmimic_la_SOURCES += \
 
 ###############################
 
-libmimic_la_LIBADD += $(AUDIOLIBS) -lm
+libttsmimic_la_LIBADD += $(AUDIOLIBS) -lm
 
 
 ################# main ########################
@@ -554,28 +554,28 @@ endif
 endif
 
 mimic_SOURCES = main/mimic_main.c
-mimic_LDADD = libmimic_lang_all_langs.la libmimic_lang_all_voices.la libmimic.la -lm
+mimic_LDADD = libttsmimic_lang_all_langs.la libttsmimic_lang_all_voices.la libttsmimic.la -lm
 
 compile_regexes_SOURCES = main/compile_regexes.c
-compile_regexes_LDADD = libmimic.la
+compile_regexes_LDADD = libttsmimic.la
 t2p_SOURCES = main/t2p_main.c
-t2p_LDADD = libmimic.la libmimic_lang_cmulex.la libmimic_lang_usenglish.la
+t2p_LDADD = libttsmimic.la libttsmimic_lang_cmulex.la libttsmimic_lang_usenglish.la
 
 mimic_time_SOURCES = main/mimic_time_main.c
-mimic_time_LDADD = libmimic.la \
-  libmimic_lang_cmulex.la \
-  libmimic_lang_usenglish.la \
-  libmimic_lang_cmu_time_awb.la
+mimic_time_LDADD = libttsmimic.la \
+  libttsmimic_lang_cmulex.la \
+  libttsmimic_lang_usenglish.la \
+  libttsmimic_lang_cmu_time_awb.la
 
 mimicvox_info_SOURCES = \
   main/mimicvox_info_main.c
-mimicvox_info_LDADD = libmimic.la libmimic_lang_all_langs.la libmimic_lang_all_voices.la
+mimicvox_info_LDADD = libttsmimic.la libttsmimic_lang_all_langs.la libttsmimic_lang_all_voices.la
 
 ################# END: main ###################
 dist_noinst_SCRIPTS = autogen.sh
 
-lib_LTLIBRARIES += libmimic_lang_all_langs.la
-lib_LTLIBRARIES += libmimic_lang_all_voices.la
+lib_LTLIBRARIES += libttsmimic_lang_all_langs.la
+lib_LTLIBRARIES += libttsmimic_lang_all_voices.la
 
 
 ########## Unit tests #########################
@@ -588,7 +588,7 @@ myunittests = unittests/hrg_test \
               unittests/wave_test
 
 unittests_hrg_test_SOURCES = unittests/hrg_test_main.c
-unittests_hrg_test_LDADD = libmimic.la
+unittests_hrg_test_LDADD = libttsmimic.la
 
 if LEX_CMULEX
 if LANG_USENGLISH
@@ -599,39 +599,39 @@ endif
 check_PROGRAMS = $(myunittests)
 
 unittests_lex_test_SOURCES = unittests/lex_test_main.c
-unittests_lex_test_LDADD = libmimic.la \
-                           libmimic_lang_cmulex.la \
-                           libmimic_lang_all_langs.la
+unittests_lex_test_LDADD = libttsmimic.la \
+                           libttsmimic_lang_cmulex.la \
+                           libttsmimic_lang_all_langs.la
 
 unittests_lts_test_SOURCES = unittests/lts_test_main.c
-unittests_lts_test_LDADD = libmimic.la \
-                           libmimic_lang_cmulex.la \
-                           libmimic_lang_all_langs.la
+unittests_lts_test_LDADD = libttsmimic.la \
+                           libttsmimic_lang_cmulex.la \
+                           libttsmimic_lang_all_langs.la
 
 unittests_nums_test_SOURCES = unittests/nums_test_main.c
 unittests_nums_test_CFLAGS = -I$(top_srcdir)/lang/usenglish
-unittests_nums_test_LDADD = libmimic.la \
-                            libmimic_lang_cmulex.la \
-                            libmimic_lang_usenglish.la \
-                            libmimic_lang_all_langs.la
+unittests_nums_test_LDADD = libttsmimic.la \
+                            libttsmimic_lang_cmulex.la \
+                            libttsmimic_lang_usenglish.la \
+                            libttsmimic_lang_all_langs.la
 
 unittests_regex_test_SOURCES = unittests/regex_test_main.c
-unittests_regex_test_LDADD = libmimic.la
+unittests_regex_test_LDADD = libttsmimic.la
 
 unittests_token_test_SOURCES = unittests/token_test_main.c
 unittests_token_test_CFLAGS = -DTEST_FILE=\"$(top_srcdir)/unittests/data.one\" \
                               -DTEST_FILE_UTF8=\"$(top_srcdir)/unittests/data_utf8.txt\"
-unittests_token_test_LDADD = libmimic.la
+unittests_token_test_LDADD = libttsmimic.la
 
 unittests_voice_select_SOURCES = unittests/voice_select_test_main.c
 unittests_voice_select_CFLAGS = -DVOICE_LIST_DIR=\"$(top_srcdir)/voices\" \
                                 -DA_VOICE=\"$(top_srcdir)/voices/cmu_us_rms.flitevox\" 
-unittests_voice_select_LDADD = libmimic.la libmimic_lang_all_langs.la libmimic_lang_all_voices.la
+unittests_voice_select_LDADD = libttsmimic.la libttsmimic_lang_all_langs.la libttsmimic_lang_all_voices.la
 
 unittests_wave_test_SOURCES = unittests/wave_test_main.c
-unittests_wave_test_LDADD = libmimic.la \
-                            libmimic_lang_all_langs.la \
-                            libmimic_lang_all_voices.la
+unittests_wave_test_LDADD = libttsmimic.la \
+                            libttsmimic_lang_all_langs.la \
+                            libttsmimic_lang_all_voices.la
 unittests_wave_test_CFLAGS = -DVOICE_LIST_DIR=\"$(top_srcdir)/voices\" \
                              -DA_VOICE=\"$(top_srcdir)/voices/cmu_us_rms.flitevox\" 
 
@@ -685,70 +685,70 @@ if LEX_CMULEX
   check_PROGRAMS += testsuite/utt_test
 endif
 testsuite_asciiS2U_SOURCES = testsuite/asciiS2U_main.c
-testsuite_asciiS2U_LDADD = libmimic.la
+testsuite_asciiS2U_LDADD = libttsmimic.la
 
 testsuite_asciiU2S_SOURCES = testsuite/asciiU2S_main.c
-testsuite_asciiU2S_LDADD = libmimic.la
+testsuite_asciiU2S_LDADD = libttsmimic.la
 
 testsuite_bin2ascii_SOURCES = testsuite/bin2ascii_main.c
-testsuite_bin2ascii_LDADD = libmimic.la
+testsuite_bin2ascii_LDADD = libttsmimic.la
 
 testsuite_by_word_SOURCES = testsuite/by_word_main.c
-testsuite_by_word_LDADD = libmimic.la \
-                          libmimic_lang_all_langs.la \
-                          libmimic_lang_all_voices.la \
-                          libmimic_lang_cmu_us_kal.la
+testsuite_by_word_LDADD = libttsmimic.la \
+                          libttsmimic_lang_all_langs.la \
+                          libttsmimic_lang_all_voices.la \
+                          libttsmimic_lang_cmu_us_kal.la
 
 testsuite_combine_waves_SOURCES = testsuite/combine_waves_main.c
-testsuite_combine_waves_LDADD = libmimic.la
+testsuite_combine_waves_LDADD = libttsmimic.la
 
 testsuite_compare_wave_SOURCES = testsuite/compare_wave_main.c
-testsuite_compare_wave_LDADD = libmimic.la
+testsuite_compare_wave_LDADD = libttsmimic.la
 
 testsuite_kal_test_SOURCES = testsuite/kal_test_main.c
-testsuite_kal_test_LDADD = libmimic.la \
-                           libmimic_lang_all_langs.la \
-                           libmimic_lang_all_voices.la \
-                           libmimic_lang_cmu_us_kal.la
+testsuite_kal_test_LDADD = libttsmimic.la \
+                           libttsmimic_lang_all_langs.la \
+                           libttsmimic_lang_all_voices.la \
+                           libttsmimic_lang_cmu_us_kal.la
 
 testsuite_lex_lookup_SOURCES = testsuite/lex_lookup_main.c
-testsuite_lex_lookup_LDADD = libmimic.la libmimic_lang_all_langs.la \
-                             libmimic_lang_cmulex.la \
-                             libmimic_lang_usenglish.la
+testsuite_lex_lookup_LDADD = libttsmimic.la libttsmimic_lang_all_langs.la \
+                             libttsmimic_lang_cmulex.la \
+                             libttsmimic_lang_usenglish.la
 
 testsuite_lpc_resynth_SOURCES = testsuite/lpc_resynth_main.c
-testsuite_lpc_resynth_LDADD = libmimic.la
+testsuite_lpc_resynth_LDADD = libttsmimic.la
 
 testsuite_lpc_test2_SOURCES = testsuite/lpc_test2_main.c
-testsuite_lpc_test2_LDADD = libmimic.la
+testsuite_lpc_test2_LDADD = libttsmimic.la
 
 testsuite_lpc_test_SOURCES = testsuite/lpc_test_main.c
-testsuite_lpc_test_LDADD = libmimic.la
+testsuite_lpc_test_LDADD = libttsmimic.la
 
 testsuite_multi_thread_SOURCES = testsuite/multi_thread_main.c
 testsuite_multi_thread_CFLAGS = $(OPENMP_CFLAGS)
-testsuite_multi_thread_LDADD = libmimic.la \
-                               libmimic_lang_all_langs.la \
-                               libmimic_lang_all_voices.la \
-                               libmimic_lang_cmu_us_slt.la
+testsuite_multi_thread_LDADD = libttsmimic.la \
+                               libttsmimic_lang_all_langs.la \
+                               libttsmimic_lang_all_voices.la \
+                               libttsmimic_lang_cmu_us_slt.la
 
 testsuite_play_client_SOURCES = testsuite/play_client_main.c
-testsuite_play_client_LDADD = libmimic.la
+testsuite_play_client_LDADD = libttsmimic.la
 
 testsuite_play_server_SOURCES = testsuite/play_server_main.c
-testsuite_play_server_LDADD = libmimic.la
+testsuite_play_server_LDADD = libttsmimic.la
 
 testsuite_play_sync_SOURCES = testsuite/play_sync_main.c
-testsuite_play_sync_LDADD = libmimic.la
+testsuite_play_sync_LDADD = libttsmimic.la
 
 testsuite_play_wave_SOURCES = testsuite/play_wave_main.c
-testsuite_play_wave_LDADD = libmimic.la
+testsuite_play_wave_LDADD = libttsmimic.la
 
 testsuite_rfc_SOURCES = testsuite/rfc_main.c
-testsuite_rfc_LDADD = libmimic.la
+testsuite_rfc_LDADD = libttsmimic.la
 
 testsuite_utt_test_SOURCES = testsuite/utt_test_main.c
-testsuite_utt_test_LDADD = libmimic.la libmimic_lang_all_langs.la libmimic_lang_cmulex.la
+testsuite_utt_test_LDADD = libttsmimic.la libttsmimic_lang_all_langs.la libttsmimic_lang_cmulex.la
 
 TESTS += $(myunittests)
 # "testsuite/multi_thread_run.sh"

--- a/Makefile.am
+++ b/Makefile.am
@@ -4,11 +4,13 @@ AM_CPPFLAGS = -I$(top_srcdir)/include
 
 SUBDIRS = .
 
-langheaderdir = $(pkgincludedir)/lang/
+# instead of pkgincludedir we will use $(includedir)/ttsmimic
+headersdir = $(includedir)/ttsmimic/
+langheaderdir = $(headersdir)/lang/
 
 EXTRA_DIST = ACKNOWLEDGEMENTS COPYING 
 noinst_HEADERS = 
-pkginclude_HEADERS =
+headers_HEADERS =
 langheader_HEADERS =
 lib_LTLIBRARIES =
 
@@ -753,7 +755,7 @@ testsuite_utt_test_LDADD = libttsmimic.la libttsmimic_lang_all_langs.la libttsmi
 TESTS += $(myunittests)
 # "testsuite/multi_thread_run.sh"
 
-pkginclude_HEADERS += \
+headers_HEADERS += \
   include/cst_alloc.h \
   include/cst_args.h \
   include/cst_audio.h \

--- a/Makefile.in
+++ b/Makefile.in
@@ -175,7 +175,7 @@ DIST_COMMON = $(srcdir)/Makefile.in $(srcdir)/Makefile.am \
 	$(top_srcdir)/configure $(am__configure_deps) \
 	$(top_srcdir)/include/config.h.in $(srcdir)/mimic.pc.in \
 	$(dist_noinst_SCRIPTS) $(top_srcdir)/config/depcomp \
-	$(langheader_HEADERS) $(noinst_HEADERS) $(pkginclude_HEADERS) \
+	$(headers_HEADERS) $(langheader_HEADERS) $(noinst_HEADERS) \
 	$(top_srcdir)/config/test-driver COPYING config/ar-lib \
 	config/compile config/config.guess config/config.sub \
 	config/depcomp config/install-sh config/missing \
@@ -225,8 +225,8 @@ am__uninstall_files_from_dir = { \
          $(am__cd) "$$dir" && rm -f $$files; }; \
   }
 am__installdirs = "$(DESTDIR)$(libdir)" "$(DESTDIR)$(bindir)" \
-	"$(DESTDIR)$(pkgconfiginstalldir)" \
-	"$(DESTDIR)$(langheaderdir)" "$(DESTDIR)$(pkgincludedir)"
+	"$(DESTDIR)$(pkgconfiginstalldir)" "$(DESTDIR)$(headersdir)" \
+	"$(DESTDIR)$(langheaderdir)"
 LTLIBRARIES = $(lib_LTLIBRARIES)
 am__DEPENDENCIES_1 =
 libttsmimic_la_DEPENDENCIES = $(am__DEPENDENCIES_1) \
@@ -836,8 +836,7 @@ am__can_run_installinfo = \
     *) (install-info --version) >/dev/null 2>&1;; \
   esac
 DATA = $(pkgconfiginstall_DATA)
-HEADERS = $(langheader_HEADERS) $(noinst_HEADERS) \
-	$(pkginclude_HEADERS)
+HEADERS = $(headers_HEADERS) $(langheader_HEADERS) $(noinst_HEADERS)
 RECURSIVE_CLEAN_TARGETS = mostlyclean-recursive clean-recursive	\
   distclean-recursive maintainer-clean-recursive
 am__recursive_targets = \
@@ -1218,7 +1217,10 @@ top_srcdir = @top_srcdir@
 ACLOCAL_AMFLAGS = -I m4
 AM_CPPFLAGS = -I$(top_srcdir)/include
 SUBDIRS = .
-langheaderdir = $(pkgincludedir)/lang/
+
+# instead of pkgincludedir we will use $(includedir)/ttsmimic
+headersdir = $(includedir)/ttsmimic/
+langheaderdir = $(headersdir)/lang/
 EXTRA_DIST = ACKNOWLEDGEMENTS COPYING lang/usenglish/make_us_regexes \
 	lang/usenglish/us_pos.tree \
 	lang/cmu_grapheme_lang/make_grapheme_phoneset \
@@ -1233,7 +1235,7 @@ EXTRA_DIST = ACKNOWLEDGEMENTS COPYING lang/usenglish/make_us_regexes \
 ########## Unit tests #########################
 noinst_HEADERS = unittests/cutest.h
 # "testsuite/multi_thread_run.sh"
-pkginclude_HEADERS = include/cst_alloc.h include/cst_args.h \
+headers_HEADERS = include/cst_alloc.h include/cst_args.h \
 	include/cst_audio.h include/cst_cart.h include/cst_cg.h \
 	include/cst_clunits.h include/config.h include/cst_diphone.h \
 	include/cst_endian.h include/cst_error.h \
@@ -4014,6 +4016,27 @@ uninstall-pkgconfiginstallDATA:
 	@list='$(pkgconfiginstall_DATA)'; test -n "$(pkgconfiginstalldir)" || list=; \
 	files=`for p in $$list; do echo $$p; done | sed -e 's|^.*/||'`; \
 	dir='$(DESTDIR)$(pkgconfiginstalldir)'; $(am__uninstall_files_from_dir)
+install-headersHEADERS: $(headers_HEADERS)
+	@$(NORMAL_INSTALL)
+	@list='$(headers_HEADERS)'; test -n "$(headersdir)" || list=; \
+	if test -n "$$list"; then \
+	  echo " $(MKDIR_P) '$(DESTDIR)$(headersdir)'"; \
+	  $(MKDIR_P) "$(DESTDIR)$(headersdir)" || exit 1; \
+	fi; \
+	for p in $$list; do \
+	  if test -f "$$p"; then d=; else d="$(srcdir)/"; fi; \
+	  echo "$$d$$p"; \
+	done | $(am__base_list) | \
+	while read files; do \
+	  echo " $(INSTALL_HEADER) $$files '$(DESTDIR)$(headersdir)'"; \
+	  $(INSTALL_HEADER) $$files "$(DESTDIR)$(headersdir)" || exit $$?; \
+	done
+
+uninstall-headersHEADERS:
+	@$(NORMAL_UNINSTALL)
+	@list='$(headers_HEADERS)'; test -n "$(headersdir)" || list=; \
+	files=`for p in $$list; do echo $$p; done | sed -e 's|^.*/||'`; \
+	dir='$(DESTDIR)$(headersdir)'; $(am__uninstall_files_from_dir)
 install-langheaderHEADERS: $(langheader_HEADERS)
 	@$(NORMAL_INSTALL)
 	@list='$(langheader_HEADERS)'; test -n "$(langheaderdir)" || list=; \
@@ -4035,27 +4058,6 @@ uninstall-langheaderHEADERS:
 	@list='$(langheader_HEADERS)'; test -n "$(langheaderdir)" || list=; \
 	files=`for p in $$list; do echo $$p; done | sed -e 's|^.*/||'`; \
 	dir='$(DESTDIR)$(langheaderdir)'; $(am__uninstall_files_from_dir)
-install-pkgincludeHEADERS: $(pkginclude_HEADERS)
-	@$(NORMAL_INSTALL)
-	@list='$(pkginclude_HEADERS)'; test -n "$(pkgincludedir)" || list=; \
-	if test -n "$$list"; then \
-	  echo " $(MKDIR_P) '$(DESTDIR)$(pkgincludedir)'"; \
-	  $(MKDIR_P) "$(DESTDIR)$(pkgincludedir)" || exit 1; \
-	fi; \
-	for p in $$list; do \
-	  if test -f "$$p"; then d=; else d="$(srcdir)/"; fi; \
-	  echo "$$d$$p"; \
-	done | $(am__base_list) | \
-	while read files; do \
-	  echo " $(INSTALL_HEADER) $$files '$(DESTDIR)$(pkgincludedir)'"; \
-	  $(INSTALL_HEADER) $$files "$(DESTDIR)$(pkgincludedir)" || exit $$?; \
-	done
-
-uninstall-pkgincludeHEADERS:
-	@$(NORMAL_UNINSTALL)
-	@list='$(pkginclude_HEADERS)'; test -n "$(pkgincludedir)" || list=; \
-	files=`for p in $$list; do echo $$p; done | sed -e 's|^.*/||'`; \
-	dir='$(DESTDIR)$(pkgincludedir)'; $(am__uninstall_files_from_dir)
 
 # This directory's subdirectories are mostly independent; you can cd
 # into them and run 'make' without going through this Makefile.
@@ -4573,7 +4575,7 @@ install-binPROGRAMS: install-libLTLIBRARIES
 
 installdirs: installdirs-recursive
 installdirs-am:
-	for dir in "$(DESTDIR)$(libdir)" "$(DESTDIR)$(bindir)" "$(DESTDIR)$(pkgconfiginstalldir)" "$(DESTDIR)$(langheaderdir)" "$(DESTDIR)$(pkgincludedir)"; do \
+	for dir in "$(DESTDIR)$(libdir)" "$(DESTDIR)$(bindir)" "$(DESTDIR)$(pkgconfiginstalldir)" "$(DESTDIR)$(headersdir)" "$(DESTDIR)$(langheaderdir)"; do \
 	  test -z "$$dir" || $(MKDIR_P) "$$dir"; \
 	done
 install: install-recursive
@@ -4685,8 +4687,8 @@ info: info-recursive
 
 info-am:
 
-install-data-am: install-langheaderHEADERS \
-	install-pkgconfiginstallDATA install-pkgincludeHEADERS
+install-data-am: install-headersHEADERS install-langheaderHEADERS \
+	install-pkgconfiginstallDATA
 
 install-dvi: install-dvi-recursive
 
@@ -4734,9 +4736,9 @@ ps: ps-recursive
 
 ps-am:
 
-uninstall-am: uninstall-binPROGRAMS uninstall-langheaderHEADERS \
-	uninstall-libLTLIBRARIES uninstall-pkgconfiginstallDATA \
-	uninstall-pkgincludeHEADERS
+uninstall-am: uninstall-binPROGRAMS uninstall-headersHEADERS \
+	uninstall-langheaderHEADERS uninstall-libLTLIBRARIES \
+	uninstall-pkgconfiginstallDATA
 
 .MAKE: $(am__recursive_targets) check-am install-am install-strip
 
@@ -4751,18 +4753,18 @@ uninstall-am: uninstall-binPROGRAMS uninstall-langheaderHEADERS \
 	distuninstallcheck dvi dvi-am html html-am info info-am \
 	install install-am install-binPROGRAMS install-data \
 	install-data-am install-dvi install-dvi-am install-exec \
-	install-exec-am install-html install-html-am install-info \
-	install-info-am install-langheaderHEADERS \
-	install-libLTLIBRARIES install-man install-pdf install-pdf-am \
-	install-pkgconfiginstallDATA install-pkgincludeHEADERS \
+	install-exec-am install-headersHEADERS install-html \
+	install-html-am install-info install-info-am \
+	install-langheaderHEADERS install-libLTLIBRARIES install-man \
+	install-pdf install-pdf-am install-pkgconfiginstallDATA \
 	install-ps install-ps-am install-strip installcheck \
 	installcheck-am installdirs installdirs-am maintainer-clean \
 	maintainer-clean-generic mostlyclean mostlyclean-compile \
 	mostlyclean-generic mostlyclean-libtool pdf pdf-am ps ps-am \
 	recheck tags tags-am uninstall uninstall-am \
-	uninstall-binPROGRAMS uninstall-langheaderHEADERS \
-	uninstall-libLTLIBRARIES uninstall-pkgconfiginstallDATA \
-	uninstall-pkgincludeHEADERS
+	uninstall-binPROGRAMS uninstall-headersHEADERS \
+	uninstall-langheaderHEADERS uninstall-libLTLIBRARIES \
+	uninstall-pkgconfiginstallDATA
 
 
 # Tell versions [3.59,3.63) of GNU make to not export all variables.

--- a/Makefile.in
+++ b/Makefile.in
@@ -85,8 +85,8 @@ host_triplet = @host@
 TESTS = $(am__EXEEXT_3)
 
 ################## START: LANG_USENGLISH #################################
-@LANG_USENGLISH_TRUE@am__append_1 = libmimic_lang_usenglish.la
-@LANG_USENGLISH_TRUE@am__append_2 = libmimic_lang_usenglish.la
+@LANG_USENGLISH_TRUE@am__append_1 = libttsmimic_lang_usenglish.la
+@LANG_USENGLISH_TRUE@am__append_2 = libttsmimic_lang_usenglish.la
 
 #regexes:
 #	./make_us_regexes $(BINDIR) >us_regexes.h
@@ -99,56 +99,56 @@ TESTS = $(am__EXEEXT_3)
 ################## END: LANG_USENGLISH ###################################
 
 #################### START:  LANG_INDIC ##################################
-@LANG_INDIC_ANALYSIS_TRUE@am__append_3 = libmimic_lang_cmu_grapheme_lang.la \
-@LANG_INDIC_ANALYSIS_TRUE@                     libmimic_lang_cmu_indic_lang.la
+@LANG_INDIC_ANALYSIS_TRUE@am__append_3 = libttsmimic_lang_cmu_grapheme_lang.la \
+@LANG_INDIC_ANALYSIS_TRUE@                     libttsmimic_lang_cmu_indic_lang.la
 
-@LANG_INDIC_ANALYSIS_TRUE@am__append_4 = libmimic_lang_cmu_grapheme_lang.la \
-@LANG_INDIC_ANALYSIS_TRUE@                                       libmimic_lang_cmu_indic_lang.la
+@LANG_INDIC_ANALYSIS_TRUE@am__append_4 = libttsmimic_lang_cmu_grapheme_lang.la \
+@LANG_INDIC_ANALYSIS_TRUE@                                       libttsmimic_lang_cmu_indic_lang.la
 
 
 ################# END: LANG_INDIC ########################################
 
 ############## START: LEX_CMULEX #########################################
-@LEX_CMULEX_TRUE@am__append_5 = libmimic_lang_cmulex.la
-@LEX_CMULEX_TRUE@am__append_6 = libmimic_lang_cmulex.la
+@LEX_CMULEX_TRUE@am__append_5 = libttsmimic_lang_cmulex.la
+@LEX_CMULEX_TRUE@am__append_6 = libttsmimic_lang_cmulex.la
 
 ############## END: LEX_CMULEX ###########################################
 
 ############# START: Lexicon for indic: #################################
-@LEX_INDIC_TRUE@am__append_7 = libmimic_lang_cmu_indic_lex.la \
-@LEX_INDIC_TRUE@                       libmimic_lang_cmu_grapheme_lex.la
+@LEX_INDIC_TRUE@am__append_7 = libttsmimic_lang_cmu_indic_lex.la \
+@LEX_INDIC_TRUE@                       libttsmimic_lang_cmu_grapheme_lex.la
 
-@LEX_INDIC_TRUE@am__append_8 = libmimic_lang_cmu_indic_lex.la \
-@LEX_INDIC_TRUE@                                         libmimic_lang_cmu_grapheme_lex.la
+@LEX_INDIC_TRUE@am__append_8 = libttsmimic_lang_cmu_indic_lex.la \
+@LEX_INDIC_TRUE@                                         libttsmimic_lang_cmu_grapheme_lex.la
 
 
 # END: Lexicon for indic ####################
-@VOICE_CMU_US_KAL_TRUE@am__append_9 = libmimic_lang_cmu_us_kal.la
-@VOICE_CMU_US_KAL_TRUE@am__append_10 = libmimic_lang_cmu_us_kal.la
+@VOICE_CMU_US_KAL_TRUE@am__append_9 = libttsmimic_lang_cmu_us_kal.la
+@VOICE_CMU_US_KAL_TRUE@am__append_10 = libttsmimic_lang_cmu_us_kal.la
 
 ############
-@VOICE_CMU_TIME_AWB_TRUE@am__append_11 = libmimic_lang_cmu_time_awb.la
-@VOICE_CMU_TIME_AWB_TRUE@am__append_12 = libmimic_lang_cmu_time_awb.la
+@VOICE_CMU_TIME_AWB_TRUE@am__append_11 = libttsmimic_lang_cmu_time_awb.la
+@VOICE_CMU_TIME_AWB_TRUE@am__append_12 = libttsmimic_lang_cmu_time_awb.la
 
 ##########
-@VOICE_CMU_US_KAL16_TRUE@am__append_13 = libmimic_lang_cmu_us_kal16.la
-@VOICE_CMU_US_KAL16_TRUE@am__append_14 = libmimic_lang_cmu_us_kal16.la
+@VOICE_CMU_US_KAL16_TRUE@am__append_13 = libttsmimic_lang_cmu_us_kal16.la
+@VOICE_CMU_US_KAL16_TRUE@am__append_14 = libttsmimic_lang_cmu_us_kal16.la
 
 ####################
-@VOICE_CMU_US_AWB_TRUE@am__append_15 = libmimic_lang_cmu_us_awb.la
-@VOICE_CMU_US_AWB_TRUE@am__append_16 = libmimic_lang_cmu_us_awb.la
+@VOICE_CMU_US_AWB_TRUE@am__append_15 = libttsmimic_lang_cmu_us_awb.la
+@VOICE_CMU_US_AWB_TRUE@am__append_16 = libttsmimic_lang_cmu_us_awb.la
 
 ###########
-@VOICE_CMU_US_RMS_TRUE@am__append_17 = libmimic_lang_cmu_us_rms.la
-@VOICE_CMU_US_RMS_TRUE@am__append_18 = libmimic_lang_cmu_us_rms.la
+@VOICE_CMU_US_RMS_TRUE@am__append_17 = libttsmimic_lang_cmu_us_rms.la
+@VOICE_CMU_US_RMS_TRUE@am__append_18 = libttsmimic_lang_cmu_us_rms.la
 
 ###############
-@VOICE_CMU_US_SLT_TRUE@am__append_19 = libmimic_lang_cmu_us_slt.la
-@VOICE_CMU_US_SLT_TRUE@am__append_20 = libmimic_lang_cmu_us_slt.la
+@VOICE_CMU_US_SLT_TRUE@am__append_19 = libttsmimic_lang_cmu_us_slt.la
+@VOICE_CMU_US_SLT_TRUE@am__append_20 = libttsmimic_lang_cmu_us_slt.la
 
 ###########
-@VOICE_VID_GB_AP_TRUE@am__append_21 = libmimic_lang_vid_gb_ap.la
-@VOICE_VID_GB_AP_TRUE@am__append_22 = libmimic_lang_vid_gb_ap.la
+@VOICE_VID_GB_AP_TRUE@am__append_21 = libttsmimic_lang_vid_gb_ap.la
+@VOICE_VID_GB_AP_TRUE@am__append_22 = libttsmimic_lang_vid_gb_ap.la
 bin_PROGRAMS = mimic$(EXEEXT) compile_regexes$(EXEEXT) \
 	mimicvox_info$(EXEEXT) $(am__EXEEXT_1)
 @LANG_USENGLISH_TRUE@@LEX_CMULEX_TRUE@am__append_23 = t2p mimic_time
@@ -229,286 +229,294 @@ am__installdirs = "$(DESTDIR)$(libdir)" "$(DESTDIR)$(bindir)" \
 	"$(DESTDIR)$(langheaderdir)" "$(DESTDIR)$(pkgincludedir)"
 LTLIBRARIES = $(lib_LTLIBRARIES)
 am__DEPENDENCIES_1 =
-libmimic_la_DEPENDENCIES = $(am__DEPENDENCIES_1) $(am__DEPENDENCIES_1)
+libttsmimic_la_DEPENDENCIES = $(am__DEPENDENCIES_1) \
+	$(am__DEPENDENCIES_1)
 am__dirstamp = $(am__leading_dot)dirstamp
-am__objects_1 = src/audio/libmimic_la-au_alsa.lo \
-	src/audio/libmimic_la-auclient.lo \
-	src/audio/libmimic_la-au_command.lo \
-	src/audio/libmimic_la-audio.lo \
-	src/audio/libmimic_la-au_none.lo \
-	src/audio/libmimic_la-au_oss.lo \
-	src/audio/libmimic_la-au_portaudio.lo \
-	src/audio/libmimic_la-au_pulseaudio.lo \
-	src/audio/libmimic_la-auserver.lo \
-	src/audio/libmimic_la-au_streaming.lo \
-	src/audio/libmimic_la-au_sun.lo \
-	src/audio/libmimic_la-au_wince.lo
-am_libmimic_la_OBJECTS = $(am__objects_1) src/cg/libmimic_la-cst_cg.lo \
-	src/cg/libmimic_la-cst_mlsa.lo src/cg/libmimic_la-cst_mlpg.lo \
-	src/cg/libmimic_la-cst_vc.lo \
-	src/cg/libmimic_la-cst_cg_load_voice.lo \
-	src/cg/libmimic_la-cst_cg_dump_voice.lo \
-	src/cg/libmimic_la-cst_cg_map.lo \
-	src/cg/libmimic_la-cst_spamf0.lo \
-	src/hrg/libmimic_la-cst_utterance.lo \
-	src/hrg/libmimic_la-cst_relation.lo \
-	src/hrg/libmimic_la-cst_item.lo \
-	src/hrg/libmimic_la-cst_ffeature.lo \
-	src/hrg/libmimic_la-cst_rel_io.lo \
-	src/lexicon/libmimic_la-cst_lexicon.lo \
-	src/lexicon/libmimic_la-cst_lts.lo \
-	src/lexicon/libmimic_la-cst_lts_rewrites.lo \
-	src/regex/libmimic_la-cst_regex.lo \
-	src/regex/libmimic_la-regexp.lo \
-	src/regex/libmimic_la-regsub.lo \
-	src/speech/libmimic_la-cst_lpcres.lo \
-	src/speech/libmimic_la-cst_track.lo \
-	src/speech/libmimic_la-cst_track_io.lo \
-	src/speech/libmimic_la-cst_wave.lo \
-	src/speech/libmimic_la-cst_wave_io.lo \
-	src/speech/libmimic_la-cst_wave_utils.lo \
-	src/speech/libmimic_la-g721.lo \
-	src/speech/libmimic_la-g723_24.lo \
-	src/speech/libmimic_la-g723_40.lo \
-	src/speech/libmimic_la-g72x.lo \
-	src/speech/libmimic_la-rateconv.lo \
-	src/stats/libmimic_la-cst_cart.lo \
-	src/stats/libmimic_la-cst_ss.lo \
-	src/stats/libmimic_la-cst_viterbi.lo \
-	src/synth/libmimic_la-cst_ffeatures.lo \
-	src/synth/libmimic_la-cst_phoneset.lo \
-	src/synth/libmimic_la-cst_ssml.lo \
-	src/synth/libmimic_la-cst_synth.lo \
-	src/synth/libmimic_la-cst_utt_utils.lo \
-	src/synth/libmimic_la-cst_voice.lo \
-	src/synth/libmimic_la-mimic.lo \
-	src/utils/libmimic_la-cst_alloc.lo \
-	src/utils/libmimic_la-cst_args.lo \
-	src/utils/libmimic_la-cst_endian.lo \
-	src/utils/libmimic_la-cst_error.lo \
-	src/utils/libmimic_la-cst_features.lo \
-	src/utils/libmimic_la-cst_file_stdio.lo \
-	src/utils/libmimic_la-cst_mmap_none.lo \
-	src/utils/libmimic_la-cst_mmap_posix.lo \
-	src/utils/libmimic_la-cst_mmap_win32.lo \
-	src/utils/libmimic_la-cst_socket.lo \
-	src/utils/libmimic_la-cst_string.lo \
-	src/utils/libmimic_la-cst_tokenstream.lo \
-	src/utils/libmimic_la-cst_url.lo \
-	src/utils/libmimic_la-cst_val.lo \
-	src/utils/libmimic_la-cst_val_const.lo \
-	src/utils/libmimic_la-cst_val_user.lo \
-	src/utils/libmimic_la-cst_wchar.lo \
-	src/wavesynth/libmimic_la-cst_clunits.lo \
-	src/wavesynth/libmimic_la-cst_diphone.lo \
-	src/wavesynth/libmimic_la-cst_reflpc.lo \
-	src/wavesynth/libmimic_la-cst_sigpr.lo \
-	src/wavesynth/libmimic_la-cst_sts.lo \
-	src/wavesynth/libmimic_la-cst_units.lo
-libmimic_la_OBJECTS = $(am_libmimic_la_OBJECTS)
+am__objects_1 = src/audio/libttsmimic_la-au_alsa.lo \
+	src/audio/libttsmimic_la-auclient.lo \
+	src/audio/libttsmimic_la-au_command.lo \
+	src/audio/libttsmimic_la-audio.lo \
+	src/audio/libttsmimic_la-au_none.lo \
+	src/audio/libttsmimic_la-au_oss.lo \
+	src/audio/libttsmimic_la-au_portaudio.lo \
+	src/audio/libttsmimic_la-au_pulseaudio.lo \
+	src/audio/libttsmimic_la-auserver.lo \
+	src/audio/libttsmimic_la-au_streaming.lo \
+	src/audio/libttsmimic_la-au_sun.lo \
+	src/audio/libttsmimic_la-au_wince.lo
+am_libttsmimic_la_OBJECTS = $(am__objects_1) \
+	src/cg/libttsmimic_la-cst_cg.lo \
+	src/cg/libttsmimic_la-cst_mlsa.lo \
+	src/cg/libttsmimic_la-cst_mlpg.lo \
+	src/cg/libttsmimic_la-cst_vc.lo \
+	src/cg/libttsmimic_la-cst_cg_load_voice.lo \
+	src/cg/libttsmimic_la-cst_cg_dump_voice.lo \
+	src/cg/libttsmimic_la-cst_cg_map.lo \
+	src/cg/libttsmimic_la-cst_spamf0.lo \
+	src/hrg/libttsmimic_la-cst_utterance.lo \
+	src/hrg/libttsmimic_la-cst_relation.lo \
+	src/hrg/libttsmimic_la-cst_item.lo \
+	src/hrg/libttsmimic_la-cst_ffeature.lo \
+	src/hrg/libttsmimic_la-cst_rel_io.lo \
+	src/lexicon/libttsmimic_la-cst_lexicon.lo \
+	src/lexicon/libttsmimic_la-cst_lts.lo \
+	src/lexicon/libttsmimic_la-cst_lts_rewrites.lo \
+	src/regex/libttsmimic_la-cst_regex.lo \
+	src/regex/libttsmimic_la-regexp.lo \
+	src/regex/libttsmimic_la-regsub.lo \
+	src/speech/libttsmimic_la-cst_lpcres.lo \
+	src/speech/libttsmimic_la-cst_track.lo \
+	src/speech/libttsmimic_la-cst_track_io.lo \
+	src/speech/libttsmimic_la-cst_wave.lo \
+	src/speech/libttsmimic_la-cst_wave_io.lo \
+	src/speech/libttsmimic_la-cst_wave_utils.lo \
+	src/speech/libttsmimic_la-g721.lo \
+	src/speech/libttsmimic_la-g723_24.lo \
+	src/speech/libttsmimic_la-g723_40.lo \
+	src/speech/libttsmimic_la-g72x.lo \
+	src/speech/libttsmimic_la-rateconv.lo \
+	src/stats/libttsmimic_la-cst_cart.lo \
+	src/stats/libttsmimic_la-cst_ss.lo \
+	src/stats/libttsmimic_la-cst_viterbi.lo \
+	src/synth/libttsmimic_la-cst_ffeatures.lo \
+	src/synth/libttsmimic_la-cst_phoneset.lo \
+	src/synth/libttsmimic_la-cst_ssml.lo \
+	src/synth/libttsmimic_la-cst_synth.lo \
+	src/synth/libttsmimic_la-cst_utt_utils.lo \
+	src/synth/libttsmimic_la-cst_voice.lo \
+	src/synth/libttsmimic_la-mimic.lo \
+	src/utils/libttsmimic_la-cst_alloc.lo \
+	src/utils/libttsmimic_la-cst_args.lo \
+	src/utils/libttsmimic_la-cst_endian.lo \
+	src/utils/libttsmimic_la-cst_error.lo \
+	src/utils/libttsmimic_la-cst_features.lo \
+	src/utils/libttsmimic_la-cst_file_stdio.lo \
+	src/utils/libttsmimic_la-cst_mmap_none.lo \
+	src/utils/libttsmimic_la-cst_mmap_posix.lo \
+	src/utils/libttsmimic_la-cst_mmap_win32.lo \
+	src/utils/libttsmimic_la-cst_socket.lo \
+	src/utils/libttsmimic_la-cst_string.lo \
+	src/utils/libttsmimic_la-cst_tokenstream.lo \
+	src/utils/libttsmimic_la-cst_url.lo \
+	src/utils/libttsmimic_la-cst_val.lo \
+	src/utils/libttsmimic_la-cst_val_const.lo \
+	src/utils/libttsmimic_la-cst_val_user.lo \
+	src/utils/libttsmimic_la-cst_wchar.lo \
+	src/wavesynth/libttsmimic_la-cst_clunits.lo \
+	src/wavesynth/libttsmimic_la-cst_diphone.lo \
+	src/wavesynth/libttsmimic_la-cst_reflpc.lo \
+	src/wavesynth/libttsmimic_la-cst_sigpr.lo \
+	src/wavesynth/libttsmimic_la-cst_sts.lo \
+	src/wavesynth/libttsmimic_la-cst_units.lo
+libttsmimic_la_OBJECTS = $(am_libttsmimic_la_OBJECTS)
 AM_V_lt = $(am__v_lt_@AM_V@)
 am__v_lt_ = $(am__v_lt_@AM_DEFAULT_V@)
 am__v_lt_0 = --silent
 am__v_lt_1 = 
-libmimic_la_LINK = $(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) \
-	$(LIBTOOLFLAGS) --mode=link $(CCLD) $(libmimic_la_CFLAGS) \
-	$(CFLAGS) $(libmimic_la_LDFLAGS) $(LDFLAGS) -o $@
-libmimic_lang_all_langs_la_DEPENDENCIES = libmimic.la $(am__append_2) \
-	$(am__append_4) $(am__append_6) $(am__append_8)
-am_libmimic_lang_all_langs_la_OBJECTS = main/mimic_lang_list.lo
-libmimic_lang_all_langs_la_OBJECTS =  \
-	$(am_libmimic_lang_all_langs_la_OBJECTS)
-libmimic_lang_all_langs_la_LINK = $(LIBTOOL) $(AM_V_lt) --tag=CC \
+libttsmimic_la_LINK = $(LIBTOOL) $(AM_V_lt) --tag=CC \
 	$(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=link $(CCLD) \
-	$(AM_CFLAGS) $(CFLAGS) $(libmimic_lang_all_langs_la_LDFLAGS) \
+	$(libttsmimic_la_CFLAGS) $(CFLAGS) $(libttsmimic_la_LDFLAGS) \
 	$(LDFLAGS) -o $@
-libmimic_lang_all_voices_la_DEPENDENCIES = libmimic.la \
+libttsmimic_lang_all_langs_la_DEPENDENCIES = libttsmimic.la \
+	$(am__append_2) $(am__append_4) $(am__append_6) \
+	$(am__append_8)
+am_libttsmimic_lang_all_langs_la_OBJECTS = main/mimic_lang_list.lo
+libttsmimic_lang_all_langs_la_OBJECTS =  \
+	$(am_libttsmimic_lang_all_langs_la_OBJECTS)
+libttsmimic_lang_all_langs_la_LINK = $(LIBTOOL) $(AM_V_lt) --tag=CC \
+	$(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=link $(CCLD) \
+	$(AM_CFLAGS) $(CFLAGS) \
+	$(libttsmimic_lang_all_langs_la_LDFLAGS) $(LDFLAGS) -o $@
+libttsmimic_lang_all_voices_la_DEPENDENCIES = libttsmimic.la \
 	$(am__append_10) $(am__append_12) $(am__append_14) \
 	$(am__append_16) $(am__append_18) $(am__append_20) \
 	$(am__append_22)
-am_libmimic_lang_all_voices_la_OBJECTS = main/mimic_voice_list.lo
-libmimic_lang_all_voices_la_OBJECTS =  \
-	$(am_libmimic_lang_all_voices_la_OBJECTS)
-libmimic_lang_all_voices_la_LINK = $(LIBTOOL) $(AM_V_lt) --tag=CC \
+am_libttsmimic_lang_all_voices_la_OBJECTS = main/mimic_voice_list.lo
+libttsmimic_lang_all_voices_la_OBJECTS =  \
+	$(am_libttsmimic_lang_all_voices_la_OBJECTS)
+libttsmimic_lang_all_voices_la_LINK = $(LIBTOOL) $(AM_V_lt) --tag=CC \
 	$(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=link $(CCLD) \
-	$(AM_CFLAGS) $(CFLAGS) $(libmimic_lang_all_voices_la_LDFLAGS) \
-	$(LDFLAGS) -o $@
-libmimic_lang_cmu_grapheme_lang_la_DEPENDENCIES = libmimic.la
-am_libmimic_lang_cmu_grapheme_lang_la_OBJECTS =  \
+	$(AM_CFLAGS) $(CFLAGS) \
+	$(libttsmimic_lang_all_voices_la_LDFLAGS) $(LDFLAGS) -o $@
+libttsmimic_lang_cmu_grapheme_lang_la_DEPENDENCIES = libttsmimic.la
+am_libttsmimic_lang_cmu_grapheme_lang_la_OBJECTS =  \
 	lang/cmu_grapheme_lang/cmu_grapheme_lang.lo \
 	lang/cmu_grapheme_lang/cmu_grapheme_phrasing_cart.lo \
 	lang/cmu_grapheme_lang/cmu_grapheme_phoneset.lo
-libmimic_lang_cmu_grapheme_lang_la_OBJECTS =  \
-	$(am_libmimic_lang_cmu_grapheme_lang_la_OBJECTS)
-libmimic_lang_cmu_grapheme_lang_la_LINK = $(LIBTOOL) $(AM_V_lt) \
+libttsmimic_lang_cmu_grapheme_lang_la_OBJECTS =  \
+	$(am_libttsmimic_lang_cmu_grapheme_lang_la_OBJECTS)
+libttsmimic_lang_cmu_grapheme_lang_la_LINK = $(LIBTOOL) $(AM_V_lt) \
 	--tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=link \
 	$(CCLD) $(AM_CFLAGS) $(CFLAGS) \
-	$(libmimic_lang_cmu_grapheme_lang_la_LDFLAGS) $(LDFLAGS) -o $@
-@LANG_INDIC_ANALYSIS_TRUE@am_libmimic_lang_cmu_grapheme_lang_la_rpath =  \
+	$(libttsmimic_lang_cmu_grapheme_lang_la_LDFLAGS) $(LDFLAGS) -o \
+	$@
+@LANG_INDIC_ANALYSIS_TRUE@am_libttsmimic_lang_cmu_grapheme_lang_la_rpath =  \
 @LANG_INDIC_ANALYSIS_TRUE@	-rpath $(libdir)
-libmimic_lang_cmu_grapheme_lex_la_DEPENDENCIES = libmimic.la
-am_libmimic_lang_cmu_grapheme_lex_la_OBJECTS =  \
+libttsmimic_lang_cmu_grapheme_lex_la_DEPENDENCIES = libttsmimic.la
+am_libttsmimic_lang_cmu_grapheme_lex_la_OBJECTS =  \
 	lang/cmu_grapheme_lex/cmu_grapheme_lex.lo \
 	lang/cmu_grapheme_lex/grapheme_unitran_tables.lo
-libmimic_lang_cmu_grapheme_lex_la_OBJECTS =  \
-	$(am_libmimic_lang_cmu_grapheme_lex_la_OBJECTS)
-libmimic_lang_cmu_grapheme_lex_la_LINK = $(LIBTOOL) $(AM_V_lt) \
+libttsmimic_lang_cmu_grapheme_lex_la_OBJECTS =  \
+	$(am_libttsmimic_lang_cmu_grapheme_lex_la_OBJECTS)
+libttsmimic_lang_cmu_grapheme_lex_la_LINK = $(LIBTOOL) $(AM_V_lt) \
 	--tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=link \
 	$(CCLD) $(AM_CFLAGS) $(CFLAGS) \
-	$(libmimic_lang_cmu_grapheme_lex_la_LDFLAGS) $(LDFLAGS) -o $@
-@LEX_INDIC_TRUE@am_libmimic_lang_cmu_grapheme_lex_la_rpath = -rpath \
-@LEX_INDIC_TRUE@	$(libdir)
-libmimic_lang_cmu_indic_lang_la_DEPENDENCIES = libmimic.la \
-	libmimic_lang_usenglish.la
-am_libmimic_lang_cmu_indic_lang_la_OBJECTS =  \
+	$(libttsmimic_lang_cmu_grapheme_lex_la_LDFLAGS) $(LDFLAGS) -o \
+	$@
+@LEX_INDIC_TRUE@am_libttsmimic_lang_cmu_grapheme_lex_la_rpath =  \
+@LEX_INDIC_TRUE@	-rpath $(libdir)
+libttsmimic_lang_cmu_indic_lang_la_DEPENDENCIES = libttsmimic.la \
+	libttsmimic_lang_usenglish.la
+am_libttsmimic_lang_cmu_indic_lang_la_OBJECTS =  \
 	lang/cmu_indic_lang/cmu_indic_lang.lo \
 	lang/cmu_indic_lang/cmu_indic_phoneset.lo \
 	lang/cmu_indic_lang/cmu_indic_phrasing_cart.lo
-libmimic_lang_cmu_indic_lang_la_OBJECTS =  \
-	$(am_libmimic_lang_cmu_indic_lang_la_OBJECTS)
-libmimic_lang_cmu_indic_lang_la_LINK = $(LIBTOOL) $(AM_V_lt) --tag=CC \
-	$(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=link $(CCLD) \
-	$(AM_CFLAGS) $(CFLAGS) \
-	$(libmimic_lang_cmu_indic_lang_la_LDFLAGS) $(LDFLAGS) -o $@
-@LANG_INDIC_ANALYSIS_TRUE@am_libmimic_lang_cmu_indic_lang_la_rpath =  \
+libttsmimic_lang_cmu_indic_lang_la_OBJECTS =  \
+	$(am_libttsmimic_lang_cmu_indic_lang_la_OBJECTS)
+libttsmimic_lang_cmu_indic_lang_la_LINK = $(LIBTOOL) $(AM_V_lt) \
+	--tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=link \
+	$(CCLD) $(AM_CFLAGS) $(CFLAGS) \
+	$(libttsmimic_lang_cmu_indic_lang_la_LDFLAGS) $(LDFLAGS) -o $@
+@LANG_INDIC_ANALYSIS_TRUE@am_libttsmimic_lang_cmu_indic_lang_la_rpath =  \
 @LANG_INDIC_ANALYSIS_TRUE@	-rpath $(libdir)
-libmimic_lang_cmu_indic_lex_la_DEPENDENCIES = libmimic.la \
-	libmimic_lang_cmulex.la libmimic_lang_cmu_indic_lang.la
-am_libmimic_lang_cmu_indic_lex_la_OBJECTS =  \
+libttsmimic_lang_cmu_indic_lex_la_DEPENDENCIES = libttsmimic.la \
+	libttsmimic_lang_cmulex.la libttsmimic_lang_cmu_indic_lang.la
+am_libttsmimic_lang_cmu_indic_lex_la_OBJECTS =  \
 	lang/cmu_indic_lex/cmu_indic_lex.lo
-libmimic_lang_cmu_indic_lex_la_OBJECTS =  \
-	$(am_libmimic_lang_cmu_indic_lex_la_OBJECTS)
-libmimic_lang_cmu_indic_lex_la_LINK = $(LIBTOOL) $(AM_V_lt) --tag=CC \
-	$(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=link $(CCLD) \
-	$(AM_CFLAGS) $(CFLAGS) \
-	$(libmimic_lang_cmu_indic_lex_la_LDFLAGS) $(LDFLAGS) -o $@
-@LEX_INDIC_TRUE@am_libmimic_lang_cmu_indic_lex_la_rpath = -rpath \
+libttsmimic_lang_cmu_indic_lex_la_OBJECTS =  \
+	$(am_libttsmimic_lang_cmu_indic_lex_la_OBJECTS)
+libttsmimic_lang_cmu_indic_lex_la_LINK = $(LIBTOOL) $(AM_V_lt) \
+	--tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=link \
+	$(CCLD) $(AM_CFLAGS) $(CFLAGS) \
+	$(libttsmimic_lang_cmu_indic_lex_la_LDFLAGS) $(LDFLAGS) -o $@
+@LEX_INDIC_TRUE@am_libttsmimic_lang_cmu_indic_lex_la_rpath = -rpath \
 @LEX_INDIC_TRUE@	$(libdir)
-libmimic_lang_cmu_time_awb_la_DEPENDENCIES = libmimic.la \
-	libmimic_lang_cmulex.la libmimic_lang_usenglish.la
-am_libmimic_lang_cmu_time_awb_la_OBJECTS = lang/cmu_time_awb/libmimic_lang_cmu_time_awb_la-cmu_time_awb.lo \
-	lang/cmu_time_awb/libmimic_lang_cmu_time_awb_la-cmu_time_awb_cart.lo \
-	lang/cmu_time_awb/libmimic_lang_cmu_time_awb_la-cmu_time_awb_clunits.lo \
-	lang/cmu_time_awb/libmimic_lang_cmu_time_awb_la-cmu_time_awb_lex_entry.lo \
-	lang/cmu_time_awb/libmimic_lang_cmu_time_awb_la-cmu_time_awb_lpc.lo \
-	lang/cmu_time_awb/libmimic_lang_cmu_time_awb_la-cmu_time_awb_mcep.lo
-libmimic_lang_cmu_time_awb_la_OBJECTS =  \
-	$(am_libmimic_lang_cmu_time_awb_la_OBJECTS)
-libmimic_lang_cmu_time_awb_la_LINK = $(LIBTOOL) $(AM_V_lt) --tag=CC \
+libttsmimic_lang_cmu_time_awb_la_DEPENDENCIES = libttsmimic.la \
+	libttsmimic_lang_cmulex.la libttsmimic_lang_usenglish.la
+am_libttsmimic_lang_cmu_time_awb_la_OBJECTS = lang/cmu_time_awb/libttsmimic_lang_cmu_time_awb_la-cmu_time_awb.lo \
+	lang/cmu_time_awb/libttsmimic_lang_cmu_time_awb_la-cmu_time_awb_cart.lo \
+	lang/cmu_time_awb/libttsmimic_lang_cmu_time_awb_la-cmu_time_awb_clunits.lo \
+	lang/cmu_time_awb/libttsmimic_lang_cmu_time_awb_la-cmu_time_awb_lex_entry.lo \
+	lang/cmu_time_awb/libttsmimic_lang_cmu_time_awb_la-cmu_time_awb_lpc.lo \
+	lang/cmu_time_awb/libttsmimic_lang_cmu_time_awb_la-cmu_time_awb_mcep.lo
+libttsmimic_lang_cmu_time_awb_la_OBJECTS =  \
+	$(am_libttsmimic_lang_cmu_time_awb_la_OBJECTS)
+libttsmimic_lang_cmu_time_awb_la_LINK = $(LIBTOOL) $(AM_V_lt) --tag=CC \
 	$(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=link $(CCLD) \
-	$(libmimic_lang_cmu_time_awb_la_CFLAGS) $(CFLAGS) \
-	$(libmimic_lang_cmu_time_awb_la_LDFLAGS) $(LDFLAGS) -o $@
-@VOICE_CMU_TIME_AWB_TRUE@am_libmimic_lang_cmu_time_awb_la_rpath =  \
+	$(libttsmimic_lang_cmu_time_awb_la_CFLAGS) $(CFLAGS) \
+	$(libttsmimic_lang_cmu_time_awb_la_LDFLAGS) $(LDFLAGS) -o $@
+@VOICE_CMU_TIME_AWB_TRUE@am_libttsmimic_lang_cmu_time_awb_la_rpath =  \
 @VOICE_CMU_TIME_AWB_TRUE@	-rpath $(libdir)
-libmimic_lang_cmu_us_awb_la_DEPENDENCIES = libmimic.la \
-	libmimic_lang_cmulex.la libmimic_lang_usenglish.la
-am_libmimic_lang_cmu_us_awb_la_OBJECTS =  \
-	lang/cmu_us_awb/libmimic_lang_cmu_us_awb_la-cmu_us_awb.lo \
-	lang/cmu_us_awb/libmimic_lang_cmu_us_awb_la-cmu_us_awb_cg.lo \
-	lang/cmu_us_awb/libmimic_lang_cmu_us_awb_la-cmu_us_awb_cg_durmodel.lo \
-	lang/cmu_us_awb/libmimic_lang_cmu_us_awb_la-cmu_us_awb_cg_f0_trees.lo \
-	lang/cmu_us_awb/libmimic_lang_cmu_us_awb_la-cmu_us_awb_cg_phonestate.lo \
-	lang/cmu_us_awb/libmimic_lang_cmu_us_awb_la-cmu_us_awb_cg_single_mcep_trees.lo \
-	lang/cmu_us_awb/libmimic_lang_cmu_us_awb_la-cmu_us_awb_cg_single_params.lo \
-	lang/cmu_us_awb/libmimic_lang_cmu_us_awb_la-cmu_us_awb_spamf0_accent.lo \
-	lang/cmu_us_awb/libmimic_lang_cmu_us_awb_la-cmu_us_awb_spamf0_accent_params.lo \
-	lang/cmu_us_awb/libmimic_lang_cmu_us_awb_la-cmu_us_awb_spamf0_phrase.lo
-libmimic_lang_cmu_us_awb_la_OBJECTS =  \
-	$(am_libmimic_lang_cmu_us_awb_la_OBJECTS)
-libmimic_lang_cmu_us_awb_la_LINK = $(LIBTOOL) $(AM_V_lt) --tag=CC \
+libttsmimic_lang_cmu_us_awb_la_DEPENDENCIES = libttsmimic.la \
+	libttsmimic_lang_cmulex.la libttsmimic_lang_usenglish.la
+am_libttsmimic_lang_cmu_us_awb_la_OBJECTS =  \
+	lang/cmu_us_awb/libttsmimic_lang_cmu_us_awb_la-cmu_us_awb.lo \
+	lang/cmu_us_awb/libttsmimic_lang_cmu_us_awb_la-cmu_us_awb_cg.lo \
+	lang/cmu_us_awb/libttsmimic_lang_cmu_us_awb_la-cmu_us_awb_cg_durmodel.lo \
+	lang/cmu_us_awb/libttsmimic_lang_cmu_us_awb_la-cmu_us_awb_cg_f0_trees.lo \
+	lang/cmu_us_awb/libttsmimic_lang_cmu_us_awb_la-cmu_us_awb_cg_phonestate.lo \
+	lang/cmu_us_awb/libttsmimic_lang_cmu_us_awb_la-cmu_us_awb_cg_single_mcep_trees.lo \
+	lang/cmu_us_awb/libttsmimic_lang_cmu_us_awb_la-cmu_us_awb_cg_single_params.lo \
+	lang/cmu_us_awb/libttsmimic_lang_cmu_us_awb_la-cmu_us_awb_spamf0_accent.lo \
+	lang/cmu_us_awb/libttsmimic_lang_cmu_us_awb_la-cmu_us_awb_spamf0_accent_params.lo \
+	lang/cmu_us_awb/libttsmimic_lang_cmu_us_awb_la-cmu_us_awb_spamf0_phrase.lo
+libttsmimic_lang_cmu_us_awb_la_OBJECTS =  \
+	$(am_libttsmimic_lang_cmu_us_awb_la_OBJECTS)
+libttsmimic_lang_cmu_us_awb_la_LINK = $(LIBTOOL) $(AM_V_lt) --tag=CC \
 	$(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=link $(CCLD) \
-	$(libmimic_lang_cmu_us_awb_la_CFLAGS) $(CFLAGS) \
-	$(libmimic_lang_cmu_us_awb_la_LDFLAGS) $(LDFLAGS) -o $@
-@VOICE_CMU_US_AWB_TRUE@am_libmimic_lang_cmu_us_awb_la_rpath = -rpath \
-@VOICE_CMU_US_AWB_TRUE@	$(libdir)
-libmimic_lang_cmu_us_kal_la_DEPENDENCIES = libmimic.la \
-	libmimic_lang_cmulex.la libmimic_lang_usenglish.la
-am_libmimic_lang_cmu_us_kal_la_OBJECTS =  \
-	lang/cmu_us_kal/libmimic_lang_cmu_us_kal_la-cmu_us_kal.lo \
-	lang/cmu_us_kal/libmimic_lang_cmu_us_kal_la-cmu_us_kal_diphone.lo \
-	lang/cmu_us_kal/libmimic_lang_cmu_us_kal_la-cmu_us_kal_lpc.lo \
-	lang/cmu_us_kal/libmimic_lang_cmu_us_kal_la-cmu_us_kal_res.lo \
-	lang/cmu_us_kal/libmimic_lang_cmu_us_kal_la-cmu_us_kal_residx.lo \
-	lang/cmu_us_kal/libmimic_lang_cmu_us_kal_la-cmu_us_kal_ressize.lo
-libmimic_lang_cmu_us_kal_la_OBJECTS =  \
-	$(am_libmimic_lang_cmu_us_kal_la_OBJECTS)
-libmimic_lang_cmu_us_kal_la_LINK = $(LIBTOOL) $(AM_V_lt) --tag=CC \
+	$(libttsmimic_lang_cmu_us_awb_la_CFLAGS) $(CFLAGS) \
+	$(libttsmimic_lang_cmu_us_awb_la_LDFLAGS) $(LDFLAGS) -o $@
+@VOICE_CMU_US_AWB_TRUE@am_libttsmimic_lang_cmu_us_awb_la_rpath =  \
+@VOICE_CMU_US_AWB_TRUE@	-rpath $(libdir)
+libttsmimic_lang_cmu_us_kal_la_DEPENDENCIES = libttsmimic.la \
+	libttsmimic_lang_cmulex.la libttsmimic_lang_usenglish.la
+am_libttsmimic_lang_cmu_us_kal_la_OBJECTS =  \
+	lang/cmu_us_kal/libttsmimic_lang_cmu_us_kal_la-cmu_us_kal.lo \
+	lang/cmu_us_kal/libttsmimic_lang_cmu_us_kal_la-cmu_us_kal_diphone.lo \
+	lang/cmu_us_kal/libttsmimic_lang_cmu_us_kal_la-cmu_us_kal_lpc.lo \
+	lang/cmu_us_kal/libttsmimic_lang_cmu_us_kal_la-cmu_us_kal_res.lo \
+	lang/cmu_us_kal/libttsmimic_lang_cmu_us_kal_la-cmu_us_kal_residx.lo \
+	lang/cmu_us_kal/libttsmimic_lang_cmu_us_kal_la-cmu_us_kal_ressize.lo
+libttsmimic_lang_cmu_us_kal_la_OBJECTS =  \
+	$(am_libttsmimic_lang_cmu_us_kal_la_OBJECTS)
+libttsmimic_lang_cmu_us_kal_la_LINK = $(LIBTOOL) $(AM_V_lt) --tag=CC \
 	$(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=link $(CCLD) \
-	$(libmimic_lang_cmu_us_kal_la_CFLAGS) $(CFLAGS) \
-	$(libmimic_lang_cmu_us_kal_la_LDFLAGS) $(LDFLAGS) -o $@
-@VOICE_CMU_US_KAL_TRUE@am_libmimic_lang_cmu_us_kal_la_rpath = -rpath \
-@VOICE_CMU_US_KAL_TRUE@	$(libdir)
-libmimic_lang_cmu_us_kal16_la_DEPENDENCIES = libmimic.la \
-	libmimic_lang_cmulex.la libmimic_lang_usenglish.la
-am_libmimic_lang_cmu_us_kal16_la_OBJECTS = lang/cmu_us_kal16/libmimic_lang_cmu_us_kal16_la-cmu_us_kal16.lo \
-	lang/cmu_us_kal16/libmimic_lang_cmu_us_kal16_la-cmu_us_kal16_diphone.lo \
-	lang/cmu_us_kal16/libmimic_lang_cmu_us_kal16_la-cmu_us_kal16_lpc.lo \
-	lang/cmu_us_kal16/libmimic_lang_cmu_us_kal16_la-cmu_us_kal16_res.lo \
-	lang/cmu_us_kal16/libmimic_lang_cmu_us_kal16_la-cmu_us_kal16_residx.lo
-libmimic_lang_cmu_us_kal16_la_OBJECTS =  \
-	$(am_libmimic_lang_cmu_us_kal16_la_OBJECTS)
-libmimic_lang_cmu_us_kal16_la_LINK = $(LIBTOOL) $(AM_V_lt) --tag=CC \
+	$(libttsmimic_lang_cmu_us_kal_la_CFLAGS) $(CFLAGS) \
+	$(libttsmimic_lang_cmu_us_kal_la_LDFLAGS) $(LDFLAGS) -o $@
+@VOICE_CMU_US_KAL_TRUE@am_libttsmimic_lang_cmu_us_kal_la_rpath =  \
+@VOICE_CMU_US_KAL_TRUE@	-rpath $(libdir)
+libttsmimic_lang_cmu_us_kal16_la_DEPENDENCIES = libttsmimic.la \
+	libttsmimic_lang_cmulex.la libttsmimic_lang_usenglish.la
+am_libttsmimic_lang_cmu_us_kal16_la_OBJECTS = lang/cmu_us_kal16/libttsmimic_lang_cmu_us_kal16_la-cmu_us_kal16.lo \
+	lang/cmu_us_kal16/libttsmimic_lang_cmu_us_kal16_la-cmu_us_kal16_diphone.lo \
+	lang/cmu_us_kal16/libttsmimic_lang_cmu_us_kal16_la-cmu_us_kal16_lpc.lo \
+	lang/cmu_us_kal16/libttsmimic_lang_cmu_us_kal16_la-cmu_us_kal16_res.lo \
+	lang/cmu_us_kal16/libttsmimic_lang_cmu_us_kal16_la-cmu_us_kal16_residx.lo
+libttsmimic_lang_cmu_us_kal16_la_OBJECTS =  \
+	$(am_libttsmimic_lang_cmu_us_kal16_la_OBJECTS)
+libttsmimic_lang_cmu_us_kal16_la_LINK = $(LIBTOOL) $(AM_V_lt) --tag=CC \
 	$(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=link $(CCLD) \
-	$(libmimic_lang_cmu_us_kal16_la_CFLAGS) $(CFLAGS) \
-	$(libmimic_lang_cmu_us_kal16_la_LDFLAGS) $(LDFLAGS) -o $@
-@VOICE_CMU_US_KAL16_TRUE@am_libmimic_lang_cmu_us_kal16_la_rpath =  \
+	$(libttsmimic_lang_cmu_us_kal16_la_CFLAGS) $(CFLAGS) \
+	$(libttsmimic_lang_cmu_us_kal16_la_LDFLAGS) $(LDFLAGS) -o $@
+@VOICE_CMU_US_KAL16_TRUE@am_libttsmimic_lang_cmu_us_kal16_la_rpath =  \
 @VOICE_CMU_US_KAL16_TRUE@	-rpath $(libdir)
-libmimic_lang_cmu_us_rms_la_DEPENDENCIES = libmimic.la \
-	libmimic_lang_cmulex.la libmimic_lang_usenglish.la
-am_libmimic_lang_cmu_us_rms_la_OBJECTS =  \
-	lang/cmu_us_rms/libmimic_lang_cmu_us_rms_la-cmu_us_rms.lo \
-	lang/cmu_us_rms/libmimic_lang_cmu_us_rms_la-cmu_us_rms_cg.lo \
-	lang/cmu_us_rms/libmimic_lang_cmu_us_rms_la-cmu_us_rms_cg_durmodel.lo \
-	lang/cmu_us_rms/libmimic_lang_cmu_us_rms_la-cmu_us_rms_cg_f0_trees.lo \
-	lang/cmu_us_rms/libmimic_lang_cmu_us_rms_la-cmu_us_rms_cg_phonestate.lo \
-	lang/cmu_us_rms/libmimic_lang_cmu_us_rms_la-cmu_us_rms_cg_single_mcep_trees.lo \
-	lang/cmu_us_rms/libmimic_lang_cmu_us_rms_la-cmu_us_rms_cg_single_params.lo \
-	lang/cmu_us_rms/libmimic_lang_cmu_us_rms_la-cmu_us_rms_spamf0_accent.lo \
-	lang/cmu_us_rms/libmimic_lang_cmu_us_rms_la-cmu_us_rms_spamf0_accent_params.lo \
-	lang/cmu_us_rms/libmimic_lang_cmu_us_rms_la-cmu_us_rms_spamf0_phrase.lo
-libmimic_lang_cmu_us_rms_la_OBJECTS =  \
-	$(am_libmimic_lang_cmu_us_rms_la_OBJECTS)
-libmimic_lang_cmu_us_rms_la_LINK = $(LIBTOOL) $(AM_V_lt) --tag=CC \
+libttsmimic_lang_cmu_us_rms_la_DEPENDENCIES = libttsmimic.la \
+	libttsmimic_lang_cmulex.la libttsmimic_lang_usenglish.la
+am_libttsmimic_lang_cmu_us_rms_la_OBJECTS =  \
+	lang/cmu_us_rms/libttsmimic_lang_cmu_us_rms_la-cmu_us_rms.lo \
+	lang/cmu_us_rms/libttsmimic_lang_cmu_us_rms_la-cmu_us_rms_cg.lo \
+	lang/cmu_us_rms/libttsmimic_lang_cmu_us_rms_la-cmu_us_rms_cg_durmodel.lo \
+	lang/cmu_us_rms/libttsmimic_lang_cmu_us_rms_la-cmu_us_rms_cg_f0_trees.lo \
+	lang/cmu_us_rms/libttsmimic_lang_cmu_us_rms_la-cmu_us_rms_cg_phonestate.lo \
+	lang/cmu_us_rms/libttsmimic_lang_cmu_us_rms_la-cmu_us_rms_cg_single_mcep_trees.lo \
+	lang/cmu_us_rms/libttsmimic_lang_cmu_us_rms_la-cmu_us_rms_cg_single_params.lo \
+	lang/cmu_us_rms/libttsmimic_lang_cmu_us_rms_la-cmu_us_rms_spamf0_accent.lo \
+	lang/cmu_us_rms/libttsmimic_lang_cmu_us_rms_la-cmu_us_rms_spamf0_accent_params.lo \
+	lang/cmu_us_rms/libttsmimic_lang_cmu_us_rms_la-cmu_us_rms_spamf0_phrase.lo
+libttsmimic_lang_cmu_us_rms_la_OBJECTS =  \
+	$(am_libttsmimic_lang_cmu_us_rms_la_OBJECTS)
+libttsmimic_lang_cmu_us_rms_la_LINK = $(LIBTOOL) $(AM_V_lt) --tag=CC \
 	$(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=link $(CCLD) \
-	$(libmimic_lang_cmu_us_rms_la_CFLAGS) $(CFLAGS) \
-	$(libmimic_lang_cmu_us_rms_la_LDFLAGS) $(LDFLAGS) -o $@
-@VOICE_CMU_US_RMS_TRUE@am_libmimic_lang_cmu_us_rms_la_rpath = -rpath \
-@VOICE_CMU_US_RMS_TRUE@	$(libdir)
-libmimic_lang_cmu_us_slt_la_DEPENDENCIES = libmimic.la \
-	libmimic_lang_cmulex.la libmimic_lang_usenglish.la
-am_libmimic_lang_cmu_us_slt_la_OBJECTS =  \
-	lang/cmu_us_slt/libmimic_lang_cmu_us_slt_la-cmu_us_slt.lo \
-	lang/cmu_us_slt/libmimic_lang_cmu_us_slt_la-cmu_us_slt_cg.lo \
-	lang/cmu_us_slt/libmimic_lang_cmu_us_slt_la-cmu_us_slt_cg_durmodel.lo \
-	lang/cmu_us_slt/libmimic_lang_cmu_us_slt_la-cmu_us_slt_cg_f0_trees.lo \
-	lang/cmu_us_slt/libmimic_lang_cmu_us_slt_la-cmu_us_slt_cg_phonestate.lo \
-	lang/cmu_us_slt/libmimic_lang_cmu_us_slt_la-cmu_us_slt_cg_single_mcep_trees.lo \
-	lang/cmu_us_slt/libmimic_lang_cmu_us_slt_la-cmu_us_slt_cg_single_params.lo \
-	lang/cmu_us_slt/libmimic_lang_cmu_us_slt_la-cmu_us_slt_spamf0_accent.lo \
-	lang/cmu_us_slt/libmimic_lang_cmu_us_slt_la-cmu_us_slt_spamf0_accent_params.lo \
-	lang/cmu_us_slt/libmimic_lang_cmu_us_slt_la-cmu_us_slt_spamf0_phrase.lo
-libmimic_lang_cmu_us_slt_la_OBJECTS =  \
-	$(am_libmimic_lang_cmu_us_slt_la_OBJECTS)
-libmimic_lang_cmu_us_slt_la_LINK = $(LIBTOOL) $(AM_V_lt) --tag=CC \
+	$(libttsmimic_lang_cmu_us_rms_la_CFLAGS) $(CFLAGS) \
+	$(libttsmimic_lang_cmu_us_rms_la_LDFLAGS) $(LDFLAGS) -o $@
+@VOICE_CMU_US_RMS_TRUE@am_libttsmimic_lang_cmu_us_rms_la_rpath =  \
+@VOICE_CMU_US_RMS_TRUE@	-rpath $(libdir)
+libttsmimic_lang_cmu_us_slt_la_DEPENDENCIES = libttsmimic.la \
+	libttsmimic_lang_cmulex.la libttsmimic_lang_usenglish.la
+am_libttsmimic_lang_cmu_us_slt_la_OBJECTS =  \
+	lang/cmu_us_slt/libttsmimic_lang_cmu_us_slt_la-cmu_us_slt.lo \
+	lang/cmu_us_slt/libttsmimic_lang_cmu_us_slt_la-cmu_us_slt_cg.lo \
+	lang/cmu_us_slt/libttsmimic_lang_cmu_us_slt_la-cmu_us_slt_cg_durmodel.lo \
+	lang/cmu_us_slt/libttsmimic_lang_cmu_us_slt_la-cmu_us_slt_cg_f0_trees.lo \
+	lang/cmu_us_slt/libttsmimic_lang_cmu_us_slt_la-cmu_us_slt_cg_phonestate.lo \
+	lang/cmu_us_slt/libttsmimic_lang_cmu_us_slt_la-cmu_us_slt_cg_single_mcep_trees.lo \
+	lang/cmu_us_slt/libttsmimic_lang_cmu_us_slt_la-cmu_us_slt_cg_single_params.lo \
+	lang/cmu_us_slt/libttsmimic_lang_cmu_us_slt_la-cmu_us_slt_spamf0_accent.lo \
+	lang/cmu_us_slt/libttsmimic_lang_cmu_us_slt_la-cmu_us_slt_spamf0_accent_params.lo \
+	lang/cmu_us_slt/libttsmimic_lang_cmu_us_slt_la-cmu_us_slt_spamf0_phrase.lo
+libttsmimic_lang_cmu_us_slt_la_OBJECTS =  \
+	$(am_libttsmimic_lang_cmu_us_slt_la_OBJECTS)
+libttsmimic_lang_cmu_us_slt_la_LINK = $(LIBTOOL) $(AM_V_lt) --tag=CC \
 	$(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=link $(CCLD) \
-	$(libmimic_lang_cmu_us_slt_la_CFLAGS) $(CFLAGS) \
-	$(libmimic_lang_cmu_us_slt_la_LDFLAGS) $(LDFLAGS) -o $@
-@VOICE_CMU_US_SLT_TRUE@am_libmimic_lang_cmu_us_slt_la_rpath = -rpath \
-@VOICE_CMU_US_SLT_TRUE@	$(libdir)
-libmimic_lang_cmulex_la_DEPENDENCIES = libmimic.la
-am_libmimic_lang_cmulex_la_OBJECTS = lang/cmulex/cmu_lex.lo \
+	$(libttsmimic_lang_cmu_us_slt_la_CFLAGS) $(CFLAGS) \
+	$(libttsmimic_lang_cmu_us_slt_la_LDFLAGS) $(LDFLAGS) -o $@
+@VOICE_CMU_US_SLT_TRUE@am_libttsmimic_lang_cmu_us_slt_la_rpath =  \
+@VOICE_CMU_US_SLT_TRUE@	-rpath $(libdir)
+libttsmimic_lang_cmulex_la_DEPENDENCIES = libttsmimic.la
+am_libttsmimic_lang_cmulex_la_OBJECTS = lang/cmulex/cmu_lex.lo \
 	lang/cmulex/cmu_lex_data.lo lang/cmulex/cmu_lex_entries.lo \
 	lang/cmulex/cmu_lts_model.lo lang/cmulex/cmu_lts_rules.lo \
 	lang/cmulex/cmu_postlex.lo
-libmimic_lang_cmulex_la_OBJECTS =  \
-	$(am_libmimic_lang_cmulex_la_OBJECTS)
-libmimic_lang_cmulex_la_LINK = $(LIBTOOL) $(AM_V_lt) --tag=CC \
+libttsmimic_lang_cmulex_la_OBJECTS =  \
+	$(am_libttsmimic_lang_cmulex_la_OBJECTS)
+libttsmimic_lang_cmulex_la_LINK = $(LIBTOOL) $(AM_V_lt) --tag=CC \
 	$(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=link $(CCLD) \
-	$(AM_CFLAGS) $(CFLAGS) $(libmimic_lang_cmulex_la_LDFLAGS) \
+	$(AM_CFLAGS) $(CFLAGS) $(libttsmimic_lang_cmulex_la_LDFLAGS) \
 	$(LDFLAGS) -o $@
-@LEX_CMULEX_TRUE@am_libmimic_lang_cmulex_la_rpath = -rpath $(libdir)
-libmimic_lang_usenglish_la_DEPENDENCIES = libmimic.la
-am_libmimic_lang_usenglish_la_OBJECTS = lang/usenglish/us_aswd.lo \
+@LEX_CMULEX_TRUE@am_libttsmimic_lang_cmulex_la_rpath = -rpath \
+@LEX_CMULEX_TRUE@	$(libdir)
+libttsmimic_lang_usenglish_la_DEPENDENCIES = libttsmimic.la
+am_libttsmimic_lang_usenglish_la_OBJECTS = lang/usenglish/us_aswd.lo \
 	lang/usenglish/us_dur_stats.lo lang/usenglish/us_durz_cart.lo \
 	lang/usenglish/usenglish.lo lang/usenglish/us_expand.lo \
 	lang/usenglish/us_f0lr.lo lang/usenglish/us_f0_model.lo \
@@ -518,37 +526,37 @@ am_libmimic_lang_usenglish_la_OBJECTS = lang/usenglish/us_aswd.lo \
 	lang/usenglish/us_nums_cart.lo lang/usenglish/us_phoneset.lo \
 	lang/usenglish/us_phrasing_cart.lo \
 	lang/usenglish/us_pos_cart.lo lang/usenglish/us_text.lo
-libmimic_lang_usenglish_la_OBJECTS =  \
-	$(am_libmimic_lang_usenglish_la_OBJECTS)
-libmimic_lang_usenglish_la_LINK = $(LIBTOOL) $(AM_V_lt) --tag=CC \
+libttsmimic_lang_usenglish_la_OBJECTS =  \
+	$(am_libttsmimic_lang_usenglish_la_OBJECTS)
+libttsmimic_lang_usenglish_la_LINK = $(LIBTOOL) $(AM_V_lt) --tag=CC \
 	$(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=link $(CCLD) \
-	$(AM_CFLAGS) $(CFLAGS) $(libmimic_lang_usenglish_la_LDFLAGS) \
-	$(LDFLAGS) -o $@
-@LANG_USENGLISH_TRUE@am_libmimic_lang_usenglish_la_rpath = -rpath \
+	$(AM_CFLAGS) $(CFLAGS) \
+	$(libttsmimic_lang_usenglish_la_LDFLAGS) $(LDFLAGS) -o $@
+@LANG_USENGLISH_TRUE@am_libttsmimic_lang_usenglish_la_rpath = -rpath \
 @LANG_USENGLISH_TRUE@	$(libdir)
-libmimic_lang_vid_gb_ap_la_DEPENDENCIES = libmimic.la \
-	libmimic_lang_cmulex.la libmimic_lang_usenglish.la
-am_libmimic_lang_vid_gb_ap_la_OBJECTS =  \
-	lang/vid_gb_ap/libmimic_lang_vid_gb_ap_la-vid_gb_ap.lo \
-	lang/vid_gb_ap/libmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_01_mcep_trees.lo \
-	lang/vid_gb_ap/libmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_01_params.lo \
-	lang/vid_gb_ap/libmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_08_durmodel.lo \
-	lang/vid_gb_ap/libmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_10_durmodel.lo \
-	lang/vid_gb_ap/libmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_12_mcep_trees.lo \
-	lang/vid_gb_ap/libmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_12_params.lo \
-	lang/vid_gb_ap/libmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_17_durmodel.lo \
-	lang/vid_gb_ap/libmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_17_mcep_trees.lo \
-	lang/vid_gb_ap/libmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_17_params.lo \
-	lang/vid_gb_ap/libmimic_lang_vid_gb_ap_la-vid_gb_ap_cg.lo \
-	lang/vid_gb_ap/libmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_f0_trees.lo \
-	lang/vid_gb_ap/libmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_phonestate.lo
-libmimic_lang_vid_gb_ap_la_OBJECTS =  \
-	$(am_libmimic_lang_vid_gb_ap_la_OBJECTS)
-libmimic_lang_vid_gb_ap_la_LINK = $(LIBTOOL) $(AM_V_lt) --tag=CC \
+libttsmimic_lang_vid_gb_ap_la_DEPENDENCIES = libttsmimic.la \
+	libttsmimic_lang_cmulex.la libttsmimic_lang_usenglish.la
+am_libttsmimic_lang_vid_gb_ap_la_OBJECTS =  \
+	lang/vid_gb_ap/libttsmimic_lang_vid_gb_ap_la-vid_gb_ap.lo \
+	lang/vid_gb_ap/libttsmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_01_mcep_trees.lo \
+	lang/vid_gb_ap/libttsmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_01_params.lo \
+	lang/vid_gb_ap/libttsmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_08_durmodel.lo \
+	lang/vid_gb_ap/libttsmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_10_durmodel.lo \
+	lang/vid_gb_ap/libttsmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_12_mcep_trees.lo \
+	lang/vid_gb_ap/libttsmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_12_params.lo \
+	lang/vid_gb_ap/libttsmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_17_durmodel.lo \
+	lang/vid_gb_ap/libttsmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_17_mcep_trees.lo \
+	lang/vid_gb_ap/libttsmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_17_params.lo \
+	lang/vid_gb_ap/libttsmimic_lang_vid_gb_ap_la-vid_gb_ap_cg.lo \
+	lang/vid_gb_ap/libttsmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_f0_trees.lo \
+	lang/vid_gb_ap/libttsmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_phonestate.lo
+libttsmimic_lang_vid_gb_ap_la_OBJECTS =  \
+	$(am_libttsmimic_lang_vid_gb_ap_la_OBJECTS)
+libttsmimic_lang_vid_gb_ap_la_LINK = $(LIBTOOL) $(AM_V_lt) --tag=CC \
 	$(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=link $(CCLD) \
-	$(libmimic_lang_vid_gb_ap_la_CFLAGS) $(CFLAGS) \
-	$(libmimic_lang_vid_gb_ap_la_LDFLAGS) $(LDFLAGS) -o $@
-@VOICE_VID_GB_AP_TRUE@am_libmimic_lang_vid_gb_ap_la_rpath = -rpath \
+	$(libttsmimic_lang_vid_gb_ap_la_CFLAGS) $(CFLAGS) \
+	$(libttsmimic_lang_vid_gb_ap_la_LDFLAGS) $(LDFLAGS) -o $@
+@VOICE_VID_GB_AP_TRUE@am_libttsmimic_lang_vid_gb_ap_la_rpath = -rpath \
 @VOICE_VID_GB_AP_TRUE@	$(libdir)
 @LANG_USENGLISH_TRUE@@LEX_CMULEX_TRUE@am__EXEEXT_1 = t2p$(EXEEXT) \
 @LANG_USENGLISH_TRUE@@LEX_CMULEX_TRUE@	mimic_time$(EXEEXT)
@@ -567,72 +575,72 @@ am__EXEEXT_3 = unittests/hrg_test$(EXEEXT) \
 PROGRAMS = $(bin_PROGRAMS)
 am_compile_regexes_OBJECTS = main/compile_regexes.$(OBJEXT)
 compile_regexes_OBJECTS = $(am_compile_regexes_OBJECTS)
-compile_regexes_DEPENDENCIES = libmimic.la
+compile_regexes_DEPENDENCIES = libttsmimic.la
 am_mimic_OBJECTS = main/mimic_main.$(OBJEXT)
 mimic_OBJECTS = $(am_mimic_OBJECTS)
-mimic_DEPENDENCIES = libmimic_lang_all_langs.la \
-	libmimic_lang_all_voices.la libmimic.la
+mimic_DEPENDENCIES = libttsmimic_lang_all_langs.la \
+	libttsmimic_lang_all_voices.la libttsmimic.la
 am_mimic_time_OBJECTS = main/mimic_time_main.$(OBJEXT)
 mimic_time_OBJECTS = $(am_mimic_time_OBJECTS)
-mimic_time_DEPENDENCIES = libmimic.la libmimic_lang_cmulex.la \
-	libmimic_lang_usenglish.la libmimic_lang_cmu_time_awb.la
+mimic_time_DEPENDENCIES = libttsmimic.la libttsmimic_lang_cmulex.la \
+	libttsmimic_lang_usenglish.la libttsmimic_lang_cmu_time_awb.la
 am_mimicvox_info_OBJECTS = main/mimicvox_info_main.$(OBJEXT)
 mimicvox_info_OBJECTS = $(am_mimicvox_info_OBJECTS)
-mimicvox_info_DEPENDENCIES = libmimic.la libmimic_lang_all_langs.la \
-	libmimic_lang_all_voices.la
+mimicvox_info_DEPENDENCIES = libttsmimic.la \
+	libttsmimic_lang_all_langs.la libttsmimic_lang_all_voices.la
 am_t2p_OBJECTS = main/t2p_main.$(OBJEXT)
 t2p_OBJECTS = $(am_t2p_OBJECTS)
-t2p_DEPENDENCIES = libmimic.la libmimic_lang_cmulex.la \
-	libmimic_lang_usenglish.la
+t2p_DEPENDENCIES = libttsmimic.la libttsmimic_lang_cmulex.la \
+	libttsmimic_lang_usenglish.la
 am_testsuite_asciiS2U_OBJECTS = testsuite/asciiS2U_main.$(OBJEXT)
 testsuite_asciiS2U_OBJECTS = $(am_testsuite_asciiS2U_OBJECTS)
-testsuite_asciiS2U_DEPENDENCIES = libmimic.la
+testsuite_asciiS2U_DEPENDENCIES = libttsmimic.la
 am_testsuite_asciiU2S_OBJECTS = testsuite/asciiU2S_main.$(OBJEXT)
 testsuite_asciiU2S_OBJECTS = $(am_testsuite_asciiU2S_OBJECTS)
-testsuite_asciiU2S_DEPENDENCIES = libmimic.la
+testsuite_asciiU2S_DEPENDENCIES = libttsmimic.la
 am_testsuite_bin2ascii_OBJECTS = testsuite/bin2ascii_main.$(OBJEXT)
 testsuite_bin2ascii_OBJECTS = $(am_testsuite_bin2ascii_OBJECTS)
-testsuite_bin2ascii_DEPENDENCIES = libmimic.la
+testsuite_bin2ascii_DEPENDENCIES = libttsmimic.la
 am_testsuite_by_word_OBJECTS = testsuite/by_word_main.$(OBJEXT)
 testsuite_by_word_OBJECTS = $(am_testsuite_by_word_OBJECTS)
-testsuite_by_word_DEPENDENCIES = libmimic.la \
-	libmimic_lang_all_langs.la libmimic_lang_all_voices.la \
-	libmimic_lang_cmu_us_kal.la
+testsuite_by_word_DEPENDENCIES = libttsmimic.la \
+	libttsmimic_lang_all_langs.la libttsmimic_lang_all_voices.la \
+	libttsmimic_lang_cmu_us_kal.la
 am_testsuite_combine_waves_OBJECTS =  \
 	testsuite/combine_waves_main.$(OBJEXT)
 testsuite_combine_waves_OBJECTS =  \
 	$(am_testsuite_combine_waves_OBJECTS)
-testsuite_combine_waves_DEPENDENCIES = libmimic.la
+testsuite_combine_waves_DEPENDENCIES = libttsmimic.la
 am_testsuite_compare_wave_OBJECTS =  \
 	testsuite/compare_wave_main.$(OBJEXT)
 testsuite_compare_wave_OBJECTS = $(am_testsuite_compare_wave_OBJECTS)
-testsuite_compare_wave_DEPENDENCIES = libmimic.la
+testsuite_compare_wave_DEPENDENCIES = libttsmimic.la
 am_testsuite_kal_test_OBJECTS = testsuite/kal_test_main.$(OBJEXT)
 testsuite_kal_test_OBJECTS = $(am_testsuite_kal_test_OBJECTS)
-testsuite_kal_test_DEPENDENCIES = libmimic.la \
-	libmimic_lang_all_langs.la libmimic_lang_all_voices.la \
-	libmimic_lang_cmu_us_kal.la
+testsuite_kal_test_DEPENDENCIES = libttsmimic.la \
+	libttsmimic_lang_all_langs.la libttsmimic_lang_all_voices.la \
+	libttsmimic_lang_cmu_us_kal.la
 am_testsuite_lex_lookup_OBJECTS = testsuite/lex_lookup_main.$(OBJEXT)
 testsuite_lex_lookup_OBJECTS = $(am_testsuite_lex_lookup_OBJECTS)
-testsuite_lex_lookup_DEPENDENCIES = libmimic.la \
-	libmimic_lang_all_langs.la libmimic_lang_cmulex.la \
-	libmimic_lang_usenglish.la
+testsuite_lex_lookup_DEPENDENCIES = libttsmimic.la \
+	libttsmimic_lang_all_langs.la libttsmimic_lang_cmulex.la \
+	libttsmimic_lang_usenglish.la
 am_testsuite_lpc_resynth_OBJECTS =  \
 	testsuite/lpc_resynth_main.$(OBJEXT)
 testsuite_lpc_resynth_OBJECTS = $(am_testsuite_lpc_resynth_OBJECTS)
-testsuite_lpc_resynth_DEPENDENCIES = libmimic.la
+testsuite_lpc_resynth_DEPENDENCIES = libttsmimic.la
 am_testsuite_lpc_test_OBJECTS = testsuite/lpc_test_main.$(OBJEXT)
 testsuite_lpc_test_OBJECTS = $(am_testsuite_lpc_test_OBJECTS)
-testsuite_lpc_test_DEPENDENCIES = libmimic.la
+testsuite_lpc_test_DEPENDENCIES = libttsmimic.la
 am_testsuite_lpc_test2_OBJECTS = testsuite/lpc_test2_main.$(OBJEXT)
 testsuite_lpc_test2_OBJECTS = $(am_testsuite_lpc_test2_OBJECTS)
-testsuite_lpc_test2_DEPENDENCIES = libmimic.la
+testsuite_lpc_test2_DEPENDENCIES = libttsmimic.la
 am_testsuite_multi_thread_OBJECTS =  \
 	testsuite/testsuite_multi_thread-multi_thread_main.$(OBJEXT)
 testsuite_multi_thread_OBJECTS = $(am_testsuite_multi_thread_OBJECTS)
-testsuite_multi_thread_DEPENDENCIES = libmimic.la \
-	libmimic_lang_all_langs.la libmimic_lang_all_voices.la \
-	libmimic_lang_cmu_us_slt.la
+testsuite_multi_thread_DEPENDENCIES = libttsmimic.la \
+	libttsmimic_lang_all_langs.la libttsmimic_lang_all_voices.la \
+	libttsmimic_lang_cmu_us_slt.la
 testsuite_multi_thread_LINK = $(LIBTOOL) $(AM_V_lt) --tag=CC \
 	$(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=link $(CCLD) \
 	$(testsuite_multi_thread_CFLAGS) $(CFLAGS) $(AM_LDFLAGS) \
@@ -640,59 +648,60 @@ testsuite_multi_thread_LINK = $(LIBTOOL) $(AM_V_lt) --tag=CC \
 am_testsuite_play_client_OBJECTS =  \
 	testsuite/play_client_main.$(OBJEXT)
 testsuite_play_client_OBJECTS = $(am_testsuite_play_client_OBJECTS)
-testsuite_play_client_DEPENDENCIES = libmimic.la
+testsuite_play_client_DEPENDENCIES = libttsmimic.la
 am_testsuite_play_server_OBJECTS =  \
 	testsuite/play_server_main.$(OBJEXT)
 testsuite_play_server_OBJECTS = $(am_testsuite_play_server_OBJECTS)
-testsuite_play_server_DEPENDENCIES = libmimic.la
+testsuite_play_server_DEPENDENCIES = libttsmimic.la
 am_testsuite_play_sync_OBJECTS = testsuite/play_sync_main.$(OBJEXT)
 testsuite_play_sync_OBJECTS = $(am_testsuite_play_sync_OBJECTS)
-testsuite_play_sync_DEPENDENCIES = libmimic.la
+testsuite_play_sync_DEPENDENCIES = libttsmimic.la
 am_testsuite_play_wave_OBJECTS = testsuite/play_wave_main.$(OBJEXT)
 testsuite_play_wave_OBJECTS = $(am_testsuite_play_wave_OBJECTS)
-testsuite_play_wave_DEPENDENCIES = libmimic.la
+testsuite_play_wave_DEPENDENCIES = libttsmimic.la
 am_testsuite_rfc_OBJECTS = testsuite/rfc_main.$(OBJEXT)
 testsuite_rfc_OBJECTS = $(am_testsuite_rfc_OBJECTS)
-testsuite_rfc_DEPENDENCIES = libmimic.la
+testsuite_rfc_DEPENDENCIES = libttsmimic.la
 am_testsuite_utt_test_OBJECTS = testsuite/utt_test_main.$(OBJEXT)
 testsuite_utt_test_OBJECTS = $(am_testsuite_utt_test_OBJECTS)
-testsuite_utt_test_DEPENDENCIES = libmimic.la \
-	libmimic_lang_all_langs.la libmimic_lang_cmulex.la
+testsuite_utt_test_DEPENDENCIES = libttsmimic.la \
+	libttsmimic_lang_all_langs.la libttsmimic_lang_cmulex.la
 am_unittests_hrg_test_OBJECTS = unittests/hrg_test_main.$(OBJEXT)
 unittests_hrg_test_OBJECTS = $(am_unittests_hrg_test_OBJECTS)
-unittests_hrg_test_DEPENDENCIES = libmimic.la
+unittests_hrg_test_DEPENDENCIES = libttsmimic.la
 am_unittests_lex_test_OBJECTS = unittests/lex_test_main.$(OBJEXT)
 unittests_lex_test_OBJECTS = $(am_unittests_lex_test_OBJECTS)
-unittests_lex_test_DEPENDENCIES = libmimic.la libmimic_lang_cmulex.la \
-	libmimic_lang_all_langs.la
+unittests_lex_test_DEPENDENCIES = libttsmimic.la \
+	libttsmimic_lang_cmulex.la libttsmimic_lang_all_langs.la
 am_unittests_lts_test_OBJECTS = unittests/lts_test_main.$(OBJEXT)
 unittests_lts_test_OBJECTS = $(am_unittests_lts_test_OBJECTS)
-unittests_lts_test_DEPENDENCIES = libmimic.la libmimic_lang_cmulex.la \
-	libmimic_lang_all_langs.la
+unittests_lts_test_DEPENDENCIES = libttsmimic.la \
+	libttsmimic_lang_cmulex.la libttsmimic_lang_all_langs.la
 am_unittests_nums_test_OBJECTS =  \
 	unittests/unittests_nums_test-nums_test_main.$(OBJEXT)
 unittests_nums_test_OBJECTS = $(am_unittests_nums_test_OBJECTS)
-unittests_nums_test_DEPENDENCIES = libmimic.la libmimic_lang_cmulex.la \
-	libmimic_lang_usenglish.la libmimic_lang_all_langs.la
+unittests_nums_test_DEPENDENCIES = libttsmimic.la \
+	libttsmimic_lang_cmulex.la libttsmimic_lang_usenglish.la \
+	libttsmimic_lang_all_langs.la
 unittests_nums_test_LINK = $(LIBTOOL) $(AM_V_lt) --tag=CC \
 	$(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=link $(CCLD) \
 	$(unittests_nums_test_CFLAGS) $(CFLAGS) $(AM_LDFLAGS) \
 	$(LDFLAGS) -o $@
 am_unittests_regex_test_OBJECTS = unittests/regex_test_main.$(OBJEXT)
 unittests_regex_test_OBJECTS = $(am_unittests_regex_test_OBJECTS)
-unittests_regex_test_DEPENDENCIES = libmimic.la
+unittests_regex_test_DEPENDENCIES = libttsmimic.la
 am_unittests_token_test_OBJECTS =  \
 	unittests/unittests_token_test-token_test_main.$(OBJEXT)
 unittests_token_test_OBJECTS = $(am_unittests_token_test_OBJECTS)
-unittests_token_test_DEPENDENCIES = libmimic.la
+unittests_token_test_DEPENDENCIES = libttsmimic.la
 unittests_token_test_LINK = $(LIBTOOL) $(AM_V_lt) --tag=CC \
 	$(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=link $(CCLD) \
 	$(unittests_token_test_CFLAGS) $(CFLAGS) $(AM_LDFLAGS) \
 	$(LDFLAGS) -o $@
 am_unittests_voice_select_OBJECTS = unittests/unittests_voice_select-voice_select_test_main.$(OBJEXT)
 unittests_voice_select_OBJECTS = $(am_unittests_voice_select_OBJECTS)
-unittests_voice_select_DEPENDENCIES = libmimic.la \
-	libmimic_lang_all_langs.la libmimic_lang_all_voices.la
+unittests_voice_select_DEPENDENCIES = libttsmimic.la \
+	libttsmimic_lang_all_langs.la libttsmimic_lang_all_voices.la
 unittests_voice_select_LINK = $(LIBTOOL) $(AM_V_lt) --tag=CC \
 	$(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=link $(CCLD) \
 	$(unittests_voice_select_CFLAGS) $(CFLAGS) $(AM_LDFLAGS) \
@@ -700,8 +709,8 @@ unittests_voice_select_LINK = $(LIBTOOL) $(AM_V_lt) --tag=CC \
 am_unittests_wave_test_OBJECTS =  \
 	unittests/unittests_wave_test-wave_test_main.$(OBJEXT)
 unittests_wave_test_OBJECTS = $(am_unittests_wave_test_OBJECTS)
-unittests_wave_test_DEPENDENCIES = libmimic.la \
-	libmimic_lang_all_langs.la libmimic_lang_all_voices.la
+unittests_wave_test_DEPENDENCIES = libttsmimic.la \
+	libttsmimic_lang_all_langs.la libttsmimic_lang_all_voices.la
 unittests_wave_test_LINK = $(LIBTOOL) $(AM_V_lt) --tag=CC \
 	$(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=link $(CCLD) \
 	$(unittests_wave_test_CFLAGS) $(CFLAGS) $(AM_LDFLAGS) \
@@ -741,21 +750,22 @@ AM_V_CCLD = $(am__v_CCLD_@AM_V@)
 am__v_CCLD_ = $(am__v_CCLD_@AM_DEFAULT_V@)
 am__v_CCLD_0 = @echo "  CCLD    " $@;
 am__v_CCLD_1 = 
-SOURCES = $(libmimic_la_SOURCES) $(libmimic_lang_all_langs_la_SOURCES) \
-	$(libmimic_lang_all_voices_la_SOURCES) \
-	$(libmimic_lang_cmu_grapheme_lang_la_SOURCES) \
-	$(libmimic_lang_cmu_grapheme_lex_la_SOURCES) \
-	$(libmimic_lang_cmu_indic_lang_la_SOURCES) \
-	$(libmimic_lang_cmu_indic_lex_la_SOURCES) \
-	$(libmimic_lang_cmu_time_awb_la_SOURCES) \
-	$(libmimic_lang_cmu_us_awb_la_SOURCES) \
-	$(libmimic_lang_cmu_us_kal_la_SOURCES) \
-	$(libmimic_lang_cmu_us_kal16_la_SOURCES) \
-	$(libmimic_lang_cmu_us_rms_la_SOURCES) \
-	$(libmimic_lang_cmu_us_slt_la_SOURCES) \
-	$(libmimic_lang_cmulex_la_SOURCES) \
-	$(libmimic_lang_usenglish_la_SOURCES) \
-	$(libmimic_lang_vid_gb_ap_la_SOURCES) \
+SOURCES = $(libttsmimic_la_SOURCES) \
+	$(libttsmimic_lang_all_langs_la_SOURCES) \
+	$(libttsmimic_lang_all_voices_la_SOURCES) \
+	$(libttsmimic_lang_cmu_grapheme_lang_la_SOURCES) \
+	$(libttsmimic_lang_cmu_grapheme_lex_la_SOURCES) \
+	$(libttsmimic_lang_cmu_indic_lang_la_SOURCES) \
+	$(libttsmimic_lang_cmu_indic_lex_la_SOURCES) \
+	$(libttsmimic_lang_cmu_time_awb_la_SOURCES) \
+	$(libttsmimic_lang_cmu_us_awb_la_SOURCES) \
+	$(libttsmimic_lang_cmu_us_kal_la_SOURCES) \
+	$(libttsmimic_lang_cmu_us_kal16_la_SOURCES) \
+	$(libttsmimic_lang_cmu_us_rms_la_SOURCES) \
+	$(libttsmimic_lang_cmu_us_slt_la_SOURCES) \
+	$(libttsmimic_lang_cmulex_la_SOURCES) \
+	$(libttsmimic_lang_usenglish_la_SOURCES) \
+	$(libttsmimic_lang_vid_gb_ap_la_SOURCES) \
 	$(compile_regexes_SOURCES) $(mimic_SOURCES) \
 	$(mimic_time_SOURCES) $(mimicvox_info_SOURCES) $(t2p_SOURCES) \
 	$(testsuite_asciiS2U_SOURCES) $(testsuite_asciiU2S_SOURCES) \
@@ -776,22 +786,22 @@ SOURCES = $(libmimic_la_SOURCES) $(libmimic_lang_all_langs_la_SOURCES) \
 	$(unittests_token_test_SOURCES) \
 	$(unittests_voice_select_SOURCES) \
 	$(unittests_wave_test_SOURCES)
-DIST_SOURCES = $(libmimic_la_SOURCES) \
-	$(libmimic_lang_all_langs_la_SOURCES) \
-	$(libmimic_lang_all_voices_la_SOURCES) \
-	$(libmimic_lang_cmu_grapheme_lang_la_SOURCES) \
-	$(libmimic_lang_cmu_grapheme_lex_la_SOURCES) \
-	$(libmimic_lang_cmu_indic_lang_la_SOURCES) \
-	$(libmimic_lang_cmu_indic_lex_la_SOURCES) \
-	$(libmimic_lang_cmu_time_awb_la_SOURCES) \
-	$(libmimic_lang_cmu_us_awb_la_SOURCES) \
-	$(libmimic_lang_cmu_us_kal_la_SOURCES) \
-	$(libmimic_lang_cmu_us_kal16_la_SOURCES) \
-	$(libmimic_lang_cmu_us_rms_la_SOURCES) \
-	$(libmimic_lang_cmu_us_slt_la_SOURCES) \
-	$(libmimic_lang_cmulex_la_SOURCES) \
-	$(libmimic_lang_usenglish_la_SOURCES) \
-	$(libmimic_lang_vid_gb_ap_la_SOURCES) \
+DIST_SOURCES = $(libttsmimic_la_SOURCES) \
+	$(libttsmimic_lang_all_langs_la_SOURCES) \
+	$(libttsmimic_lang_all_voices_la_SOURCES) \
+	$(libttsmimic_lang_cmu_grapheme_lang_la_SOURCES) \
+	$(libttsmimic_lang_cmu_grapheme_lex_la_SOURCES) \
+	$(libttsmimic_lang_cmu_indic_lang_la_SOURCES) \
+	$(libttsmimic_lang_cmu_indic_lex_la_SOURCES) \
+	$(libttsmimic_lang_cmu_time_awb_la_SOURCES) \
+	$(libttsmimic_lang_cmu_us_awb_la_SOURCES) \
+	$(libttsmimic_lang_cmu_us_kal_la_SOURCES) \
+	$(libttsmimic_lang_cmu_us_kal16_la_SOURCES) \
+	$(libttsmimic_lang_cmu_us_rms_la_SOURCES) \
+	$(libttsmimic_lang_cmu_us_slt_la_SOURCES) \
+	$(libttsmimic_lang_cmulex_la_SOURCES) \
+	$(libttsmimic_lang_usenglish_la_SOURCES) \
+	$(libttsmimic_lang_vid_gb_ap_la_SOURCES) \
 	$(compile_regexes_SOURCES) $(mimic_SOURCES) \
 	$(mimic_time_SOURCES) $(mimicvox_info_SOURCES) $(t2p_SOURCES) \
 	$(testsuite_asciiS2U_SOURCES) $(testsuite_asciiU2S_SOURCES) \
@@ -1247,11 +1257,11 @@ langheader_HEADERS = lang/usenglish/usenglish.h lang/usenglish/us_f0.h \
 	lang/cmu_indic_lang/cmu_indic_lang.h lang/cmulex/cmu_lex.h \
 	lang/cmu_grapheme_lex/cmu_grapheme_lex.h \
 	lang/cmu_indic_lex/cmu_indic_lex.h
-lib_LTLIBRARIES = libmimic.la $(am__append_1) $(am__append_3) \
+lib_LTLIBRARIES = libttsmimic.la $(am__append_1) $(am__append_3) \
 	$(am__append_5) $(am__append_7) $(am__append_9) \
 	$(am__append_11) $(am__append_13) $(am__append_15) \
 	$(am__append_17) $(am__append_19) $(am__append_21) \
-	libmimic_lang_all_langs.la libmimic_lang_all_voices.la
+	libttsmimic_lang_all_langs.la libttsmimic_lang_all_voices.la
 
 ###### src/cg ##################
 
@@ -1273,7 +1283,7 @@ lib_LTLIBRARIES = libmimic.la $(am__append_1) $(am__append_3) \
 ###### src/utils #########
 
 ###### src/wavesynth #########
-libmimic_la_SOURCES = $(src_audio_SOURCES) src/cg/cst_mlsa.h \
+libttsmimic_la_SOURCES = $(src_audio_SOURCES) src/cg/cst_mlsa.h \
 	src/cg/cst_mlpg.h src/cg/cst_vc.h src/cg/cst_cg_map.h \
 	src/cg/cst_spamf0.h src/cg/cst_cg.c src/cg/cst_mlsa.c \
 	src/cg/cst_mlpg.c src/cg/cst_vc.c src/cg/cst_cg_load_voice.c \
@@ -1306,23 +1316,24 @@ libmimic_la_SOURCES = $(src_audio_SOURCES) src/cg/cst_mlsa.h \
 	src/wavesynth/cst_diphone.c src/wavesynth/cst_reflpc.c \
 	src/wavesynth/cst_sigpr.c src/wavesynth/cst_sts.c \
 	src/wavesynth/cst_units.c
-libmimic_la_CFLAGS = $(AUDIODEFS)
-libmimic_la_LDFLAGS = -no-undefined
+libttsmimic_la_CFLAGS = $(AUDIODEFS)
+libttsmimic_la_LDFLAGS = -no-undefined
 
 ###############################
-libmimic_la_LIBADD = $(AUDIOLIBS) $(AUDIOLIBS) -lm
-libmimic_lang_all_langs_la_SOURCES = main/mimic_lang_list.c
-libmimic_lang_all_langs_la_LDFLAGS = -no-undefined
-libmimic_lang_all_langs_la_LIBADD = libmimic.la $(am__append_2) \
+libttsmimic_la_LIBADD = $(AUDIOLIBS) $(AUDIOLIBS) -lm
+libttsmimic_lang_all_langs_la_SOURCES = main/mimic_lang_list.c
+libttsmimic_lang_all_langs_la_LDFLAGS = -no-undefined
+libttsmimic_lang_all_langs_la_LIBADD = libttsmimic.la $(am__append_2) \
 	$(am__append_4) $(am__append_6) $(am__append_8)
-libmimic_lang_all_voices_la_SOURCES = main/mimic_voice_list.c
-libmimic_lang_all_voices_la_LDFLAGS = -no-undefined
-libmimic_lang_all_voices_la_LIBADD = libmimic.la $(am__append_10) \
-	$(am__append_12) $(am__append_14) $(am__append_16) \
-	$(am__append_18) $(am__append_20) $(am__append_22)
+libttsmimic_lang_all_voices_la_SOURCES = main/mimic_voice_list.c
+libttsmimic_lang_all_voices_la_LDFLAGS = -no-undefined
+libttsmimic_lang_all_voices_la_LIBADD = libttsmimic.la \
+	$(am__append_10) $(am__append_12) $(am__append_14) \
+	$(am__append_16) $(am__append_18) $(am__append_20) \
+	$(am__append_22)
 pkgconfiginstalldir = $(libdir)/pkgconfig
 pkgconfiginstall_DATA = mimic.pc
-libmimic_lang_usenglish_la_SOURCES = \
+libttsmimic_lang_usenglish_la_SOURCES = \
   lang/usenglish/us_aswd.c \
   lang/usenglish/us_dur_stats.c \
   lang/usenglish/us_durz_cart.c \
@@ -1346,27 +1357,27 @@ libmimic_lang_usenglish_la_SOURCES = \
   lang/usenglish/us_pos_cart.h \
   lang/usenglish/us_text.c
 
-libmimic_lang_usenglish_la_LDFLAGS = -no-undefined
-libmimic_lang_usenglish_la_LIBADD = libmimic.la
-libmimic_lang_cmu_grapheme_lang_la_LDFLAGS = -no-undefined
-libmimic_lang_cmu_grapheme_lang_la_LIBADD = libmimic.la
-libmimic_lang_cmu_grapheme_lang_la_SOURCES = \
+libttsmimic_lang_usenglish_la_LDFLAGS = -no-undefined
+libttsmimic_lang_usenglish_la_LIBADD = libttsmimic.la
+libttsmimic_lang_cmu_grapheme_lang_la_LDFLAGS = -no-undefined
+libttsmimic_lang_cmu_grapheme_lang_la_LIBADD = libttsmimic.la
+libttsmimic_lang_cmu_grapheme_lang_la_SOURCES = \
   lang/cmu_grapheme_lang/cmu_grapheme_phrasing_cart.h \
   lang/cmu_grapheme_lang/cmu_grapheme_lang.c \
   lang/cmu_grapheme_lang/cmu_grapheme_phrasing_cart.c \
   lang/cmu_grapheme_lang/cmu_grapheme_phoneset.c
 
-libmimic_lang_cmu_indic_lang_la_LDFLAGS = -no-undefined
-libmimic_lang_cmu_indic_lang_la_LIBADD = libmimic.la libmimic_lang_usenglish.la
-libmimic_lang_cmu_indic_lang_la_SOURCES = \
+libttsmimic_lang_cmu_indic_lang_la_LDFLAGS = -no-undefined
+libttsmimic_lang_cmu_indic_lang_la_LIBADD = libttsmimic.la libttsmimic_lang_usenglish.la
+libttsmimic_lang_cmu_indic_lang_la_SOURCES = \
   lang/cmu_indic_lang/cmu_indic_lang.c \
   lang/cmu_indic_lang/cmu_indic_phoneset.c \
   lang/cmu_indic_lang/cmu_indic_phrasing_cart.h \
   lang/cmu_indic_lang/cmu_indic_phrasing_cart.c
 
-libmimic_lang_cmulex_la_LDFLAGS = -no-undefined
-libmimic_lang_cmulex_la_LIBADD = libmimic.la
-libmimic_lang_cmulex_la_SOURCES = \
+libttsmimic_lang_cmulex_la_LDFLAGS = -no-undefined
+libttsmimic_lang_cmulex_la_LIBADD = libttsmimic.la
+libttsmimic_lang_cmulex_la_SOURCES = \
   lang/cmulex/cmu_lex.c \
   lang/cmulex/cmu_lex_data.c \
   lang/cmulex/cmu_lex_entries.c \
@@ -1375,9 +1386,9 @@ libmimic_lang_cmulex_la_SOURCES = \
   lang/cmulex/cmu_lts_rules.c \
   lang/cmulex/cmu_postlex.c
 
-libmimic_lang_cmu_grapheme_lex_la_LDFLAGS = -no-undefined
-libmimic_lang_cmu_grapheme_lex_la_LIBADD = libmimic.la
-libmimic_lang_cmu_grapheme_lex_la_SOURCES = \
+libttsmimic_lang_cmu_grapheme_lex_la_LDFLAGS = -no-undefined
+libttsmimic_lang_cmu_grapheme_lex_la_LIBADD = libttsmimic.la
+libttsmimic_lang_cmu_grapheme_lex_la_SOURCES = \
   lang/cmu_grapheme_lex/cmu_grapheme_lex.c \
   lang/cmu_grapheme_lex/grapheme_unitran_tables.c
 
@@ -1386,16 +1397,16 @@ libmimic_lang_cmu_grapheme_lex_la_SOURCES = \
 #	${ESTDIR}/../festival/bin/festival \
 #         -b ${TOP}/tools/make_ug.scm \
 #            ${FESTVOXDIR}/src/grapheme/unicode_sampa_mapping.scm '(doit)'
-libmimic_lang_cmu_indic_lex_la_LDFLAGS = -no-undefined
-libmimic_lang_cmu_indic_lex_la_LIBADD = libmimic.la \
-                                        libmimic_lang_cmulex.la \
-                                        libmimic_lang_cmu_indic_lang.la
+libttsmimic_lang_cmu_indic_lex_la_LDFLAGS = -no-undefined
+libttsmimic_lang_cmu_indic_lex_la_LIBADD = libttsmimic.la \
+                                        libttsmimic_lang_cmulex.la \
+                                        libttsmimic_lang_cmu_indic_lang.la
 
-libmimic_lang_cmu_indic_lex_la_SOURCES = \
+libttsmimic_lang_cmu_indic_lex_la_SOURCES = \
   lang/cmu_indic_lex/cmu_indic_lex.c
 
-libmimic_lang_cmu_us_kal_la_LDFLAGS = -no-undefined
-libmimic_lang_cmu_us_kal_la_SOURCES = \
+libttsmimic_lang_cmu_us_kal_la_LDFLAGS = -no-undefined
+libttsmimic_lang_cmu_us_kal_la_SOURCES = \
   lang/cmu_us_kal/cmu_us_kal.c \
   lang/cmu_us_kal/cmu_us_kal_diphone.c \
   lang/cmu_us_kal/cmu_us_kal_lpc.c \
@@ -1404,17 +1415,17 @@ libmimic_lang_cmu_us_kal_la_SOURCES = \
   lang/cmu_us_kal/cmu_us_kal_ressize.c \
   lang/cmu_us_kal/voxdefs.h
 
-libmimic_lang_cmu_us_kal_la_CFLAGS = \
+libttsmimic_lang_cmu_us_kal_la_CFLAGS = \
   -I$(top_srcdir)/lang/usenglish \
   -I$(top_srcdir)/lang/cmulex
 
-libmimic_lang_cmu_us_kal_la_LIBADD = \
-  libmimic.la \
-  libmimic_lang_cmulex.la \
-  libmimic_lang_usenglish.la
+libttsmimic_lang_cmu_us_kal_la_LIBADD = \
+  libttsmimic.la \
+  libttsmimic_lang_cmulex.la \
+  libttsmimic_lang_usenglish.la
 
-libmimic_lang_cmu_time_awb_la_LDFLAGS = -no-undefined
-libmimic_lang_cmu_time_awb_la_SOURCES = \
+libttsmimic_lang_cmu_time_awb_la_LDFLAGS = -no-undefined
+libttsmimic_lang_cmu_time_awb_la_SOURCES = \
   lang/cmu_time_awb/cmu_time_awb.c \
   lang/cmu_time_awb/cmu_time_awb_cart.c \
   lang/cmu_time_awb/cmu_time_awb_clunits.c \
@@ -1423,17 +1434,17 @@ libmimic_lang_cmu_time_awb_la_SOURCES = \
   lang/cmu_time_awb/cmu_time_awb_mcep.c \
   lang/cmu_time_awb/voxdefs.h
 
-libmimic_lang_cmu_time_awb_la_CFLAGS = \
+libttsmimic_lang_cmu_time_awb_la_CFLAGS = \
   -I$(top_srcdir)/lang/usenglish \
   -I$(top_srcdir)/lang/cmulex
 
-libmimic_lang_cmu_time_awb_la_LIBADD = \
-  libmimic.la \
-  libmimic_lang_cmulex.la \
-  libmimic_lang_usenglish.la
+libttsmimic_lang_cmu_time_awb_la_LIBADD = \
+  libttsmimic.la \
+  libttsmimic_lang_cmulex.la \
+  libttsmimic_lang_usenglish.la
 
-libmimic_lang_cmu_us_kal16_la_LDFLAGS = -no-undefined
-libmimic_lang_cmu_us_kal16_la_SOURCES = \
+libttsmimic_lang_cmu_us_kal16_la_LDFLAGS = -no-undefined
+libttsmimic_lang_cmu_us_kal16_la_SOURCES = \
   lang/cmu_us_kal16/cmu_us_kal16.c \
   lang/cmu_us_kal16/cmu_us_kal16_diphone.c \
   lang/cmu_us_kal16/cmu_us_kal16_lpc.c \
@@ -1441,17 +1452,17 @@ libmimic_lang_cmu_us_kal16_la_SOURCES = \
   lang/cmu_us_kal16/cmu_us_kal16_residx.c \
   lang/cmu_us_kal16/voxdefs.h
 
-libmimic_lang_cmu_us_kal16_la_CFLAGS = \
+libttsmimic_lang_cmu_us_kal16_la_CFLAGS = \
   -I$(top_srcdir)/lang/usenglish \
   -I$(top_srcdir)/lang/cmulex
 
-libmimic_lang_cmu_us_kal16_la_LIBADD = \
-  libmimic.la \
-  libmimic_lang_cmulex.la \
-  libmimic_lang_usenglish.la
+libttsmimic_lang_cmu_us_kal16_la_LIBADD = \
+  libttsmimic.la \
+  libttsmimic_lang_cmulex.la \
+  libttsmimic_lang_usenglish.la
 
-libmimic_lang_cmu_us_awb_la_LDFLAGS = -no-undefined
-libmimic_lang_cmu_us_awb_la_SOURCES = \
+libttsmimic_lang_cmu_us_awb_la_LDFLAGS = -no-undefined
+libttsmimic_lang_cmu_us_awb_la_SOURCES = \
   lang/cmu_us_awb/cmu_us_awb.c \
   lang/cmu_us_awb/cmu_us_awb_cg.c \
   lang/cmu_us_awb/cmu_us_awb_cg_durmodel.c \
@@ -1469,17 +1480,17 @@ libmimic_lang_cmu_us_awb_la_SOURCES = \
   lang/cmu_us_awb/cmu_us_awb_spamf0_phrase.h \
   lang/cmu_us_awb/voxdefs.h
 
-libmimic_lang_cmu_us_awb_la_CFLAGS = \
+libttsmimic_lang_cmu_us_awb_la_CFLAGS = \
   -I$(top_srcdir)/lang/usenglish \
   -I$(top_srcdir)/lang/cmulex
 
-libmimic_lang_cmu_us_awb_la_LIBADD = \
-  libmimic.la \
-  libmimic_lang_cmulex.la \
-  libmimic_lang_usenglish.la
+libttsmimic_lang_cmu_us_awb_la_LIBADD = \
+  libttsmimic.la \
+  libttsmimic_lang_cmulex.la \
+  libttsmimic_lang_usenglish.la
 
-libmimic_lang_cmu_us_rms_la_LDFLAGS = -no-undefined
-libmimic_lang_cmu_us_rms_la_SOURCES = \
+libttsmimic_lang_cmu_us_rms_la_LDFLAGS = -no-undefined
+libttsmimic_lang_cmu_us_rms_la_SOURCES = \
   lang/cmu_us_rms/cmu_us_rms.c \
   lang/cmu_us_rms/cmu_us_rms_cg.c \
   lang/cmu_us_rms/cmu_us_rms_cg_durmodel.c \
@@ -1497,17 +1508,17 @@ libmimic_lang_cmu_us_rms_la_SOURCES = \
   lang/cmu_us_rms/cmu_us_rms_spamf0_phrase.h \
   lang/cmu_us_rms/voxdefs.h
 
-libmimic_lang_cmu_us_rms_la_CFLAGS = \
+libttsmimic_lang_cmu_us_rms_la_CFLAGS = \
   -I$(top_srcdir)/lang/usenglish \
   -I$(top_srcdir)/lang/cmulex
 
-libmimic_lang_cmu_us_rms_la_LIBADD = \
-  libmimic.la \
-  libmimic_lang_cmulex.la \
-  libmimic_lang_usenglish.la
+libttsmimic_lang_cmu_us_rms_la_LIBADD = \
+  libttsmimic.la \
+  libttsmimic_lang_cmulex.la \
+  libttsmimic_lang_usenglish.la
 
-libmimic_lang_cmu_us_slt_la_LDFLAGS = -no-undefined
-libmimic_lang_cmu_us_slt_la_SOURCES = \
+libttsmimic_lang_cmu_us_slt_la_LDFLAGS = -no-undefined
+libttsmimic_lang_cmu_us_slt_la_SOURCES = \
   lang/cmu_us_slt/cmu_us_slt.c \
   lang/cmu_us_slt/cmu_us_slt_cg.c \
   lang/cmu_us_slt/cmu_us_slt_cg_durmodel.c \
@@ -1525,17 +1536,17 @@ libmimic_lang_cmu_us_slt_la_SOURCES = \
   lang/cmu_us_slt/cmu_us_slt_spamf0_phrase.h \
   lang/cmu_us_slt/voxdefs.h
 
-libmimic_lang_cmu_us_slt_la_CFLAGS = \
+libttsmimic_lang_cmu_us_slt_la_CFLAGS = \
   -I$(top_srcdir)/lang/usenglish \
   -I$(top_srcdir)/lang/cmulex
 
-libmimic_lang_cmu_us_slt_la_LIBADD = \
-  libmimic.la \
-  libmimic_lang_cmulex.la \
-  libmimic_lang_usenglish.la
+libttsmimic_lang_cmu_us_slt_la_LIBADD = \
+  libttsmimic.la \
+  libttsmimic_lang_cmulex.la \
+  libttsmimic_lang_usenglish.la
 
-libmimic_lang_vid_gb_ap_la_LDFLAGS = -no-undefined
-libmimic_lang_vid_gb_ap_la_SOURCES = \
+libttsmimic_lang_vid_gb_ap_la_LDFLAGS = -no-undefined
+libttsmimic_lang_vid_gb_ap_la_SOURCES = \
   lang/vid_gb_ap/vid_gb_ap.c \
   lang/vid_gb_ap/vid_gb_ap_cg_01_mcep_trees.c \
   lang/vid_gb_ap/vid_gb_ap_cg_01_mcep_trees.h \
@@ -1558,14 +1569,14 @@ libmimic_lang_vid_gb_ap_la_SOURCES = \
   lang/vid_gb_ap/vid_gb_ap_cg_phonestate.c \
   lang/vid_gb_ap/voxdefs.h
 
-libmimic_lang_vid_gb_ap_la_CFLAGS = \
+libttsmimic_lang_vid_gb_ap_la_CFLAGS = \
   -I$(top_srcdir)/lang/usenglish \
   -I$(top_srcdir)/lang/cmulex
 
-libmimic_lang_vid_gb_ap_la_LIBADD = \
-  libmimic.la \
-  libmimic_lang_cmulex.la \
-  libmimic_lang_usenglish.la
+libttsmimic_lang_vid_gb_ap_la_LIBADD = \
+  libttsmimic.la \
+  libttsmimic_lang_cmulex.la \
+  libttsmimic_lang_usenglish.la
 
 
 ######### END VOICES ######################################
@@ -1588,21 +1599,21 @@ src_audio_SOURCES = \
   src/audio/native_audio.h
 
 mimic_SOURCES = main/mimic_main.c
-mimic_LDADD = libmimic_lang_all_langs.la libmimic_lang_all_voices.la libmimic.la -lm
+mimic_LDADD = libttsmimic_lang_all_langs.la libttsmimic_lang_all_voices.la libttsmimic.la -lm
 compile_regexes_SOURCES = main/compile_regexes.c
-compile_regexes_LDADD = libmimic.la
+compile_regexes_LDADD = libttsmimic.la
 t2p_SOURCES = main/t2p_main.c
-t2p_LDADD = libmimic.la libmimic_lang_cmulex.la libmimic_lang_usenglish.la
+t2p_LDADD = libttsmimic.la libttsmimic_lang_cmulex.la libttsmimic_lang_usenglish.la
 mimic_time_SOURCES = main/mimic_time_main.c
-mimic_time_LDADD = libmimic.la \
-  libmimic_lang_cmulex.la \
-  libmimic_lang_usenglish.la \
-  libmimic_lang_cmu_time_awb.la
+mimic_time_LDADD = libttsmimic.la \
+  libttsmimic_lang_cmulex.la \
+  libttsmimic_lang_usenglish.la \
+  libttsmimic_lang_cmu_time_awb.la
 
 mimicvox_info_SOURCES = \
   main/mimicvox_info_main.c
 
-mimicvox_info_LDADD = libmimic.la libmimic_lang_all_langs.la libmimic_lang_all_voices.la
+mimicvox_info_LDADD = libttsmimic.la libttsmimic_lang_all_langs.la libttsmimic_lang_all_voices.la
 
 ################# END: main ###################
 dist_noinst_SCRIPTS = autogen.sh
@@ -1610,96 +1621,96 @@ myunittests = unittests/hrg_test unittests/regex_test \
 	unittests/token_test unittests/voice_select \
 	unittests/wave_test $(am__append_24)
 unittests_hrg_test_SOURCES = unittests/hrg_test_main.c
-unittests_hrg_test_LDADD = libmimic.la
+unittests_hrg_test_LDADD = libttsmimic.la
 unittests_lex_test_SOURCES = unittests/lex_test_main.c
-unittests_lex_test_LDADD = libmimic.la \
-                           libmimic_lang_cmulex.la \
-                           libmimic_lang_all_langs.la
+unittests_lex_test_LDADD = libttsmimic.la \
+                           libttsmimic_lang_cmulex.la \
+                           libttsmimic_lang_all_langs.la
 
 unittests_lts_test_SOURCES = unittests/lts_test_main.c
-unittests_lts_test_LDADD = libmimic.la \
-                           libmimic_lang_cmulex.la \
-                           libmimic_lang_all_langs.la
+unittests_lts_test_LDADD = libttsmimic.la \
+                           libttsmimic_lang_cmulex.la \
+                           libttsmimic_lang_all_langs.la
 
 unittests_nums_test_SOURCES = unittests/nums_test_main.c
 unittests_nums_test_CFLAGS = -I$(top_srcdir)/lang/usenglish
-unittests_nums_test_LDADD = libmimic.la \
-                            libmimic_lang_cmulex.la \
-                            libmimic_lang_usenglish.la \
-                            libmimic_lang_all_langs.la
+unittests_nums_test_LDADD = libttsmimic.la \
+                            libttsmimic_lang_cmulex.la \
+                            libttsmimic_lang_usenglish.la \
+                            libttsmimic_lang_all_langs.la
 
 unittests_regex_test_SOURCES = unittests/regex_test_main.c
-unittests_regex_test_LDADD = libmimic.la
+unittests_regex_test_LDADD = libttsmimic.la
 unittests_token_test_SOURCES = unittests/token_test_main.c
 unittests_token_test_CFLAGS = -DTEST_FILE=\"$(top_srcdir)/unittests/data.one\" \
                               -DTEST_FILE_UTF8=\"$(top_srcdir)/unittests/data_utf8.txt\"
 
-unittests_token_test_LDADD = libmimic.la
+unittests_token_test_LDADD = libttsmimic.la
 unittests_voice_select_SOURCES = unittests/voice_select_test_main.c
 unittests_voice_select_CFLAGS = -DVOICE_LIST_DIR=\"$(top_srcdir)/voices\" \
                                 -DA_VOICE=\"$(top_srcdir)/voices/cmu_us_rms.flitevox\" 
 
-unittests_voice_select_LDADD = libmimic.la libmimic_lang_all_langs.la libmimic_lang_all_voices.la
+unittests_voice_select_LDADD = libttsmimic.la libttsmimic_lang_all_langs.la libttsmimic_lang_all_voices.la
 unittests_wave_test_SOURCES = unittests/wave_test_main.c
-unittests_wave_test_LDADD = libmimic.la \
-                            libmimic_lang_all_langs.la \
-                            libmimic_lang_all_voices.la
+unittests_wave_test_LDADD = libttsmimic.la \
+                            libttsmimic_lang_all_langs.la \
+                            libttsmimic_lang_all_voices.la
 
 unittests_wave_test_CFLAGS = -DVOICE_LIST_DIR=\"$(top_srcdir)/voices\" \
                              -DA_VOICE=\"$(top_srcdir)/voices/cmu_us_rms.flitevox\" 
 
 testsuite_asciiS2U_SOURCES = testsuite/asciiS2U_main.c
-testsuite_asciiS2U_LDADD = libmimic.la
+testsuite_asciiS2U_LDADD = libttsmimic.la
 testsuite_asciiU2S_SOURCES = testsuite/asciiU2S_main.c
-testsuite_asciiU2S_LDADD = libmimic.la
+testsuite_asciiU2S_LDADD = libttsmimic.la
 testsuite_bin2ascii_SOURCES = testsuite/bin2ascii_main.c
-testsuite_bin2ascii_LDADD = libmimic.la
+testsuite_bin2ascii_LDADD = libttsmimic.la
 testsuite_by_word_SOURCES = testsuite/by_word_main.c
-testsuite_by_word_LDADD = libmimic.la \
-                          libmimic_lang_all_langs.la \
-                          libmimic_lang_all_voices.la \
-                          libmimic_lang_cmu_us_kal.la
+testsuite_by_word_LDADD = libttsmimic.la \
+                          libttsmimic_lang_all_langs.la \
+                          libttsmimic_lang_all_voices.la \
+                          libttsmimic_lang_cmu_us_kal.la
 
 testsuite_combine_waves_SOURCES = testsuite/combine_waves_main.c
-testsuite_combine_waves_LDADD = libmimic.la
+testsuite_combine_waves_LDADD = libttsmimic.la
 testsuite_compare_wave_SOURCES = testsuite/compare_wave_main.c
-testsuite_compare_wave_LDADD = libmimic.la
+testsuite_compare_wave_LDADD = libttsmimic.la
 testsuite_kal_test_SOURCES = testsuite/kal_test_main.c
-testsuite_kal_test_LDADD = libmimic.la \
-                           libmimic_lang_all_langs.la \
-                           libmimic_lang_all_voices.la \
-                           libmimic_lang_cmu_us_kal.la
+testsuite_kal_test_LDADD = libttsmimic.la \
+                           libttsmimic_lang_all_langs.la \
+                           libttsmimic_lang_all_voices.la \
+                           libttsmimic_lang_cmu_us_kal.la
 
 testsuite_lex_lookup_SOURCES = testsuite/lex_lookup_main.c
-testsuite_lex_lookup_LDADD = libmimic.la libmimic_lang_all_langs.la \
-                             libmimic_lang_cmulex.la \
-                             libmimic_lang_usenglish.la
+testsuite_lex_lookup_LDADD = libttsmimic.la libttsmimic_lang_all_langs.la \
+                             libttsmimic_lang_cmulex.la \
+                             libttsmimic_lang_usenglish.la
 
 testsuite_lpc_resynth_SOURCES = testsuite/lpc_resynth_main.c
-testsuite_lpc_resynth_LDADD = libmimic.la
+testsuite_lpc_resynth_LDADD = libttsmimic.la
 testsuite_lpc_test2_SOURCES = testsuite/lpc_test2_main.c
-testsuite_lpc_test2_LDADD = libmimic.la
+testsuite_lpc_test2_LDADD = libttsmimic.la
 testsuite_lpc_test_SOURCES = testsuite/lpc_test_main.c
-testsuite_lpc_test_LDADD = libmimic.la
+testsuite_lpc_test_LDADD = libttsmimic.la
 testsuite_multi_thread_SOURCES = testsuite/multi_thread_main.c
 testsuite_multi_thread_CFLAGS = $(OPENMP_CFLAGS)
-testsuite_multi_thread_LDADD = libmimic.la \
-                               libmimic_lang_all_langs.la \
-                               libmimic_lang_all_voices.la \
-                               libmimic_lang_cmu_us_slt.la
+testsuite_multi_thread_LDADD = libttsmimic.la \
+                               libttsmimic_lang_all_langs.la \
+                               libttsmimic_lang_all_voices.la \
+                               libttsmimic_lang_cmu_us_slt.la
 
 testsuite_play_client_SOURCES = testsuite/play_client_main.c
-testsuite_play_client_LDADD = libmimic.la
+testsuite_play_client_LDADD = libttsmimic.la
 testsuite_play_server_SOURCES = testsuite/play_server_main.c
-testsuite_play_server_LDADD = libmimic.la
+testsuite_play_server_LDADD = libttsmimic.la
 testsuite_play_sync_SOURCES = testsuite/play_sync_main.c
-testsuite_play_sync_LDADD = libmimic.la
+testsuite_play_sync_LDADD = libttsmimic.la
 testsuite_play_wave_SOURCES = testsuite/play_wave_main.c
-testsuite_play_wave_LDADD = libmimic.la
+testsuite_play_wave_LDADD = libttsmimic.la
 testsuite_rfc_SOURCES = testsuite/rfc_main.c
-testsuite_rfc_LDADD = libmimic.la
+testsuite_rfc_LDADD = libttsmimic.la
 testsuite_utt_test_SOURCES = testsuite/utt_test_main.c
-testsuite_utt_test_LDADD = libmimic.la libmimic_lang_all_langs.la libmimic_lang_cmulex.la
+testsuite_utt_test_LDADD = libttsmimic.la libttsmimic_lang_all_langs.la libttsmimic_lang_cmulex.la
 all: all-recursive
 
 .SUFFIXES:
@@ -1796,29 +1807,29 @@ src/audio/$(am__dirstamp):
 src/audio/$(DEPDIR)/$(am__dirstamp):
 	@$(MKDIR_P) src/audio/$(DEPDIR)
 	@: > src/audio/$(DEPDIR)/$(am__dirstamp)
-src/audio/libmimic_la-au_alsa.lo: src/audio/$(am__dirstamp) \
+src/audio/libttsmimic_la-au_alsa.lo: src/audio/$(am__dirstamp) \
 	src/audio/$(DEPDIR)/$(am__dirstamp)
-src/audio/libmimic_la-auclient.lo: src/audio/$(am__dirstamp) \
+src/audio/libttsmimic_la-auclient.lo: src/audio/$(am__dirstamp) \
 	src/audio/$(DEPDIR)/$(am__dirstamp)
-src/audio/libmimic_la-au_command.lo: src/audio/$(am__dirstamp) \
+src/audio/libttsmimic_la-au_command.lo: src/audio/$(am__dirstamp) \
 	src/audio/$(DEPDIR)/$(am__dirstamp)
-src/audio/libmimic_la-audio.lo: src/audio/$(am__dirstamp) \
+src/audio/libttsmimic_la-audio.lo: src/audio/$(am__dirstamp) \
 	src/audio/$(DEPDIR)/$(am__dirstamp)
-src/audio/libmimic_la-au_none.lo: src/audio/$(am__dirstamp) \
+src/audio/libttsmimic_la-au_none.lo: src/audio/$(am__dirstamp) \
 	src/audio/$(DEPDIR)/$(am__dirstamp)
-src/audio/libmimic_la-au_oss.lo: src/audio/$(am__dirstamp) \
+src/audio/libttsmimic_la-au_oss.lo: src/audio/$(am__dirstamp) \
 	src/audio/$(DEPDIR)/$(am__dirstamp)
-src/audio/libmimic_la-au_portaudio.lo: src/audio/$(am__dirstamp) \
+src/audio/libttsmimic_la-au_portaudio.lo: src/audio/$(am__dirstamp) \
 	src/audio/$(DEPDIR)/$(am__dirstamp)
-src/audio/libmimic_la-au_pulseaudio.lo: src/audio/$(am__dirstamp) \
+src/audio/libttsmimic_la-au_pulseaudio.lo: src/audio/$(am__dirstamp) \
 	src/audio/$(DEPDIR)/$(am__dirstamp)
-src/audio/libmimic_la-auserver.lo: src/audio/$(am__dirstamp) \
+src/audio/libttsmimic_la-auserver.lo: src/audio/$(am__dirstamp) \
 	src/audio/$(DEPDIR)/$(am__dirstamp)
-src/audio/libmimic_la-au_streaming.lo: src/audio/$(am__dirstamp) \
+src/audio/libttsmimic_la-au_streaming.lo: src/audio/$(am__dirstamp) \
 	src/audio/$(DEPDIR)/$(am__dirstamp)
-src/audio/libmimic_la-au_sun.lo: src/audio/$(am__dirstamp) \
+src/audio/libttsmimic_la-au_sun.lo: src/audio/$(am__dirstamp) \
 	src/audio/$(DEPDIR)/$(am__dirstamp)
-src/audio/libmimic_la-au_wince.lo: src/audio/$(am__dirstamp) \
+src/audio/libttsmimic_la-au_wince.lo: src/audio/$(am__dirstamp) \
 	src/audio/$(DEPDIR)/$(am__dirstamp)
 src/cg/$(am__dirstamp):
 	@$(MKDIR_P) src/cg
@@ -1826,21 +1837,21 @@ src/cg/$(am__dirstamp):
 src/cg/$(DEPDIR)/$(am__dirstamp):
 	@$(MKDIR_P) src/cg/$(DEPDIR)
 	@: > src/cg/$(DEPDIR)/$(am__dirstamp)
-src/cg/libmimic_la-cst_cg.lo: src/cg/$(am__dirstamp) \
+src/cg/libttsmimic_la-cst_cg.lo: src/cg/$(am__dirstamp) \
 	src/cg/$(DEPDIR)/$(am__dirstamp)
-src/cg/libmimic_la-cst_mlsa.lo: src/cg/$(am__dirstamp) \
+src/cg/libttsmimic_la-cst_mlsa.lo: src/cg/$(am__dirstamp) \
 	src/cg/$(DEPDIR)/$(am__dirstamp)
-src/cg/libmimic_la-cst_mlpg.lo: src/cg/$(am__dirstamp) \
+src/cg/libttsmimic_la-cst_mlpg.lo: src/cg/$(am__dirstamp) \
 	src/cg/$(DEPDIR)/$(am__dirstamp)
-src/cg/libmimic_la-cst_vc.lo: src/cg/$(am__dirstamp) \
+src/cg/libttsmimic_la-cst_vc.lo: src/cg/$(am__dirstamp) \
 	src/cg/$(DEPDIR)/$(am__dirstamp)
-src/cg/libmimic_la-cst_cg_load_voice.lo: src/cg/$(am__dirstamp) \
+src/cg/libttsmimic_la-cst_cg_load_voice.lo: src/cg/$(am__dirstamp) \
 	src/cg/$(DEPDIR)/$(am__dirstamp)
-src/cg/libmimic_la-cst_cg_dump_voice.lo: src/cg/$(am__dirstamp) \
+src/cg/libttsmimic_la-cst_cg_dump_voice.lo: src/cg/$(am__dirstamp) \
 	src/cg/$(DEPDIR)/$(am__dirstamp)
-src/cg/libmimic_la-cst_cg_map.lo: src/cg/$(am__dirstamp) \
+src/cg/libttsmimic_la-cst_cg_map.lo: src/cg/$(am__dirstamp) \
 	src/cg/$(DEPDIR)/$(am__dirstamp)
-src/cg/libmimic_la-cst_spamf0.lo: src/cg/$(am__dirstamp) \
+src/cg/libttsmimic_la-cst_spamf0.lo: src/cg/$(am__dirstamp) \
 	src/cg/$(DEPDIR)/$(am__dirstamp)
 src/hrg/$(am__dirstamp):
 	@$(MKDIR_P) src/hrg
@@ -1848,15 +1859,15 @@ src/hrg/$(am__dirstamp):
 src/hrg/$(DEPDIR)/$(am__dirstamp):
 	@$(MKDIR_P) src/hrg/$(DEPDIR)
 	@: > src/hrg/$(DEPDIR)/$(am__dirstamp)
-src/hrg/libmimic_la-cst_utterance.lo: src/hrg/$(am__dirstamp) \
+src/hrg/libttsmimic_la-cst_utterance.lo: src/hrg/$(am__dirstamp) \
 	src/hrg/$(DEPDIR)/$(am__dirstamp)
-src/hrg/libmimic_la-cst_relation.lo: src/hrg/$(am__dirstamp) \
+src/hrg/libttsmimic_la-cst_relation.lo: src/hrg/$(am__dirstamp) \
 	src/hrg/$(DEPDIR)/$(am__dirstamp)
-src/hrg/libmimic_la-cst_item.lo: src/hrg/$(am__dirstamp) \
+src/hrg/libttsmimic_la-cst_item.lo: src/hrg/$(am__dirstamp) \
 	src/hrg/$(DEPDIR)/$(am__dirstamp)
-src/hrg/libmimic_la-cst_ffeature.lo: src/hrg/$(am__dirstamp) \
+src/hrg/libttsmimic_la-cst_ffeature.lo: src/hrg/$(am__dirstamp) \
 	src/hrg/$(DEPDIR)/$(am__dirstamp)
-src/hrg/libmimic_la-cst_rel_io.lo: src/hrg/$(am__dirstamp) \
+src/hrg/libttsmimic_la-cst_rel_io.lo: src/hrg/$(am__dirstamp) \
 	src/hrg/$(DEPDIR)/$(am__dirstamp)
 src/lexicon/$(am__dirstamp):
 	@$(MKDIR_P) src/lexicon
@@ -1864,11 +1875,12 @@ src/lexicon/$(am__dirstamp):
 src/lexicon/$(DEPDIR)/$(am__dirstamp):
 	@$(MKDIR_P) src/lexicon/$(DEPDIR)
 	@: > src/lexicon/$(DEPDIR)/$(am__dirstamp)
-src/lexicon/libmimic_la-cst_lexicon.lo: src/lexicon/$(am__dirstamp) \
+src/lexicon/libttsmimic_la-cst_lexicon.lo:  \
+	src/lexicon/$(am__dirstamp) \
 	src/lexicon/$(DEPDIR)/$(am__dirstamp)
-src/lexicon/libmimic_la-cst_lts.lo: src/lexicon/$(am__dirstamp) \
+src/lexicon/libttsmimic_la-cst_lts.lo: src/lexicon/$(am__dirstamp) \
 	src/lexicon/$(DEPDIR)/$(am__dirstamp)
-src/lexicon/libmimic_la-cst_lts_rewrites.lo:  \
+src/lexicon/libttsmimic_la-cst_lts_rewrites.lo:  \
 	src/lexicon/$(am__dirstamp) \
 	src/lexicon/$(DEPDIR)/$(am__dirstamp)
 src/regex/$(am__dirstamp):
@@ -1877,11 +1889,11 @@ src/regex/$(am__dirstamp):
 src/regex/$(DEPDIR)/$(am__dirstamp):
 	@$(MKDIR_P) src/regex/$(DEPDIR)
 	@: > src/regex/$(DEPDIR)/$(am__dirstamp)
-src/regex/libmimic_la-cst_regex.lo: src/regex/$(am__dirstamp) \
+src/regex/libttsmimic_la-cst_regex.lo: src/regex/$(am__dirstamp) \
 	src/regex/$(DEPDIR)/$(am__dirstamp)
-src/regex/libmimic_la-regexp.lo: src/regex/$(am__dirstamp) \
+src/regex/libttsmimic_la-regexp.lo: src/regex/$(am__dirstamp) \
 	src/regex/$(DEPDIR)/$(am__dirstamp)
-src/regex/libmimic_la-regsub.lo: src/regex/$(am__dirstamp) \
+src/regex/libttsmimic_la-regsub.lo: src/regex/$(am__dirstamp) \
 	src/regex/$(DEPDIR)/$(am__dirstamp)
 src/speech/$(am__dirstamp):
 	@$(MKDIR_P) src/speech
@@ -1889,27 +1901,28 @@ src/speech/$(am__dirstamp):
 src/speech/$(DEPDIR)/$(am__dirstamp):
 	@$(MKDIR_P) src/speech/$(DEPDIR)
 	@: > src/speech/$(DEPDIR)/$(am__dirstamp)
-src/speech/libmimic_la-cst_lpcres.lo: src/speech/$(am__dirstamp) \
+src/speech/libttsmimic_la-cst_lpcres.lo: src/speech/$(am__dirstamp) \
 	src/speech/$(DEPDIR)/$(am__dirstamp)
-src/speech/libmimic_la-cst_track.lo: src/speech/$(am__dirstamp) \
+src/speech/libttsmimic_la-cst_track.lo: src/speech/$(am__dirstamp) \
 	src/speech/$(DEPDIR)/$(am__dirstamp)
-src/speech/libmimic_la-cst_track_io.lo: src/speech/$(am__dirstamp) \
+src/speech/libttsmimic_la-cst_track_io.lo: src/speech/$(am__dirstamp) \
 	src/speech/$(DEPDIR)/$(am__dirstamp)
-src/speech/libmimic_la-cst_wave.lo: src/speech/$(am__dirstamp) \
+src/speech/libttsmimic_la-cst_wave.lo: src/speech/$(am__dirstamp) \
 	src/speech/$(DEPDIR)/$(am__dirstamp)
-src/speech/libmimic_la-cst_wave_io.lo: src/speech/$(am__dirstamp) \
+src/speech/libttsmimic_la-cst_wave_io.lo: src/speech/$(am__dirstamp) \
 	src/speech/$(DEPDIR)/$(am__dirstamp)
-src/speech/libmimic_la-cst_wave_utils.lo: src/speech/$(am__dirstamp) \
+src/speech/libttsmimic_la-cst_wave_utils.lo:  \
+	src/speech/$(am__dirstamp) \
 	src/speech/$(DEPDIR)/$(am__dirstamp)
-src/speech/libmimic_la-g721.lo: src/speech/$(am__dirstamp) \
+src/speech/libttsmimic_la-g721.lo: src/speech/$(am__dirstamp) \
 	src/speech/$(DEPDIR)/$(am__dirstamp)
-src/speech/libmimic_la-g723_24.lo: src/speech/$(am__dirstamp) \
+src/speech/libttsmimic_la-g723_24.lo: src/speech/$(am__dirstamp) \
 	src/speech/$(DEPDIR)/$(am__dirstamp)
-src/speech/libmimic_la-g723_40.lo: src/speech/$(am__dirstamp) \
+src/speech/libttsmimic_la-g723_40.lo: src/speech/$(am__dirstamp) \
 	src/speech/$(DEPDIR)/$(am__dirstamp)
-src/speech/libmimic_la-g72x.lo: src/speech/$(am__dirstamp) \
+src/speech/libttsmimic_la-g72x.lo: src/speech/$(am__dirstamp) \
 	src/speech/$(DEPDIR)/$(am__dirstamp)
-src/speech/libmimic_la-rateconv.lo: src/speech/$(am__dirstamp) \
+src/speech/libttsmimic_la-rateconv.lo: src/speech/$(am__dirstamp) \
 	src/speech/$(DEPDIR)/$(am__dirstamp)
 src/stats/$(am__dirstamp):
 	@$(MKDIR_P) src/stats
@@ -1917,11 +1930,11 @@ src/stats/$(am__dirstamp):
 src/stats/$(DEPDIR)/$(am__dirstamp):
 	@$(MKDIR_P) src/stats/$(DEPDIR)
 	@: > src/stats/$(DEPDIR)/$(am__dirstamp)
-src/stats/libmimic_la-cst_cart.lo: src/stats/$(am__dirstamp) \
+src/stats/libttsmimic_la-cst_cart.lo: src/stats/$(am__dirstamp) \
 	src/stats/$(DEPDIR)/$(am__dirstamp)
-src/stats/libmimic_la-cst_ss.lo: src/stats/$(am__dirstamp) \
+src/stats/libttsmimic_la-cst_ss.lo: src/stats/$(am__dirstamp) \
 	src/stats/$(DEPDIR)/$(am__dirstamp)
-src/stats/libmimic_la-cst_viterbi.lo: src/stats/$(am__dirstamp) \
+src/stats/libttsmimic_la-cst_viterbi.lo: src/stats/$(am__dirstamp) \
 	src/stats/$(DEPDIR)/$(am__dirstamp)
 src/synth/$(am__dirstamp):
 	@$(MKDIR_P) src/synth
@@ -1929,19 +1942,19 @@ src/synth/$(am__dirstamp):
 src/synth/$(DEPDIR)/$(am__dirstamp):
 	@$(MKDIR_P) src/synth/$(DEPDIR)
 	@: > src/synth/$(DEPDIR)/$(am__dirstamp)
-src/synth/libmimic_la-cst_ffeatures.lo: src/synth/$(am__dirstamp) \
+src/synth/libttsmimic_la-cst_ffeatures.lo: src/synth/$(am__dirstamp) \
 	src/synth/$(DEPDIR)/$(am__dirstamp)
-src/synth/libmimic_la-cst_phoneset.lo: src/synth/$(am__dirstamp) \
+src/synth/libttsmimic_la-cst_phoneset.lo: src/synth/$(am__dirstamp) \
 	src/synth/$(DEPDIR)/$(am__dirstamp)
-src/synth/libmimic_la-cst_ssml.lo: src/synth/$(am__dirstamp) \
+src/synth/libttsmimic_la-cst_ssml.lo: src/synth/$(am__dirstamp) \
 	src/synth/$(DEPDIR)/$(am__dirstamp)
-src/synth/libmimic_la-cst_synth.lo: src/synth/$(am__dirstamp) \
+src/synth/libttsmimic_la-cst_synth.lo: src/synth/$(am__dirstamp) \
 	src/synth/$(DEPDIR)/$(am__dirstamp)
-src/synth/libmimic_la-cst_utt_utils.lo: src/synth/$(am__dirstamp) \
+src/synth/libttsmimic_la-cst_utt_utils.lo: src/synth/$(am__dirstamp) \
 	src/synth/$(DEPDIR)/$(am__dirstamp)
-src/synth/libmimic_la-cst_voice.lo: src/synth/$(am__dirstamp) \
+src/synth/libttsmimic_la-cst_voice.lo: src/synth/$(am__dirstamp) \
 	src/synth/$(DEPDIR)/$(am__dirstamp)
-src/synth/libmimic_la-mimic.lo: src/synth/$(am__dirstamp) \
+src/synth/libttsmimic_la-mimic.lo: src/synth/$(am__dirstamp) \
 	src/synth/$(DEPDIR)/$(am__dirstamp)
 src/utils/$(am__dirstamp):
 	@$(MKDIR_P) src/utils
@@ -1949,39 +1962,39 @@ src/utils/$(am__dirstamp):
 src/utils/$(DEPDIR)/$(am__dirstamp):
 	@$(MKDIR_P) src/utils/$(DEPDIR)
 	@: > src/utils/$(DEPDIR)/$(am__dirstamp)
-src/utils/libmimic_la-cst_alloc.lo: src/utils/$(am__dirstamp) \
+src/utils/libttsmimic_la-cst_alloc.lo: src/utils/$(am__dirstamp) \
 	src/utils/$(DEPDIR)/$(am__dirstamp)
-src/utils/libmimic_la-cst_args.lo: src/utils/$(am__dirstamp) \
+src/utils/libttsmimic_la-cst_args.lo: src/utils/$(am__dirstamp) \
 	src/utils/$(DEPDIR)/$(am__dirstamp)
-src/utils/libmimic_la-cst_endian.lo: src/utils/$(am__dirstamp) \
+src/utils/libttsmimic_la-cst_endian.lo: src/utils/$(am__dirstamp) \
 	src/utils/$(DEPDIR)/$(am__dirstamp)
-src/utils/libmimic_la-cst_error.lo: src/utils/$(am__dirstamp) \
+src/utils/libttsmimic_la-cst_error.lo: src/utils/$(am__dirstamp) \
 	src/utils/$(DEPDIR)/$(am__dirstamp)
-src/utils/libmimic_la-cst_features.lo: src/utils/$(am__dirstamp) \
+src/utils/libttsmimic_la-cst_features.lo: src/utils/$(am__dirstamp) \
 	src/utils/$(DEPDIR)/$(am__dirstamp)
-src/utils/libmimic_la-cst_file_stdio.lo: src/utils/$(am__dirstamp) \
+src/utils/libttsmimic_la-cst_file_stdio.lo: src/utils/$(am__dirstamp) \
 	src/utils/$(DEPDIR)/$(am__dirstamp)
-src/utils/libmimic_la-cst_mmap_none.lo: src/utils/$(am__dirstamp) \
+src/utils/libttsmimic_la-cst_mmap_none.lo: src/utils/$(am__dirstamp) \
 	src/utils/$(DEPDIR)/$(am__dirstamp)
-src/utils/libmimic_la-cst_mmap_posix.lo: src/utils/$(am__dirstamp) \
+src/utils/libttsmimic_la-cst_mmap_posix.lo: src/utils/$(am__dirstamp) \
 	src/utils/$(DEPDIR)/$(am__dirstamp)
-src/utils/libmimic_la-cst_mmap_win32.lo: src/utils/$(am__dirstamp) \
+src/utils/libttsmimic_la-cst_mmap_win32.lo: src/utils/$(am__dirstamp) \
 	src/utils/$(DEPDIR)/$(am__dirstamp)
-src/utils/libmimic_la-cst_socket.lo: src/utils/$(am__dirstamp) \
+src/utils/libttsmimic_la-cst_socket.lo: src/utils/$(am__dirstamp) \
 	src/utils/$(DEPDIR)/$(am__dirstamp)
-src/utils/libmimic_la-cst_string.lo: src/utils/$(am__dirstamp) \
+src/utils/libttsmimic_la-cst_string.lo: src/utils/$(am__dirstamp) \
 	src/utils/$(DEPDIR)/$(am__dirstamp)
-src/utils/libmimic_la-cst_tokenstream.lo: src/utils/$(am__dirstamp) \
+src/utils/libttsmimic_la-cst_tokenstream.lo:  \
+	src/utils/$(am__dirstamp) src/utils/$(DEPDIR)/$(am__dirstamp)
+src/utils/libttsmimic_la-cst_url.lo: src/utils/$(am__dirstamp) \
 	src/utils/$(DEPDIR)/$(am__dirstamp)
-src/utils/libmimic_la-cst_url.lo: src/utils/$(am__dirstamp) \
+src/utils/libttsmimic_la-cst_val.lo: src/utils/$(am__dirstamp) \
 	src/utils/$(DEPDIR)/$(am__dirstamp)
-src/utils/libmimic_la-cst_val.lo: src/utils/$(am__dirstamp) \
+src/utils/libttsmimic_la-cst_val_const.lo: src/utils/$(am__dirstamp) \
 	src/utils/$(DEPDIR)/$(am__dirstamp)
-src/utils/libmimic_la-cst_val_const.lo: src/utils/$(am__dirstamp) \
+src/utils/libttsmimic_la-cst_val_user.lo: src/utils/$(am__dirstamp) \
 	src/utils/$(DEPDIR)/$(am__dirstamp)
-src/utils/libmimic_la-cst_val_user.lo: src/utils/$(am__dirstamp) \
-	src/utils/$(DEPDIR)/$(am__dirstamp)
-src/utils/libmimic_la-cst_wchar.lo: src/utils/$(am__dirstamp) \
+src/utils/libttsmimic_la-cst_wchar.lo: src/utils/$(am__dirstamp) \
 	src/utils/$(DEPDIR)/$(am__dirstamp)
 src/wavesynth/$(am__dirstamp):
 	@$(MKDIR_P) src/wavesynth
@@ -1989,24 +2002,27 @@ src/wavesynth/$(am__dirstamp):
 src/wavesynth/$(DEPDIR)/$(am__dirstamp):
 	@$(MKDIR_P) src/wavesynth/$(DEPDIR)
 	@: > src/wavesynth/$(DEPDIR)/$(am__dirstamp)
-src/wavesynth/libmimic_la-cst_clunits.lo:  \
+src/wavesynth/libttsmimic_la-cst_clunits.lo:  \
 	src/wavesynth/$(am__dirstamp) \
 	src/wavesynth/$(DEPDIR)/$(am__dirstamp)
-src/wavesynth/libmimic_la-cst_diphone.lo:  \
+src/wavesynth/libttsmimic_la-cst_diphone.lo:  \
 	src/wavesynth/$(am__dirstamp) \
 	src/wavesynth/$(DEPDIR)/$(am__dirstamp)
-src/wavesynth/libmimic_la-cst_reflpc.lo:  \
+src/wavesynth/libttsmimic_la-cst_reflpc.lo:  \
 	src/wavesynth/$(am__dirstamp) \
 	src/wavesynth/$(DEPDIR)/$(am__dirstamp)
-src/wavesynth/libmimic_la-cst_sigpr.lo: src/wavesynth/$(am__dirstamp) \
+src/wavesynth/libttsmimic_la-cst_sigpr.lo:  \
+	src/wavesynth/$(am__dirstamp) \
 	src/wavesynth/$(DEPDIR)/$(am__dirstamp)
-src/wavesynth/libmimic_la-cst_sts.lo: src/wavesynth/$(am__dirstamp) \
+src/wavesynth/libttsmimic_la-cst_sts.lo:  \
+	src/wavesynth/$(am__dirstamp) \
 	src/wavesynth/$(DEPDIR)/$(am__dirstamp)
-src/wavesynth/libmimic_la-cst_units.lo: src/wavesynth/$(am__dirstamp) \
+src/wavesynth/libttsmimic_la-cst_units.lo:  \
+	src/wavesynth/$(am__dirstamp) \
 	src/wavesynth/$(DEPDIR)/$(am__dirstamp)
 
-libmimic.la: $(libmimic_la_OBJECTS) $(libmimic_la_DEPENDENCIES) $(EXTRA_libmimic_la_DEPENDENCIES) 
-	$(AM_V_CCLD)$(libmimic_la_LINK) -rpath $(libdir) $(libmimic_la_OBJECTS) $(libmimic_la_LIBADD) $(LIBS)
+libttsmimic.la: $(libttsmimic_la_OBJECTS) $(libttsmimic_la_DEPENDENCIES) $(EXTRA_libttsmimic_la_DEPENDENCIES) 
+	$(AM_V_CCLD)$(libttsmimic_la_LINK) -rpath $(libdir) $(libttsmimic_la_OBJECTS) $(libttsmimic_la_LIBADD) $(LIBS)
 main/$(am__dirstamp):
 	@$(MKDIR_P) main
 	@: > main/$(am__dirstamp)
@@ -2016,13 +2032,13 @@ main/$(DEPDIR)/$(am__dirstamp):
 main/mimic_lang_list.lo: main/$(am__dirstamp) \
 	main/$(DEPDIR)/$(am__dirstamp)
 
-libmimic_lang_all_langs.la: $(libmimic_lang_all_langs_la_OBJECTS) $(libmimic_lang_all_langs_la_DEPENDENCIES) $(EXTRA_libmimic_lang_all_langs_la_DEPENDENCIES) 
-	$(AM_V_CCLD)$(libmimic_lang_all_langs_la_LINK) -rpath $(libdir) $(libmimic_lang_all_langs_la_OBJECTS) $(libmimic_lang_all_langs_la_LIBADD) $(LIBS)
+libttsmimic_lang_all_langs.la: $(libttsmimic_lang_all_langs_la_OBJECTS) $(libttsmimic_lang_all_langs_la_DEPENDENCIES) $(EXTRA_libttsmimic_lang_all_langs_la_DEPENDENCIES) 
+	$(AM_V_CCLD)$(libttsmimic_lang_all_langs_la_LINK) -rpath $(libdir) $(libttsmimic_lang_all_langs_la_OBJECTS) $(libttsmimic_lang_all_langs_la_LIBADD) $(LIBS)
 main/mimic_voice_list.lo: main/$(am__dirstamp) \
 	main/$(DEPDIR)/$(am__dirstamp)
 
-libmimic_lang_all_voices.la: $(libmimic_lang_all_voices_la_OBJECTS) $(libmimic_lang_all_voices_la_DEPENDENCIES) $(EXTRA_libmimic_lang_all_voices_la_DEPENDENCIES) 
-	$(AM_V_CCLD)$(libmimic_lang_all_voices_la_LINK) -rpath $(libdir) $(libmimic_lang_all_voices_la_OBJECTS) $(libmimic_lang_all_voices_la_LIBADD) $(LIBS)
+libttsmimic_lang_all_voices.la: $(libttsmimic_lang_all_voices_la_OBJECTS) $(libttsmimic_lang_all_voices_la_DEPENDENCIES) $(EXTRA_libttsmimic_lang_all_voices_la_DEPENDENCIES) 
+	$(AM_V_CCLD)$(libttsmimic_lang_all_voices_la_LINK) -rpath $(libdir) $(libttsmimic_lang_all_voices_la_OBJECTS) $(libttsmimic_lang_all_voices_la_LIBADD) $(LIBS)
 lang/cmu_grapheme_lang/$(am__dirstamp):
 	@$(MKDIR_P) lang/cmu_grapheme_lang
 	@: > lang/cmu_grapheme_lang/$(am__dirstamp)
@@ -2039,8 +2055,8 @@ lang/cmu_grapheme_lang/cmu_grapheme_phoneset.lo:  \
 	lang/cmu_grapheme_lang/$(am__dirstamp) \
 	lang/cmu_grapheme_lang/$(DEPDIR)/$(am__dirstamp)
 
-libmimic_lang_cmu_grapheme_lang.la: $(libmimic_lang_cmu_grapheme_lang_la_OBJECTS) $(libmimic_lang_cmu_grapheme_lang_la_DEPENDENCIES) $(EXTRA_libmimic_lang_cmu_grapheme_lang_la_DEPENDENCIES) 
-	$(AM_V_CCLD)$(libmimic_lang_cmu_grapheme_lang_la_LINK) $(am_libmimic_lang_cmu_grapheme_lang_la_rpath) $(libmimic_lang_cmu_grapheme_lang_la_OBJECTS) $(libmimic_lang_cmu_grapheme_lang_la_LIBADD) $(LIBS)
+libttsmimic_lang_cmu_grapheme_lang.la: $(libttsmimic_lang_cmu_grapheme_lang_la_OBJECTS) $(libttsmimic_lang_cmu_grapheme_lang_la_DEPENDENCIES) $(EXTRA_libttsmimic_lang_cmu_grapheme_lang_la_DEPENDENCIES) 
+	$(AM_V_CCLD)$(libttsmimic_lang_cmu_grapheme_lang_la_LINK) $(am_libttsmimic_lang_cmu_grapheme_lang_la_rpath) $(libttsmimic_lang_cmu_grapheme_lang_la_OBJECTS) $(libttsmimic_lang_cmu_grapheme_lang_la_LIBADD) $(LIBS)
 lang/cmu_grapheme_lex/$(am__dirstamp):
 	@$(MKDIR_P) lang/cmu_grapheme_lex
 	@: > lang/cmu_grapheme_lex/$(am__dirstamp)
@@ -2054,8 +2070,8 @@ lang/cmu_grapheme_lex/grapheme_unitran_tables.lo:  \
 	lang/cmu_grapheme_lex/$(am__dirstamp) \
 	lang/cmu_grapheme_lex/$(DEPDIR)/$(am__dirstamp)
 
-libmimic_lang_cmu_grapheme_lex.la: $(libmimic_lang_cmu_grapheme_lex_la_OBJECTS) $(libmimic_lang_cmu_grapheme_lex_la_DEPENDENCIES) $(EXTRA_libmimic_lang_cmu_grapheme_lex_la_DEPENDENCIES) 
-	$(AM_V_CCLD)$(libmimic_lang_cmu_grapheme_lex_la_LINK) $(am_libmimic_lang_cmu_grapheme_lex_la_rpath) $(libmimic_lang_cmu_grapheme_lex_la_OBJECTS) $(libmimic_lang_cmu_grapheme_lex_la_LIBADD) $(LIBS)
+libttsmimic_lang_cmu_grapheme_lex.la: $(libttsmimic_lang_cmu_grapheme_lex_la_OBJECTS) $(libttsmimic_lang_cmu_grapheme_lex_la_DEPENDENCIES) $(EXTRA_libttsmimic_lang_cmu_grapheme_lex_la_DEPENDENCIES) 
+	$(AM_V_CCLD)$(libttsmimic_lang_cmu_grapheme_lex_la_LINK) $(am_libttsmimic_lang_cmu_grapheme_lex_la_rpath) $(libttsmimic_lang_cmu_grapheme_lex_la_OBJECTS) $(libttsmimic_lang_cmu_grapheme_lex_la_LIBADD) $(LIBS)
 lang/cmu_indic_lang/$(am__dirstamp):
 	@$(MKDIR_P) lang/cmu_indic_lang
 	@: > lang/cmu_indic_lang/$(am__dirstamp)
@@ -2072,8 +2088,8 @@ lang/cmu_indic_lang/cmu_indic_phrasing_cart.lo:  \
 	lang/cmu_indic_lang/$(am__dirstamp) \
 	lang/cmu_indic_lang/$(DEPDIR)/$(am__dirstamp)
 
-libmimic_lang_cmu_indic_lang.la: $(libmimic_lang_cmu_indic_lang_la_OBJECTS) $(libmimic_lang_cmu_indic_lang_la_DEPENDENCIES) $(EXTRA_libmimic_lang_cmu_indic_lang_la_DEPENDENCIES) 
-	$(AM_V_CCLD)$(libmimic_lang_cmu_indic_lang_la_LINK) $(am_libmimic_lang_cmu_indic_lang_la_rpath) $(libmimic_lang_cmu_indic_lang_la_OBJECTS) $(libmimic_lang_cmu_indic_lang_la_LIBADD) $(LIBS)
+libttsmimic_lang_cmu_indic_lang.la: $(libttsmimic_lang_cmu_indic_lang_la_OBJECTS) $(libttsmimic_lang_cmu_indic_lang_la_DEPENDENCIES) $(EXTRA_libttsmimic_lang_cmu_indic_lang_la_DEPENDENCIES) 
+	$(AM_V_CCLD)$(libttsmimic_lang_cmu_indic_lang_la_LINK) $(am_libttsmimic_lang_cmu_indic_lang_la_rpath) $(libttsmimic_lang_cmu_indic_lang_la_OBJECTS) $(libttsmimic_lang_cmu_indic_lang_la_LIBADD) $(LIBS)
 lang/cmu_indic_lex/$(am__dirstamp):
 	@$(MKDIR_P) lang/cmu_indic_lex
 	@: > lang/cmu_indic_lex/$(am__dirstamp)
@@ -2084,203 +2100,203 @@ lang/cmu_indic_lex/cmu_indic_lex.lo:  \
 	lang/cmu_indic_lex/$(am__dirstamp) \
 	lang/cmu_indic_lex/$(DEPDIR)/$(am__dirstamp)
 
-libmimic_lang_cmu_indic_lex.la: $(libmimic_lang_cmu_indic_lex_la_OBJECTS) $(libmimic_lang_cmu_indic_lex_la_DEPENDENCIES) $(EXTRA_libmimic_lang_cmu_indic_lex_la_DEPENDENCIES) 
-	$(AM_V_CCLD)$(libmimic_lang_cmu_indic_lex_la_LINK) $(am_libmimic_lang_cmu_indic_lex_la_rpath) $(libmimic_lang_cmu_indic_lex_la_OBJECTS) $(libmimic_lang_cmu_indic_lex_la_LIBADD) $(LIBS)
+libttsmimic_lang_cmu_indic_lex.la: $(libttsmimic_lang_cmu_indic_lex_la_OBJECTS) $(libttsmimic_lang_cmu_indic_lex_la_DEPENDENCIES) $(EXTRA_libttsmimic_lang_cmu_indic_lex_la_DEPENDENCIES) 
+	$(AM_V_CCLD)$(libttsmimic_lang_cmu_indic_lex_la_LINK) $(am_libttsmimic_lang_cmu_indic_lex_la_rpath) $(libttsmimic_lang_cmu_indic_lex_la_OBJECTS) $(libttsmimic_lang_cmu_indic_lex_la_LIBADD) $(LIBS)
 lang/cmu_time_awb/$(am__dirstamp):
 	@$(MKDIR_P) lang/cmu_time_awb
 	@: > lang/cmu_time_awb/$(am__dirstamp)
 lang/cmu_time_awb/$(DEPDIR)/$(am__dirstamp):
 	@$(MKDIR_P) lang/cmu_time_awb/$(DEPDIR)
 	@: > lang/cmu_time_awb/$(DEPDIR)/$(am__dirstamp)
-lang/cmu_time_awb/libmimic_lang_cmu_time_awb_la-cmu_time_awb.lo:  \
+lang/cmu_time_awb/libttsmimic_lang_cmu_time_awb_la-cmu_time_awb.lo:  \
 	lang/cmu_time_awb/$(am__dirstamp) \
 	lang/cmu_time_awb/$(DEPDIR)/$(am__dirstamp)
-lang/cmu_time_awb/libmimic_lang_cmu_time_awb_la-cmu_time_awb_cart.lo:  \
+lang/cmu_time_awb/libttsmimic_lang_cmu_time_awb_la-cmu_time_awb_cart.lo:  \
 	lang/cmu_time_awb/$(am__dirstamp) \
 	lang/cmu_time_awb/$(DEPDIR)/$(am__dirstamp)
-lang/cmu_time_awb/libmimic_lang_cmu_time_awb_la-cmu_time_awb_clunits.lo:  \
+lang/cmu_time_awb/libttsmimic_lang_cmu_time_awb_la-cmu_time_awb_clunits.lo:  \
 	lang/cmu_time_awb/$(am__dirstamp) \
 	lang/cmu_time_awb/$(DEPDIR)/$(am__dirstamp)
-lang/cmu_time_awb/libmimic_lang_cmu_time_awb_la-cmu_time_awb_lex_entry.lo:  \
+lang/cmu_time_awb/libttsmimic_lang_cmu_time_awb_la-cmu_time_awb_lex_entry.lo:  \
 	lang/cmu_time_awb/$(am__dirstamp) \
 	lang/cmu_time_awb/$(DEPDIR)/$(am__dirstamp)
-lang/cmu_time_awb/libmimic_lang_cmu_time_awb_la-cmu_time_awb_lpc.lo:  \
+lang/cmu_time_awb/libttsmimic_lang_cmu_time_awb_la-cmu_time_awb_lpc.lo:  \
 	lang/cmu_time_awb/$(am__dirstamp) \
 	lang/cmu_time_awb/$(DEPDIR)/$(am__dirstamp)
-lang/cmu_time_awb/libmimic_lang_cmu_time_awb_la-cmu_time_awb_mcep.lo:  \
+lang/cmu_time_awb/libttsmimic_lang_cmu_time_awb_la-cmu_time_awb_mcep.lo:  \
 	lang/cmu_time_awb/$(am__dirstamp) \
 	lang/cmu_time_awb/$(DEPDIR)/$(am__dirstamp)
 
-libmimic_lang_cmu_time_awb.la: $(libmimic_lang_cmu_time_awb_la_OBJECTS) $(libmimic_lang_cmu_time_awb_la_DEPENDENCIES) $(EXTRA_libmimic_lang_cmu_time_awb_la_DEPENDENCIES) 
-	$(AM_V_CCLD)$(libmimic_lang_cmu_time_awb_la_LINK) $(am_libmimic_lang_cmu_time_awb_la_rpath) $(libmimic_lang_cmu_time_awb_la_OBJECTS) $(libmimic_lang_cmu_time_awb_la_LIBADD) $(LIBS)
+libttsmimic_lang_cmu_time_awb.la: $(libttsmimic_lang_cmu_time_awb_la_OBJECTS) $(libttsmimic_lang_cmu_time_awb_la_DEPENDENCIES) $(EXTRA_libttsmimic_lang_cmu_time_awb_la_DEPENDENCIES) 
+	$(AM_V_CCLD)$(libttsmimic_lang_cmu_time_awb_la_LINK) $(am_libttsmimic_lang_cmu_time_awb_la_rpath) $(libttsmimic_lang_cmu_time_awb_la_OBJECTS) $(libttsmimic_lang_cmu_time_awb_la_LIBADD) $(LIBS)
 lang/cmu_us_awb/$(am__dirstamp):
 	@$(MKDIR_P) lang/cmu_us_awb
 	@: > lang/cmu_us_awb/$(am__dirstamp)
 lang/cmu_us_awb/$(DEPDIR)/$(am__dirstamp):
 	@$(MKDIR_P) lang/cmu_us_awb/$(DEPDIR)
 	@: > lang/cmu_us_awb/$(DEPDIR)/$(am__dirstamp)
-lang/cmu_us_awb/libmimic_lang_cmu_us_awb_la-cmu_us_awb.lo:  \
+lang/cmu_us_awb/libttsmimic_lang_cmu_us_awb_la-cmu_us_awb.lo:  \
 	lang/cmu_us_awb/$(am__dirstamp) \
 	lang/cmu_us_awb/$(DEPDIR)/$(am__dirstamp)
-lang/cmu_us_awb/libmimic_lang_cmu_us_awb_la-cmu_us_awb_cg.lo:  \
+lang/cmu_us_awb/libttsmimic_lang_cmu_us_awb_la-cmu_us_awb_cg.lo:  \
 	lang/cmu_us_awb/$(am__dirstamp) \
 	lang/cmu_us_awb/$(DEPDIR)/$(am__dirstamp)
-lang/cmu_us_awb/libmimic_lang_cmu_us_awb_la-cmu_us_awb_cg_durmodel.lo:  \
+lang/cmu_us_awb/libttsmimic_lang_cmu_us_awb_la-cmu_us_awb_cg_durmodel.lo:  \
 	lang/cmu_us_awb/$(am__dirstamp) \
 	lang/cmu_us_awb/$(DEPDIR)/$(am__dirstamp)
-lang/cmu_us_awb/libmimic_lang_cmu_us_awb_la-cmu_us_awb_cg_f0_trees.lo:  \
+lang/cmu_us_awb/libttsmimic_lang_cmu_us_awb_la-cmu_us_awb_cg_f0_trees.lo:  \
 	lang/cmu_us_awb/$(am__dirstamp) \
 	lang/cmu_us_awb/$(DEPDIR)/$(am__dirstamp)
-lang/cmu_us_awb/libmimic_lang_cmu_us_awb_la-cmu_us_awb_cg_phonestate.lo:  \
+lang/cmu_us_awb/libttsmimic_lang_cmu_us_awb_la-cmu_us_awb_cg_phonestate.lo:  \
 	lang/cmu_us_awb/$(am__dirstamp) \
 	lang/cmu_us_awb/$(DEPDIR)/$(am__dirstamp)
-lang/cmu_us_awb/libmimic_lang_cmu_us_awb_la-cmu_us_awb_cg_single_mcep_trees.lo:  \
+lang/cmu_us_awb/libttsmimic_lang_cmu_us_awb_la-cmu_us_awb_cg_single_mcep_trees.lo:  \
 	lang/cmu_us_awb/$(am__dirstamp) \
 	lang/cmu_us_awb/$(DEPDIR)/$(am__dirstamp)
-lang/cmu_us_awb/libmimic_lang_cmu_us_awb_la-cmu_us_awb_cg_single_params.lo:  \
+lang/cmu_us_awb/libttsmimic_lang_cmu_us_awb_la-cmu_us_awb_cg_single_params.lo:  \
 	lang/cmu_us_awb/$(am__dirstamp) \
 	lang/cmu_us_awb/$(DEPDIR)/$(am__dirstamp)
-lang/cmu_us_awb/libmimic_lang_cmu_us_awb_la-cmu_us_awb_spamf0_accent.lo:  \
+lang/cmu_us_awb/libttsmimic_lang_cmu_us_awb_la-cmu_us_awb_spamf0_accent.lo:  \
 	lang/cmu_us_awb/$(am__dirstamp) \
 	lang/cmu_us_awb/$(DEPDIR)/$(am__dirstamp)
-lang/cmu_us_awb/libmimic_lang_cmu_us_awb_la-cmu_us_awb_spamf0_accent_params.lo:  \
+lang/cmu_us_awb/libttsmimic_lang_cmu_us_awb_la-cmu_us_awb_spamf0_accent_params.lo:  \
 	lang/cmu_us_awb/$(am__dirstamp) \
 	lang/cmu_us_awb/$(DEPDIR)/$(am__dirstamp)
-lang/cmu_us_awb/libmimic_lang_cmu_us_awb_la-cmu_us_awb_spamf0_phrase.lo:  \
+lang/cmu_us_awb/libttsmimic_lang_cmu_us_awb_la-cmu_us_awb_spamf0_phrase.lo:  \
 	lang/cmu_us_awb/$(am__dirstamp) \
 	lang/cmu_us_awb/$(DEPDIR)/$(am__dirstamp)
 
-libmimic_lang_cmu_us_awb.la: $(libmimic_lang_cmu_us_awb_la_OBJECTS) $(libmimic_lang_cmu_us_awb_la_DEPENDENCIES) $(EXTRA_libmimic_lang_cmu_us_awb_la_DEPENDENCIES) 
-	$(AM_V_CCLD)$(libmimic_lang_cmu_us_awb_la_LINK) $(am_libmimic_lang_cmu_us_awb_la_rpath) $(libmimic_lang_cmu_us_awb_la_OBJECTS) $(libmimic_lang_cmu_us_awb_la_LIBADD) $(LIBS)
+libttsmimic_lang_cmu_us_awb.la: $(libttsmimic_lang_cmu_us_awb_la_OBJECTS) $(libttsmimic_lang_cmu_us_awb_la_DEPENDENCIES) $(EXTRA_libttsmimic_lang_cmu_us_awb_la_DEPENDENCIES) 
+	$(AM_V_CCLD)$(libttsmimic_lang_cmu_us_awb_la_LINK) $(am_libttsmimic_lang_cmu_us_awb_la_rpath) $(libttsmimic_lang_cmu_us_awb_la_OBJECTS) $(libttsmimic_lang_cmu_us_awb_la_LIBADD) $(LIBS)
 lang/cmu_us_kal/$(am__dirstamp):
 	@$(MKDIR_P) lang/cmu_us_kal
 	@: > lang/cmu_us_kal/$(am__dirstamp)
 lang/cmu_us_kal/$(DEPDIR)/$(am__dirstamp):
 	@$(MKDIR_P) lang/cmu_us_kal/$(DEPDIR)
 	@: > lang/cmu_us_kal/$(DEPDIR)/$(am__dirstamp)
-lang/cmu_us_kal/libmimic_lang_cmu_us_kal_la-cmu_us_kal.lo:  \
+lang/cmu_us_kal/libttsmimic_lang_cmu_us_kal_la-cmu_us_kal.lo:  \
 	lang/cmu_us_kal/$(am__dirstamp) \
 	lang/cmu_us_kal/$(DEPDIR)/$(am__dirstamp)
-lang/cmu_us_kal/libmimic_lang_cmu_us_kal_la-cmu_us_kal_diphone.lo:  \
+lang/cmu_us_kal/libttsmimic_lang_cmu_us_kal_la-cmu_us_kal_diphone.lo:  \
 	lang/cmu_us_kal/$(am__dirstamp) \
 	lang/cmu_us_kal/$(DEPDIR)/$(am__dirstamp)
-lang/cmu_us_kal/libmimic_lang_cmu_us_kal_la-cmu_us_kal_lpc.lo:  \
+lang/cmu_us_kal/libttsmimic_lang_cmu_us_kal_la-cmu_us_kal_lpc.lo:  \
 	lang/cmu_us_kal/$(am__dirstamp) \
 	lang/cmu_us_kal/$(DEPDIR)/$(am__dirstamp)
-lang/cmu_us_kal/libmimic_lang_cmu_us_kal_la-cmu_us_kal_res.lo:  \
+lang/cmu_us_kal/libttsmimic_lang_cmu_us_kal_la-cmu_us_kal_res.lo:  \
 	lang/cmu_us_kal/$(am__dirstamp) \
 	lang/cmu_us_kal/$(DEPDIR)/$(am__dirstamp)
-lang/cmu_us_kal/libmimic_lang_cmu_us_kal_la-cmu_us_kal_residx.lo:  \
+lang/cmu_us_kal/libttsmimic_lang_cmu_us_kal_la-cmu_us_kal_residx.lo:  \
 	lang/cmu_us_kal/$(am__dirstamp) \
 	lang/cmu_us_kal/$(DEPDIR)/$(am__dirstamp)
-lang/cmu_us_kal/libmimic_lang_cmu_us_kal_la-cmu_us_kal_ressize.lo:  \
+lang/cmu_us_kal/libttsmimic_lang_cmu_us_kal_la-cmu_us_kal_ressize.lo:  \
 	lang/cmu_us_kal/$(am__dirstamp) \
 	lang/cmu_us_kal/$(DEPDIR)/$(am__dirstamp)
 
-libmimic_lang_cmu_us_kal.la: $(libmimic_lang_cmu_us_kal_la_OBJECTS) $(libmimic_lang_cmu_us_kal_la_DEPENDENCIES) $(EXTRA_libmimic_lang_cmu_us_kal_la_DEPENDENCIES) 
-	$(AM_V_CCLD)$(libmimic_lang_cmu_us_kal_la_LINK) $(am_libmimic_lang_cmu_us_kal_la_rpath) $(libmimic_lang_cmu_us_kal_la_OBJECTS) $(libmimic_lang_cmu_us_kal_la_LIBADD) $(LIBS)
+libttsmimic_lang_cmu_us_kal.la: $(libttsmimic_lang_cmu_us_kal_la_OBJECTS) $(libttsmimic_lang_cmu_us_kal_la_DEPENDENCIES) $(EXTRA_libttsmimic_lang_cmu_us_kal_la_DEPENDENCIES) 
+	$(AM_V_CCLD)$(libttsmimic_lang_cmu_us_kal_la_LINK) $(am_libttsmimic_lang_cmu_us_kal_la_rpath) $(libttsmimic_lang_cmu_us_kal_la_OBJECTS) $(libttsmimic_lang_cmu_us_kal_la_LIBADD) $(LIBS)
 lang/cmu_us_kal16/$(am__dirstamp):
 	@$(MKDIR_P) lang/cmu_us_kal16
 	@: > lang/cmu_us_kal16/$(am__dirstamp)
 lang/cmu_us_kal16/$(DEPDIR)/$(am__dirstamp):
 	@$(MKDIR_P) lang/cmu_us_kal16/$(DEPDIR)
 	@: > lang/cmu_us_kal16/$(DEPDIR)/$(am__dirstamp)
-lang/cmu_us_kal16/libmimic_lang_cmu_us_kal16_la-cmu_us_kal16.lo:  \
+lang/cmu_us_kal16/libttsmimic_lang_cmu_us_kal16_la-cmu_us_kal16.lo:  \
 	lang/cmu_us_kal16/$(am__dirstamp) \
 	lang/cmu_us_kal16/$(DEPDIR)/$(am__dirstamp)
-lang/cmu_us_kal16/libmimic_lang_cmu_us_kal16_la-cmu_us_kal16_diphone.lo:  \
+lang/cmu_us_kal16/libttsmimic_lang_cmu_us_kal16_la-cmu_us_kal16_diphone.lo:  \
 	lang/cmu_us_kal16/$(am__dirstamp) \
 	lang/cmu_us_kal16/$(DEPDIR)/$(am__dirstamp)
-lang/cmu_us_kal16/libmimic_lang_cmu_us_kal16_la-cmu_us_kal16_lpc.lo:  \
+lang/cmu_us_kal16/libttsmimic_lang_cmu_us_kal16_la-cmu_us_kal16_lpc.lo:  \
 	lang/cmu_us_kal16/$(am__dirstamp) \
 	lang/cmu_us_kal16/$(DEPDIR)/$(am__dirstamp)
-lang/cmu_us_kal16/libmimic_lang_cmu_us_kal16_la-cmu_us_kal16_res.lo:  \
+lang/cmu_us_kal16/libttsmimic_lang_cmu_us_kal16_la-cmu_us_kal16_res.lo:  \
 	lang/cmu_us_kal16/$(am__dirstamp) \
 	lang/cmu_us_kal16/$(DEPDIR)/$(am__dirstamp)
-lang/cmu_us_kal16/libmimic_lang_cmu_us_kal16_la-cmu_us_kal16_residx.lo:  \
+lang/cmu_us_kal16/libttsmimic_lang_cmu_us_kal16_la-cmu_us_kal16_residx.lo:  \
 	lang/cmu_us_kal16/$(am__dirstamp) \
 	lang/cmu_us_kal16/$(DEPDIR)/$(am__dirstamp)
 
-libmimic_lang_cmu_us_kal16.la: $(libmimic_lang_cmu_us_kal16_la_OBJECTS) $(libmimic_lang_cmu_us_kal16_la_DEPENDENCIES) $(EXTRA_libmimic_lang_cmu_us_kal16_la_DEPENDENCIES) 
-	$(AM_V_CCLD)$(libmimic_lang_cmu_us_kal16_la_LINK) $(am_libmimic_lang_cmu_us_kal16_la_rpath) $(libmimic_lang_cmu_us_kal16_la_OBJECTS) $(libmimic_lang_cmu_us_kal16_la_LIBADD) $(LIBS)
+libttsmimic_lang_cmu_us_kal16.la: $(libttsmimic_lang_cmu_us_kal16_la_OBJECTS) $(libttsmimic_lang_cmu_us_kal16_la_DEPENDENCIES) $(EXTRA_libttsmimic_lang_cmu_us_kal16_la_DEPENDENCIES) 
+	$(AM_V_CCLD)$(libttsmimic_lang_cmu_us_kal16_la_LINK) $(am_libttsmimic_lang_cmu_us_kal16_la_rpath) $(libttsmimic_lang_cmu_us_kal16_la_OBJECTS) $(libttsmimic_lang_cmu_us_kal16_la_LIBADD) $(LIBS)
 lang/cmu_us_rms/$(am__dirstamp):
 	@$(MKDIR_P) lang/cmu_us_rms
 	@: > lang/cmu_us_rms/$(am__dirstamp)
 lang/cmu_us_rms/$(DEPDIR)/$(am__dirstamp):
 	@$(MKDIR_P) lang/cmu_us_rms/$(DEPDIR)
 	@: > lang/cmu_us_rms/$(DEPDIR)/$(am__dirstamp)
-lang/cmu_us_rms/libmimic_lang_cmu_us_rms_la-cmu_us_rms.lo:  \
+lang/cmu_us_rms/libttsmimic_lang_cmu_us_rms_la-cmu_us_rms.lo:  \
 	lang/cmu_us_rms/$(am__dirstamp) \
 	lang/cmu_us_rms/$(DEPDIR)/$(am__dirstamp)
-lang/cmu_us_rms/libmimic_lang_cmu_us_rms_la-cmu_us_rms_cg.lo:  \
+lang/cmu_us_rms/libttsmimic_lang_cmu_us_rms_la-cmu_us_rms_cg.lo:  \
 	lang/cmu_us_rms/$(am__dirstamp) \
 	lang/cmu_us_rms/$(DEPDIR)/$(am__dirstamp)
-lang/cmu_us_rms/libmimic_lang_cmu_us_rms_la-cmu_us_rms_cg_durmodel.lo:  \
+lang/cmu_us_rms/libttsmimic_lang_cmu_us_rms_la-cmu_us_rms_cg_durmodel.lo:  \
 	lang/cmu_us_rms/$(am__dirstamp) \
 	lang/cmu_us_rms/$(DEPDIR)/$(am__dirstamp)
-lang/cmu_us_rms/libmimic_lang_cmu_us_rms_la-cmu_us_rms_cg_f0_trees.lo:  \
+lang/cmu_us_rms/libttsmimic_lang_cmu_us_rms_la-cmu_us_rms_cg_f0_trees.lo:  \
 	lang/cmu_us_rms/$(am__dirstamp) \
 	lang/cmu_us_rms/$(DEPDIR)/$(am__dirstamp)
-lang/cmu_us_rms/libmimic_lang_cmu_us_rms_la-cmu_us_rms_cg_phonestate.lo:  \
+lang/cmu_us_rms/libttsmimic_lang_cmu_us_rms_la-cmu_us_rms_cg_phonestate.lo:  \
 	lang/cmu_us_rms/$(am__dirstamp) \
 	lang/cmu_us_rms/$(DEPDIR)/$(am__dirstamp)
-lang/cmu_us_rms/libmimic_lang_cmu_us_rms_la-cmu_us_rms_cg_single_mcep_trees.lo:  \
+lang/cmu_us_rms/libttsmimic_lang_cmu_us_rms_la-cmu_us_rms_cg_single_mcep_trees.lo:  \
 	lang/cmu_us_rms/$(am__dirstamp) \
 	lang/cmu_us_rms/$(DEPDIR)/$(am__dirstamp)
-lang/cmu_us_rms/libmimic_lang_cmu_us_rms_la-cmu_us_rms_cg_single_params.lo:  \
+lang/cmu_us_rms/libttsmimic_lang_cmu_us_rms_la-cmu_us_rms_cg_single_params.lo:  \
 	lang/cmu_us_rms/$(am__dirstamp) \
 	lang/cmu_us_rms/$(DEPDIR)/$(am__dirstamp)
-lang/cmu_us_rms/libmimic_lang_cmu_us_rms_la-cmu_us_rms_spamf0_accent.lo:  \
+lang/cmu_us_rms/libttsmimic_lang_cmu_us_rms_la-cmu_us_rms_spamf0_accent.lo:  \
 	lang/cmu_us_rms/$(am__dirstamp) \
 	lang/cmu_us_rms/$(DEPDIR)/$(am__dirstamp)
-lang/cmu_us_rms/libmimic_lang_cmu_us_rms_la-cmu_us_rms_spamf0_accent_params.lo:  \
+lang/cmu_us_rms/libttsmimic_lang_cmu_us_rms_la-cmu_us_rms_spamf0_accent_params.lo:  \
 	lang/cmu_us_rms/$(am__dirstamp) \
 	lang/cmu_us_rms/$(DEPDIR)/$(am__dirstamp)
-lang/cmu_us_rms/libmimic_lang_cmu_us_rms_la-cmu_us_rms_spamf0_phrase.lo:  \
+lang/cmu_us_rms/libttsmimic_lang_cmu_us_rms_la-cmu_us_rms_spamf0_phrase.lo:  \
 	lang/cmu_us_rms/$(am__dirstamp) \
 	lang/cmu_us_rms/$(DEPDIR)/$(am__dirstamp)
 
-libmimic_lang_cmu_us_rms.la: $(libmimic_lang_cmu_us_rms_la_OBJECTS) $(libmimic_lang_cmu_us_rms_la_DEPENDENCIES) $(EXTRA_libmimic_lang_cmu_us_rms_la_DEPENDENCIES) 
-	$(AM_V_CCLD)$(libmimic_lang_cmu_us_rms_la_LINK) $(am_libmimic_lang_cmu_us_rms_la_rpath) $(libmimic_lang_cmu_us_rms_la_OBJECTS) $(libmimic_lang_cmu_us_rms_la_LIBADD) $(LIBS)
+libttsmimic_lang_cmu_us_rms.la: $(libttsmimic_lang_cmu_us_rms_la_OBJECTS) $(libttsmimic_lang_cmu_us_rms_la_DEPENDENCIES) $(EXTRA_libttsmimic_lang_cmu_us_rms_la_DEPENDENCIES) 
+	$(AM_V_CCLD)$(libttsmimic_lang_cmu_us_rms_la_LINK) $(am_libttsmimic_lang_cmu_us_rms_la_rpath) $(libttsmimic_lang_cmu_us_rms_la_OBJECTS) $(libttsmimic_lang_cmu_us_rms_la_LIBADD) $(LIBS)
 lang/cmu_us_slt/$(am__dirstamp):
 	@$(MKDIR_P) lang/cmu_us_slt
 	@: > lang/cmu_us_slt/$(am__dirstamp)
 lang/cmu_us_slt/$(DEPDIR)/$(am__dirstamp):
 	@$(MKDIR_P) lang/cmu_us_slt/$(DEPDIR)
 	@: > lang/cmu_us_slt/$(DEPDIR)/$(am__dirstamp)
-lang/cmu_us_slt/libmimic_lang_cmu_us_slt_la-cmu_us_slt.lo:  \
+lang/cmu_us_slt/libttsmimic_lang_cmu_us_slt_la-cmu_us_slt.lo:  \
 	lang/cmu_us_slt/$(am__dirstamp) \
 	lang/cmu_us_slt/$(DEPDIR)/$(am__dirstamp)
-lang/cmu_us_slt/libmimic_lang_cmu_us_slt_la-cmu_us_slt_cg.lo:  \
+lang/cmu_us_slt/libttsmimic_lang_cmu_us_slt_la-cmu_us_slt_cg.lo:  \
 	lang/cmu_us_slt/$(am__dirstamp) \
 	lang/cmu_us_slt/$(DEPDIR)/$(am__dirstamp)
-lang/cmu_us_slt/libmimic_lang_cmu_us_slt_la-cmu_us_slt_cg_durmodel.lo:  \
+lang/cmu_us_slt/libttsmimic_lang_cmu_us_slt_la-cmu_us_slt_cg_durmodel.lo:  \
 	lang/cmu_us_slt/$(am__dirstamp) \
 	lang/cmu_us_slt/$(DEPDIR)/$(am__dirstamp)
-lang/cmu_us_slt/libmimic_lang_cmu_us_slt_la-cmu_us_slt_cg_f0_trees.lo:  \
+lang/cmu_us_slt/libttsmimic_lang_cmu_us_slt_la-cmu_us_slt_cg_f0_trees.lo:  \
 	lang/cmu_us_slt/$(am__dirstamp) \
 	lang/cmu_us_slt/$(DEPDIR)/$(am__dirstamp)
-lang/cmu_us_slt/libmimic_lang_cmu_us_slt_la-cmu_us_slt_cg_phonestate.lo:  \
+lang/cmu_us_slt/libttsmimic_lang_cmu_us_slt_la-cmu_us_slt_cg_phonestate.lo:  \
 	lang/cmu_us_slt/$(am__dirstamp) \
 	lang/cmu_us_slt/$(DEPDIR)/$(am__dirstamp)
-lang/cmu_us_slt/libmimic_lang_cmu_us_slt_la-cmu_us_slt_cg_single_mcep_trees.lo:  \
+lang/cmu_us_slt/libttsmimic_lang_cmu_us_slt_la-cmu_us_slt_cg_single_mcep_trees.lo:  \
 	lang/cmu_us_slt/$(am__dirstamp) \
 	lang/cmu_us_slt/$(DEPDIR)/$(am__dirstamp)
-lang/cmu_us_slt/libmimic_lang_cmu_us_slt_la-cmu_us_slt_cg_single_params.lo:  \
+lang/cmu_us_slt/libttsmimic_lang_cmu_us_slt_la-cmu_us_slt_cg_single_params.lo:  \
 	lang/cmu_us_slt/$(am__dirstamp) \
 	lang/cmu_us_slt/$(DEPDIR)/$(am__dirstamp)
-lang/cmu_us_slt/libmimic_lang_cmu_us_slt_la-cmu_us_slt_spamf0_accent.lo:  \
+lang/cmu_us_slt/libttsmimic_lang_cmu_us_slt_la-cmu_us_slt_spamf0_accent.lo:  \
 	lang/cmu_us_slt/$(am__dirstamp) \
 	lang/cmu_us_slt/$(DEPDIR)/$(am__dirstamp)
-lang/cmu_us_slt/libmimic_lang_cmu_us_slt_la-cmu_us_slt_spamf0_accent_params.lo:  \
+lang/cmu_us_slt/libttsmimic_lang_cmu_us_slt_la-cmu_us_slt_spamf0_accent_params.lo:  \
 	lang/cmu_us_slt/$(am__dirstamp) \
 	lang/cmu_us_slt/$(DEPDIR)/$(am__dirstamp)
-lang/cmu_us_slt/libmimic_lang_cmu_us_slt_la-cmu_us_slt_spamf0_phrase.lo:  \
+lang/cmu_us_slt/libttsmimic_lang_cmu_us_slt_la-cmu_us_slt_spamf0_phrase.lo:  \
 	lang/cmu_us_slt/$(am__dirstamp) \
 	lang/cmu_us_slt/$(DEPDIR)/$(am__dirstamp)
 
-libmimic_lang_cmu_us_slt.la: $(libmimic_lang_cmu_us_slt_la_OBJECTS) $(libmimic_lang_cmu_us_slt_la_DEPENDENCIES) $(EXTRA_libmimic_lang_cmu_us_slt_la_DEPENDENCIES) 
-	$(AM_V_CCLD)$(libmimic_lang_cmu_us_slt_la_LINK) $(am_libmimic_lang_cmu_us_slt_la_rpath) $(libmimic_lang_cmu_us_slt_la_OBJECTS) $(libmimic_lang_cmu_us_slt_la_LIBADD) $(LIBS)
+libttsmimic_lang_cmu_us_slt.la: $(libttsmimic_lang_cmu_us_slt_la_OBJECTS) $(libttsmimic_lang_cmu_us_slt_la_DEPENDENCIES) $(EXTRA_libttsmimic_lang_cmu_us_slt_la_DEPENDENCIES) 
+	$(AM_V_CCLD)$(libttsmimic_lang_cmu_us_slt_la_LINK) $(am_libttsmimic_lang_cmu_us_slt_la_rpath) $(libttsmimic_lang_cmu_us_slt_la_OBJECTS) $(libttsmimic_lang_cmu_us_slt_la_LIBADD) $(LIBS)
 lang/cmulex/$(am__dirstamp):
 	@$(MKDIR_P) lang/cmulex
 	@: > lang/cmulex/$(am__dirstamp)
@@ -2300,8 +2316,8 @@ lang/cmulex/cmu_lts_rules.lo: lang/cmulex/$(am__dirstamp) \
 lang/cmulex/cmu_postlex.lo: lang/cmulex/$(am__dirstamp) \
 	lang/cmulex/$(DEPDIR)/$(am__dirstamp)
 
-libmimic_lang_cmulex.la: $(libmimic_lang_cmulex_la_OBJECTS) $(libmimic_lang_cmulex_la_DEPENDENCIES) $(EXTRA_libmimic_lang_cmulex_la_DEPENDENCIES) 
-	$(AM_V_CCLD)$(libmimic_lang_cmulex_la_LINK) $(am_libmimic_lang_cmulex_la_rpath) $(libmimic_lang_cmulex_la_OBJECTS) $(libmimic_lang_cmulex_la_LIBADD) $(LIBS)
+libttsmimic_lang_cmulex.la: $(libttsmimic_lang_cmulex_la_OBJECTS) $(libttsmimic_lang_cmulex_la_DEPENDENCIES) $(EXTRA_libttsmimic_lang_cmulex_la_DEPENDENCIES) 
+	$(AM_V_CCLD)$(libttsmimic_lang_cmulex_la_LINK) $(am_libttsmimic_lang_cmulex_la_rpath) $(libttsmimic_lang_cmulex_la_OBJECTS) $(libttsmimic_lang_cmulex_la_LIBADD) $(LIBS)
 lang/usenglish/$(am__dirstamp):
 	@$(MKDIR_P) lang/usenglish
 	@: > lang/usenglish/$(am__dirstamp)
@@ -2341,56 +2357,56 @@ lang/usenglish/us_pos_cart.lo: lang/usenglish/$(am__dirstamp) \
 lang/usenglish/us_text.lo: lang/usenglish/$(am__dirstamp) \
 	lang/usenglish/$(DEPDIR)/$(am__dirstamp)
 
-libmimic_lang_usenglish.la: $(libmimic_lang_usenglish_la_OBJECTS) $(libmimic_lang_usenglish_la_DEPENDENCIES) $(EXTRA_libmimic_lang_usenglish_la_DEPENDENCIES) 
-	$(AM_V_CCLD)$(libmimic_lang_usenglish_la_LINK) $(am_libmimic_lang_usenglish_la_rpath) $(libmimic_lang_usenglish_la_OBJECTS) $(libmimic_lang_usenglish_la_LIBADD) $(LIBS)
+libttsmimic_lang_usenglish.la: $(libttsmimic_lang_usenglish_la_OBJECTS) $(libttsmimic_lang_usenglish_la_DEPENDENCIES) $(EXTRA_libttsmimic_lang_usenglish_la_DEPENDENCIES) 
+	$(AM_V_CCLD)$(libttsmimic_lang_usenglish_la_LINK) $(am_libttsmimic_lang_usenglish_la_rpath) $(libttsmimic_lang_usenglish_la_OBJECTS) $(libttsmimic_lang_usenglish_la_LIBADD) $(LIBS)
 lang/vid_gb_ap/$(am__dirstamp):
 	@$(MKDIR_P) lang/vid_gb_ap
 	@: > lang/vid_gb_ap/$(am__dirstamp)
 lang/vid_gb_ap/$(DEPDIR)/$(am__dirstamp):
 	@$(MKDIR_P) lang/vid_gb_ap/$(DEPDIR)
 	@: > lang/vid_gb_ap/$(DEPDIR)/$(am__dirstamp)
-lang/vid_gb_ap/libmimic_lang_vid_gb_ap_la-vid_gb_ap.lo:  \
+lang/vid_gb_ap/libttsmimic_lang_vid_gb_ap_la-vid_gb_ap.lo:  \
 	lang/vid_gb_ap/$(am__dirstamp) \
 	lang/vid_gb_ap/$(DEPDIR)/$(am__dirstamp)
-lang/vid_gb_ap/libmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_01_mcep_trees.lo:  \
+lang/vid_gb_ap/libttsmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_01_mcep_trees.lo:  \
 	lang/vid_gb_ap/$(am__dirstamp) \
 	lang/vid_gb_ap/$(DEPDIR)/$(am__dirstamp)
-lang/vid_gb_ap/libmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_01_params.lo:  \
+lang/vid_gb_ap/libttsmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_01_params.lo:  \
 	lang/vid_gb_ap/$(am__dirstamp) \
 	lang/vid_gb_ap/$(DEPDIR)/$(am__dirstamp)
-lang/vid_gb_ap/libmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_08_durmodel.lo:  \
+lang/vid_gb_ap/libttsmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_08_durmodel.lo:  \
 	lang/vid_gb_ap/$(am__dirstamp) \
 	lang/vid_gb_ap/$(DEPDIR)/$(am__dirstamp)
-lang/vid_gb_ap/libmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_10_durmodel.lo:  \
+lang/vid_gb_ap/libttsmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_10_durmodel.lo:  \
 	lang/vid_gb_ap/$(am__dirstamp) \
 	lang/vid_gb_ap/$(DEPDIR)/$(am__dirstamp)
-lang/vid_gb_ap/libmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_12_mcep_trees.lo:  \
+lang/vid_gb_ap/libttsmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_12_mcep_trees.lo:  \
 	lang/vid_gb_ap/$(am__dirstamp) \
 	lang/vid_gb_ap/$(DEPDIR)/$(am__dirstamp)
-lang/vid_gb_ap/libmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_12_params.lo:  \
+lang/vid_gb_ap/libttsmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_12_params.lo:  \
 	lang/vid_gb_ap/$(am__dirstamp) \
 	lang/vid_gb_ap/$(DEPDIR)/$(am__dirstamp)
-lang/vid_gb_ap/libmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_17_durmodel.lo:  \
+lang/vid_gb_ap/libttsmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_17_durmodel.lo:  \
 	lang/vid_gb_ap/$(am__dirstamp) \
 	lang/vid_gb_ap/$(DEPDIR)/$(am__dirstamp)
-lang/vid_gb_ap/libmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_17_mcep_trees.lo:  \
+lang/vid_gb_ap/libttsmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_17_mcep_trees.lo:  \
 	lang/vid_gb_ap/$(am__dirstamp) \
 	lang/vid_gb_ap/$(DEPDIR)/$(am__dirstamp)
-lang/vid_gb_ap/libmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_17_params.lo:  \
+lang/vid_gb_ap/libttsmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_17_params.lo:  \
 	lang/vid_gb_ap/$(am__dirstamp) \
 	lang/vid_gb_ap/$(DEPDIR)/$(am__dirstamp)
-lang/vid_gb_ap/libmimic_lang_vid_gb_ap_la-vid_gb_ap_cg.lo:  \
+lang/vid_gb_ap/libttsmimic_lang_vid_gb_ap_la-vid_gb_ap_cg.lo:  \
 	lang/vid_gb_ap/$(am__dirstamp) \
 	lang/vid_gb_ap/$(DEPDIR)/$(am__dirstamp)
-lang/vid_gb_ap/libmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_f0_trees.lo:  \
+lang/vid_gb_ap/libttsmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_f0_trees.lo:  \
 	lang/vid_gb_ap/$(am__dirstamp) \
 	lang/vid_gb_ap/$(DEPDIR)/$(am__dirstamp)
-lang/vid_gb_ap/libmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_phonestate.lo:  \
+lang/vid_gb_ap/libttsmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_phonestate.lo:  \
 	lang/vid_gb_ap/$(am__dirstamp) \
 	lang/vid_gb_ap/$(DEPDIR)/$(am__dirstamp)
 
-libmimic_lang_vid_gb_ap.la: $(libmimic_lang_vid_gb_ap_la_OBJECTS) $(libmimic_lang_vid_gb_ap_la_DEPENDENCIES) $(EXTRA_libmimic_lang_vid_gb_ap_la_DEPENDENCIES) 
-	$(AM_V_CCLD)$(libmimic_lang_vid_gb_ap_la_LINK) $(am_libmimic_lang_vid_gb_ap_la_rpath) $(libmimic_lang_vid_gb_ap_la_OBJECTS) $(libmimic_lang_vid_gb_ap_la_LIBADD) $(LIBS)
+libttsmimic_lang_vid_gb_ap.la: $(libttsmimic_lang_vid_gb_ap_la_OBJECTS) $(libttsmimic_lang_vid_gb_ap_la_DEPENDENCIES) $(EXTRA_libttsmimic_lang_vid_gb_ap_la_DEPENDENCIES) 
+	$(AM_V_CCLD)$(libttsmimic_lang_vid_gb_ap_la_LINK) $(am_libttsmimic_lang_vid_gb_ap_la_rpath) $(libttsmimic_lang_vid_gb_ap_la_OBJECTS) $(libttsmimic_lang_vid_gb_ap_la_LIBADD) $(LIBS)
 install-binPROGRAMS: $(bin_PROGRAMS)
 	@$(NORMAL_INSTALL)
 	@list='$(bin_PROGRAMS)'; test -n "$(bindir)" || list=; \
@@ -2713,53 +2729,53 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@lang/cmu_indic_lang/$(DEPDIR)/cmu_indic_phoneset.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@lang/cmu_indic_lang/$(DEPDIR)/cmu_indic_phrasing_cart.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@lang/cmu_indic_lex/$(DEPDIR)/cmu_indic_lex.Plo@am__quote@
-@AMDEP_TRUE@@am__include@ @am__quote@lang/cmu_time_awb/$(DEPDIR)/libmimic_lang_cmu_time_awb_la-cmu_time_awb.Plo@am__quote@
-@AMDEP_TRUE@@am__include@ @am__quote@lang/cmu_time_awb/$(DEPDIR)/libmimic_lang_cmu_time_awb_la-cmu_time_awb_cart.Plo@am__quote@
-@AMDEP_TRUE@@am__include@ @am__quote@lang/cmu_time_awb/$(DEPDIR)/libmimic_lang_cmu_time_awb_la-cmu_time_awb_clunits.Plo@am__quote@
-@AMDEP_TRUE@@am__include@ @am__quote@lang/cmu_time_awb/$(DEPDIR)/libmimic_lang_cmu_time_awb_la-cmu_time_awb_lex_entry.Plo@am__quote@
-@AMDEP_TRUE@@am__include@ @am__quote@lang/cmu_time_awb/$(DEPDIR)/libmimic_lang_cmu_time_awb_la-cmu_time_awb_lpc.Plo@am__quote@
-@AMDEP_TRUE@@am__include@ @am__quote@lang/cmu_time_awb/$(DEPDIR)/libmimic_lang_cmu_time_awb_la-cmu_time_awb_mcep.Plo@am__quote@
-@AMDEP_TRUE@@am__include@ @am__quote@lang/cmu_us_awb/$(DEPDIR)/libmimic_lang_cmu_us_awb_la-cmu_us_awb.Plo@am__quote@
-@AMDEP_TRUE@@am__include@ @am__quote@lang/cmu_us_awb/$(DEPDIR)/libmimic_lang_cmu_us_awb_la-cmu_us_awb_cg.Plo@am__quote@
-@AMDEP_TRUE@@am__include@ @am__quote@lang/cmu_us_awb/$(DEPDIR)/libmimic_lang_cmu_us_awb_la-cmu_us_awb_cg_durmodel.Plo@am__quote@
-@AMDEP_TRUE@@am__include@ @am__quote@lang/cmu_us_awb/$(DEPDIR)/libmimic_lang_cmu_us_awb_la-cmu_us_awb_cg_f0_trees.Plo@am__quote@
-@AMDEP_TRUE@@am__include@ @am__quote@lang/cmu_us_awb/$(DEPDIR)/libmimic_lang_cmu_us_awb_la-cmu_us_awb_cg_phonestate.Plo@am__quote@
-@AMDEP_TRUE@@am__include@ @am__quote@lang/cmu_us_awb/$(DEPDIR)/libmimic_lang_cmu_us_awb_la-cmu_us_awb_cg_single_mcep_trees.Plo@am__quote@
-@AMDEP_TRUE@@am__include@ @am__quote@lang/cmu_us_awb/$(DEPDIR)/libmimic_lang_cmu_us_awb_la-cmu_us_awb_cg_single_params.Plo@am__quote@
-@AMDEP_TRUE@@am__include@ @am__quote@lang/cmu_us_awb/$(DEPDIR)/libmimic_lang_cmu_us_awb_la-cmu_us_awb_spamf0_accent.Plo@am__quote@
-@AMDEP_TRUE@@am__include@ @am__quote@lang/cmu_us_awb/$(DEPDIR)/libmimic_lang_cmu_us_awb_la-cmu_us_awb_spamf0_accent_params.Plo@am__quote@
-@AMDEP_TRUE@@am__include@ @am__quote@lang/cmu_us_awb/$(DEPDIR)/libmimic_lang_cmu_us_awb_la-cmu_us_awb_spamf0_phrase.Plo@am__quote@
-@AMDEP_TRUE@@am__include@ @am__quote@lang/cmu_us_kal/$(DEPDIR)/libmimic_lang_cmu_us_kal_la-cmu_us_kal.Plo@am__quote@
-@AMDEP_TRUE@@am__include@ @am__quote@lang/cmu_us_kal/$(DEPDIR)/libmimic_lang_cmu_us_kal_la-cmu_us_kal_diphone.Plo@am__quote@
-@AMDEP_TRUE@@am__include@ @am__quote@lang/cmu_us_kal/$(DEPDIR)/libmimic_lang_cmu_us_kal_la-cmu_us_kal_lpc.Plo@am__quote@
-@AMDEP_TRUE@@am__include@ @am__quote@lang/cmu_us_kal/$(DEPDIR)/libmimic_lang_cmu_us_kal_la-cmu_us_kal_res.Plo@am__quote@
-@AMDEP_TRUE@@am__include@ @am__quote@lang/cmu_us_kal/$(DEPDIR)/libmimic_lang_cmu_us_kal_la-cmu_us_kal_residx.Plo@am__quote@
-@AMDEP_TRUE@@am__include@ @am__quote@lang/cmu_us_kal/$(DEPDIR)/libmimic_lang_cmu_us_kal_la-cmu_us_kal_ressize.Plo@am__quote@
-@AMDEP_TRUE@@am__include@ @am__quote@lang/cmu_us_kal16/$(DEPDIR)/libmimic_lang_cmu_us_kal16_la-cmu_us_kal16.Plo@am__quote@
-@AMDEP_TRUE@@am__include@ @am__quote@lang/cmu_us_kal16/$(DEPDIR)/libmimic_lang_cmu_us_kal16_la-cmu_us_kal16_diphone.Plo@am__quote@
-@AMDEP_TRUE@@am__include@ @am__quote@lang/cmu_us_kal16/$(DEPDIR)/libmimic_lang_cmu_us_kal16_la-cmu_us_kal16_lpc.Plo@am__quote@
-@AMDEP_TRUE@@am__include@ @am__quote@lang/cmu_us_kal16/$(DEPDIR)/libmimic_lang_cmu_us_kal16_la-cmu_us_kal16_res.Plo@am__quote@
-@AMDEP_TRUE@@am__include@ @am__quote@lang/cmu_us_kal16/$(DEPDIR)/libmimic_lang_cmu_us_kal16_la-cmu_us_kal16_residx.Plo@am__quote@
-@AMDEP_TRUE@@am__include@ @am__quote@lang/cmu_us_rms/$(DEPDIR)/libmimic_lang_cmu_us_rms_la-cmu_us_rms.Plo@am__quote@
-@AMDEP_TRUE@@am__include@ @am__quote@lang/cmu_us_rms/$(DEPDIR)/libmimic_lang_cmu_us_rms_la-cmu_us_rms_cg.Plo@am__quote@
-@AMDEP_TRUE@@am__include@ @am__quote@lang/cmu_us_rms/$(DEPDIR)/libmimic_lang_cmu_us_rms_la-cmu_us_rms_cg_durmodel.Plo@am__quote@
-@AMDEP_TRUE@@am__include@ @am__quote@lang/cmu_us_rms/$(DEPDIR)/libmimic_lang_cmu_us_rms_la-cmu_us_rms_cg_f0_trees.Plo@am__quote@
-@AMDEP_TRUE@@am__include@ @am__quote@lang/cmu_us_rms/$(DEPDIR)/libmimic_lang_cmu_us_rms_la-cmu_us_rms_cg_phonestate.Plo@am__quote@
-@AMDEP_TRUE@@am__include@ @am__quote@lang/cmu_us_rms/$(DEPDIR)/libmimic_lang_cmu_us_rms_la-cmu_us_rms_cg_single_mcep_trees.Plo@am__quote@
-@AMDEP_TRUE@@am__include@ @am__quote@lang/cmu_us_rms/$(DEPDIR)/libmimic_lang_cmu_us_rms_la-cmu_us_rms_cg_single_params.Plo@am__quote@
-@AMDEP_TRUE@@am__include@ @am__quote@lang/cmu_us_rms/$(DEPDIR)/libmimic_lang_cmu_us_rms_la-cmu_us_rms_spamf0_accent.Plo@am__quote@
-@AMDEP_TRUE@@am__include@ @am__quote@lang/cmu_us_rms/$(DEPDIR)/libmimic_lang_cmu_us_rms_la-cmu_us_rms_spamf0_accent_params.Plo@am__quote@
-@AMDEP_TRUE@@am__include@ @am__quote@lang/cmu_us_rms/$(DEPDIR)/libmimic_lang_cmu_us_rms_la-cmu_us_rms_spamf0_phrase.Plo@am__quote@
-@AMDEP_TRUE@@am__include@ @am__quote@lang/cmu_us_slt/$(DEPDIR)/libmimic_lang_cmu_us_slt_la-cmu_us_slt.Plo@am__quote@
-@AMDEP_TRUE@@am__include@ @am__quote@lang/cmu_us_slt/$(DEPDIR)/libmimic_lang_cmu_us_slt_la-cmu_us_slt_cg.Plo@am__quote@
-@AMDEP_TRUE@@am__include@ @am__quote@lang/cmu_us_slt/$(DEPDIR)/libmimic_lang_cmu_us_slt_la-cmu_us_slt_cg_durmodel.Plo@am__quote@
-@AMDEP_TRUE@@am__include@ @am__quote@lang/cmu_us_slt/$(DEPDIR)/libmimic_lang_cmu_us_slt_la-cmu_us_slt_cg_f0_trees.Plo@am__quote@
-@AMDEP_TRUE@@am__include@ @am__quote@lang/cmu_us_slt/$(DEPDIR)/libmimic_lang_cmu_us_slt_la-cmu_us_slt_cg_phonestate.Plo@am__quote@
-@AMDEP_TRUE@@am__include@ @am__quote@lang/cmu_us_slt/$(DEPDIR)/libmimic_lang_cmu_us_slt_la-cmu_us_slt_cg_single_mcep_trees.Plo@am__quote@
-@AMDEP_TRUE@@am__include@ @am__quote@lang/cmu_us_slt/$(DEPDIR)/libmimic_lang_cmu_us_slt_la-cmu_us_slt_cg_single_params.Plo@am__quote@
-@AMDEP_TRUE@@am__include@ @am__quote@lang/cmu_us_slt/$(DEPDIR)/libmimic_lang_cmu_us_slt_la-cmu_us_slt_spamf0_accent.Plo@am__quote@
-@AMDEP_TRUE@@am__include@ @am__quote@lang/cmu_us_slt/$(DEPDIR)/libmimic_lang_cmu_us_slt_la-cmu_us_slt_spamf0_accent_params.Plo@am__quote@
-@AMDEP_TRUE@@am__include@ @am__quote@lang/cmu_us_slt/$(DEPDIR)/libmimic_lang_cmu_us_slt_la-cmu_us_slt_spamf0_phrase.Plo@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@lang/cmu_time_awb/$(DEPDIR)/libttsmimic_lang_cmu_time_awb_la-cmu_time_awb.Plo@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@lang/cmu_time_awb/$(DEPDIR)/libttsmimic_lang_cmu_time_awb_la-cmu_time_awb_cart.Plo@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@lang/cmu_time_awb/$(DEPDIR)/libttsmimic_lang_cmu_time_awb_la-cmu_time_awb_clunits.Plo@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@lang/cmu_time_awb/$(DEPDIR)/libttsmimic_lang_cmu_time_awb_la-cmu_time_awb_lex_entry.Plo@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@lang/cmu_time_awb/$(DEPDIR)/libttsmimic_lang_cmu_time_awb_la-cmu_time_awb_lpc.Plo@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@lang/cmu_time_awb/$(DEPDIR)/libttsmimic_lang_cmu_time_awb_la-cmu_time_awb_mcep.Plo@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@lang/cmu_us_awb/$(DEPDIR)/libttsmimic_lang_cmu_us_awb_la-cmu_us_awb.Plo@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@lang/cmu_us_awb/$(DEPDIR)/libttsmimic_lang_cmu_us_awb_la-cmu_us_awb_cg.Plo@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@lang/cmu_us_awb/$(DEPDIR)/libttsmimic_lang_cmu_us_awb_la-cmu_us_awb_cg_durmodel.Plo@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@lang/cmu_us_awb/$(DEPDIR)/libttsmimic_lang_cmu_us_awb_la-cmu_us_awb_cg_f0_trees.Plo@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@lang/cmu_us_awb/$(DEPDIR)/libttsmimic_lang_cmu_us_awb_la-cmu_us_awb_cg_phonestate.Plo@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@lang/cmu_us_awb/$(DEPDIR)/libttsmimic_lang_cmu_us_awb_la-cmu_us_awb_cg_single_mcep_trees.Plo@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@lang/cmu_us_awb/$(DEPDIR)/libttsmimic_lang_cmu_us_awb_la-cmu_us_awb_cg_single_params.Plo@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@lang/cmu_us_awb/$(DEPDIR)/libttsmimic_lang_cmu_us_awb_la-cmu_us_awb_spamf0_accent.Plo@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@lang/cmu_us_awb/$(DEPDIR)/libttsmimic_lang_cmu_us_awb_la-cmu_us_awb_spamf0_accent_params.Plo@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@lang/cmu_us_awb/$(DEPDIR)/libttsmimic_lang_cmu_us_awb_la-cmu_us_awb_spamf0_phrase.Plo@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@lang/cmu_us_kal/$(DEPDIR)/libttsmimic_lang_cmu_us_kal_la-cmu_us_kal.Plo@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@lang/cmu_us_kal/$(DEPDIR)/libttsmimic_lang_cmu_us_kal_la-cmu_us_kal_diphone.Plo@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@lang/cmu_us_kal/$(DEPDIR)/libttsmimic_lang_cmu_us_kal_la-cmu_us_kal_lpc.Plo@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@lang/cmu_us_kal/$(DEPDIR)/libttsmimic_lang_cmu_us_kal_la-cmu_us_kal_res.Plo@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@lang/cmu_us_kal/$(DEPDIR)/libttsmimic_lang_cmu_us_kal_la-cmu_us_kal_residx.Plo@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@lang/cmu_us_kal/$(DEPDIR)/libttsmimic_lang_cmu_us_kal_la-cmu_us_kal_ressize.Plo@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@lang/cmu_us_kal16/$(DEPDIR)/libttsmimic_lang_cmu_us_kal16_la-cmu_us_kal16.Plo@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@lang/cmu_us_kal16/$(DEPDIR)/libttsmimic_lang_cmu_us_kal16_la-cmu_us_kal16_diphone.Plo@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@lang/cmu_us_kal16/$(DEPDIR)/libttsmimic_lang_cmu_us_kal16_la-cmu_us_kal16_lpc.Plo@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@lang/cmu_us_kal16/$(DEPDIR)/libttsmimic_lang_cmu_us_kal16_la-cmu_us_kal16_res.Plo@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@lang/cmu_us_kal16/$(DEPDIR)/libttsmimic_lang_cmu_us_kal16_la-cmu_us_kal16_residx.Plo@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@lang/cmu_us_rms/$(DEPDIR)/libttsmimic_lang_cmu_us_rms_la-cmu_us_rms.Plo@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@lang/cmu_us_rms/$(DEPDIR)/libttsmimic_lang_cmu_us_rms_la-cmu_us_rms_cg.Plo@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@lang/cmu_us_rms/$(DEPDIR)/libttsmimic_lang_cmu_us_rms_la-cmu_us_rms_cg_durmodel.Plo@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@lang/cmu_us_rms/$(DEPDIR)/libttsmimic_lang_cmu_us_rms_la-cmu_us_rms_cg_f0_trees.Plo@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@lang/cmu_us_rms/$(DEPDIR)/libttsmimic_lang_cmu_us_rms_la-cmu_us_rms_cg_phonestate.Plo@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@lang/cmu_us_rms/$(DEPDIR)/libttsmimic_lang_cmu_us_rms_la-cmu_us_rms_cg_single_mcep_trees.Plo@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@lang/cmu_us_rms/$(DEPDIR)/libttsmimic_lang_cmu_us_rms_la-cmu_us_rms_cg_single_params.Plo@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@lang/cmu_us_rms/$(DEPDIR)/libttsmimic_lang_cmu_us_rms_la-cmu_us_rms_spamf0_accent.Plo@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@lang/cmu_us_rms/$(DEPDIR)/libttsmimic_lang_cmu_us_rms_la-cmu_us_rms_spamf0_accent_params.Plo@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@lang/cmu_us_rms/$(DEPDIR)/libttsmimic_lang_cmu_us_rms_la-cmu_us_rms_spamf0_phrase.Plo@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@lang/cmu_us_slt/$(DEPDIR)/libttsmimic_lang_cmu_us_slt_la-cmu_us_slt.Plo@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@lang/cmu_us_slt/$(DEPDIR)/libttsmimic_lang_cmu_us_slt_la-cmu_us_slt_cg.Plo@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@lang/cmu_us_slt/$(DEPDIR)/libttsmimic_lang_cmu_us_slt_la-cmu_us_slt_cg_durmodel.Plo@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@lang/cmu_us_slt/$(DEPDIR)/libttsmimic_lang_cmu_us_slt_la-cmu_us_slt_cg_f0_trees.Plo@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@lang/cmu_us_slt/$(DEPDIR)/libttsmimic_lang_cmu_us_slt_la-cmu_us_slt_cg_phonestate.Plo@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@lang/cmu_us_slt/$(DEPDIR)/libttsmimic_lang_cmu_us_slt_la-cmu_us_slt_cg_single_mcep_trees.Plo@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@lang/cmu_us_slt/$(DEPDIR)/libttsmimic_lang_cmu_us_slt_la-cmu_us_slt_cg_single_params.Plo@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@lang/cmu_us_slt/$(DEPDIR)/libttsmimic_lang_cmu_us_slt_la-cmu_us_slt_spamf0_accent.Plo@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@lang/cmu_us_slt/$(DEPDIR)/libttsmimic_lang_cmu_us_slt_la-cmu_us_slt_spamf0_accent_params.Plo@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@lang/cmu_us_slt/$(DEPDIR)/libttsmimic_lang_cmu_us_slt_la-cmu_us_slt_spamf0_phrase.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@lang/cmulex/$(DEPDIR)/cmu_lex.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@lang/cmulex/$(DEPDIR)/cmu_lex_data.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@lang/cmulex/$(DEPDIR)/cmu_lex_entries.Plo@am__quote@
@@ -2782,19 +2798,19 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@lang/usenglish/$(DEPDIR)/us_pos_cart.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@lang/usenglish/$(DEPDIR)/us_text.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@lang/usenglish/$(DEPDIR)/usenglish.Plo@am__quote@
-@AMDEP_TRUE@@am__include@ @am__quote@lang/vid_gb_ap/$(DEPDIR)/libmimic_lang_vid_gb_ap_la-vid_gb_ap.Plo@am__quote@
-@AMDEP_TRUE@@am__include@ @am__quote@lang/vid_gb_ap/$(DEPDIR)/libmimic_lang_vid_gb_ap_la-vid_gb_ap_cg.Plo@am__quote@
-@AMDEP_TRUE@@am__include@ @am__quote@lang/vid_gb_ap/$(DEPDIR)/libmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_01_mcep_trees.Plo@am__quote@
-@AMDEP_TRUE@@am__include@ @am__quote@lang/vid_gb_ap/$(DEPDIR)/libmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_01_params.Plo@am__quote@
-@AMDEP_TRUE@@am__include@ @am__quote@lang/vid_gb_ap/$(DEPDIR)/libmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_08_durmodel.Plo@am__quote@
-@AMDEP_TRUE@@am__include@ @am__quote@lang/vid_gb_ap/$(DEPDIR)/libmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_10_durmodel.Plo@am__quote@
-@AMDEP_TRUE@@am__include@ @am__quote@lang/vid_gb_ap/$(DEPDIR)/libmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_12_mcep_trees.Plo@am__quote@
-@AMDEP_TRUE@@am__include@ @am__quote@lang/vid_gb_ap/$(DEPDIR)/libmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_12_params.Plo@am__quote@
-@AMDEP_TRUE@@am__include@ @am__quote@lang/vid_gb_ap/$(DEPDIR)/libmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_17_durmodel.Plo@am__quote@
-@AMDEP_TRUE@@am__include@ @am__quote@lang/vid_gb_ap/$(DEPDIR)/libmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_17_mcep_trees.Plo@am__quote@
-@AMDEP_TRUE@@am__include@ @am__quote@lang/vid_gb_ap/$(DEPDIR)/libmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_17_params.Plo@am__quote@
-@AMDEP_TRUE@@am__include@ @am__quote@lang/vid_gb_ap/$(DEPDIR)/libmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_f0_trees.Plo@am__quote@
-@AMDEP_TRUE@@am__include@ @am__quote@lang/vid_gb_ap/$(DEPDIR)/libmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_phonestate.Plo@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@lang/vid_gb_ap/$(DEPDIR)/libttsmimic_lang_vid_gb_ap_la-vid_gb_ap.Plo@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@lang/vid_gb_ap/$(DEPDIR)/libttsmimic_lang_vid_gb_ap_la-vid_gb_ap_cg.Plo@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@lang/vid_gb_ap/$(DEPDIR)/libttsmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_01_mcep_trees.Plo@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@lang/vid_gb_ap/$(DEPDIR)/libttsmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_01_params.Plo@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@lang/vid_gb_ap/$(DEPDIR)/libttsmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_08_durmodel.Plo@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@lang/vid_gb_ap/$(DEPDIR)/libttsmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_10_durmodel.Plo@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@lang/vid_gb_ap/$(DEPDIR)/libttsmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_12_mcep_trees.Plo@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@lang/vid_gb_ap/$(DEPDIR)/libttsmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_12_params.Plo@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@lang/vid_gb_ap/$(DEPDIR)/libttsmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_17_durmodel.Plo@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@lang/vid_gb_ap/$(DEPDIR)/libttsmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_17_mcep_trees.Plo@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@lang/vid_gb_ap/$(DEPDIR)/libttsmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_17_params.Plo@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@lang/vid_gb_ap/$(DEPDIR)/libttsmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_f0_trees.Plo@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@lang/vid_gb_ap/$(DEPDIR)/libttsmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_phonestate.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@main/$(DEPDIR)/compile_regexes.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@main/$(DEPDIR)/mimic_lang_list.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@main/$(DEPDIR)/mimic_main.Po@am__quote@
@@ -2802,81 +2818,81 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@main/$(DEPDIR)/mimic_voice_list.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@main/$(DEPDIR)/mimicvox_info_main.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@main/$(DEPDIR)/t2p_main.Po@am__quote@
-@AMDEP_TRUE@@am__include@ @am__quote@src/audio/$(DEPDIR)/libmimic_la-au_alsa.Plo@am__quote@
-@AMDEP_TRUE@@am__include@ @am__quote@src/audio/$(DEPDIR)/libmimic_la-au_command.Plo@am__quote@
-@AMDEP_TRUE@@am__include@ @am__quote@src/audio/$(DEPDIR)/libmimic_la-au_none.Plo@am__quote@
-@AMDEP_TRUE@@am__include@ @am__quote@src/audio/$(DEPDIR)/libmimic_la-au_oss.Plo@am__quote@
-@AMDEP_TRUE@@am__include@ @am__quote@src/audio/$(DEPDIR)/libmimic_la-au_portaudio.Plo@am__quote@
-@AMDEP_TRUE@@am__include@ @am__quote@src/audio/$(DEPDIR)/libmimic_la-au_pulseaudio.Plo@am__quote@
-@AMDEP_TRUE@@am__include@ @am__quote@src/audio/$(DEPDIR)/libmimic_la-au_streaming.Plo@am__quote@
-@AMDEP_TRUE@@am__include@ @am__quote@src/audio/$(DEPDIR)/libmimic_la-au_sun.Plo@am__quote@
-@AMDEP_TRUE@@am__include@ @am__quote@src/audio/$(DEPDIR)/libmimic_la-au_wince.Plo@am__quote@
-@AMDEP_TRUE@@am__include@ @am__quote@src/audio/$(DEPDIR)/libmimic_la-auclient.Plo@am__quote@
-@AMDEP_TRUE@@am__include@ @am__quote@src/audio/$(DEPDIR)/libmimic_la-audio.Plo@am__quote@
-@AMDEP_TRUE@@am__include@ @am__quote@src/audio/$(DEPDIR)/libmimic_la-auserver.Plo@am__quote@
-@AMDEP_TRUE@@am__include@ @am__quote@src/cg/$(DEPDIR)/libmimic_la-cst_cg.Plo@am__quote@
-@AMDEP_TRUE@@am__include@ @am__quote@src/cg/$(DEPDIR)/libmimic_la-cst_cg_dump_voice.Plo@am__quote@
-@AMDEP_TRUE@@am__include@ @am__quote@src/cg/$(DEPDIR)/libmimic_la-cst_cg_load_voice.Plo@am__quote@
-@AMDEP_TRUE@@am__include@ @am__quote@src/cg/$(DEPDIR)/libmimic_la-cst_cg_map.Plo@am__quote@
-@AMDEP_TRUE@@am__include@ @am__quote@src/cg/$(DEPDIR)/libmimic_la-cst_mlpg.Plo@am__quote@
-@AMDEP_TRUE@@am__include@ @am__quote@src/cg/$(DEPDIR)/libmimic_la-cst_mlsa.Plo@am__quote@
-@AMDEP_TRUE@@am__include@ @am__quote@src/cg/$(DEPDIR)/libmimic_la-cst_spamf0.Plo@am__quote@
-@AMDEP_TRUE@@am__include@ @am__quote@src/cg/$(DEPDIR)/libmimic_la-cst_vc.Plo@am__quote@
-@AMDEP_TRUE@@am__include@ @am__quote@src/hrg/$(DEPDIR)/libmimic_la-cst_ffeature.Plo@am__quote@
-@AMDEP_TRUE@@am__include@ @am__quote@src/hrg/$(DEPDIR)/libmimic_la-cst_item.Plo@am__quote@
-@AMDEP_TRUE@@am__include@ @am__quote@src/hrg/$(DEPDIR)/libmimic_la-cst_rel_io.Plo@am__quote@
-@AMDEP_TRUE@@am__include@ @am__quote@src/hrg/$(DEPDIR)/libmimic_la-cst_relation.Plo@am__quote@
-@AMDEP_TRUE@@am__include@ @am__quote@src/hrg/$(DEPDIR)/libmimic_la-cst_utterance.Plo@am__quote@
-@AMDEP_TRUE@@am__include@ @am__quote@src/lexicon/$(DEPDIR)/libmimic_la-cst_lexicon.Plo@am__quote@
-@AMDEP_TRUE@@am__include@ @am__quote@src/lexicon/$(DEPDIR)/libmimic_la-cst_lts.Plo@am__quote@
-@AMDEP_TRUE@@am__include@ @am__quote@src/lexicon/$(DEPDIR)/libmimic_la-cst_lts_rewrites.Plo@am__quote@
-@AMDEP_TRUE@@am__include@ @am__quote@src/regex/$(DEPDIR)/libmimic_la-cst_regex.Plo@am__quote@
-@AMDEP_TRUE@@am__include@ @am__quote@src/regex/$(DEPDIR)/libmimic_la-regexp.Plo@am__quote@
-@AMDEP_TRUE@@am__include@ @am__quote@src/regex/$(DEPDIR)/libmimic_la-regsub.Plo@am__quote@
-@AMDEP_TRUE@@am__include@ @am__quote@src/speech/$(DEPDIR)/libmimic_la-cst_lpcres.Plo@am__quote@
-@AMDEP_TRUE@@am__include@ @am__quote@src/speech/$(DEPDIR)/libmimic_la-cst_track.Plo@am__quote@
-@AMDEP_TRUE@@am__include@ @am__quote@src/speech/$(DEPDIR)/libmimic_la-cst_track_io.Plo@am__quote@
-@AMDEP_TRUE@@am__include@ @am__quote@src/speech/$(DEPDIR)/libmimic_la-cst_wave.Plo@am__quote@
-@AMDEP_TRUE@@am__include@ @am__quote@src/speech/$(DEPDIR)/libmimic_la-cst_wave_io.Plo@am__quote@
-@AMDEP_TRUE@@am__include@ @am__quote@src/speech/$(DEPDIR)/libmimic_la-cst_wave_utils.Plo@am__quote@
-@AMDEP_TRUE@@am__include@ @am__quote@src/speech/$(DEPDIR)/libmimic_la-g721.Plo@am__quote@
-@AMDEP_TRUE@@am__include@ @am__quote@src/speech/$(DEPDIR)/libmimic_la-g723_24.Plo@am__quote@
-@AMDEP_TRUE@@am__include@ @am__quote@src/speech/$(DEPDIR)/libmimic_la-g723_40.Plo@am__quote@
-@AMDEP_TRUE@@am__include@ @am__quote@src/speech/$(DEPDIR)/libmimic_la-g72x.Plo@am__quote@
-@AMDEP_TRUE@@am__include@ @am__quote@src/speech/$(DEPDIR)/libmimic_la-rateconv.Plo@am__quote@
-@AMDEP_TRUE@@am__include@ @am__quote@src/stats/$(DEPDIR)/libmimic_la-cst_cart.Plo@am__quote@
-@AMDEP_TRUE@@am__include@ @am__quote@src/stats/$(DEPDIR)/libmimic_la-cst_ss.Plo@am__quote@
-@AMDEP_TRUE@@am__include@ @am__quote@src/stats/$(DEPDIR)/libmimic_la-cst_viterbi.Plo@am__quote@
-@AMDEP_TRUE@@am__include@ @am__quote@src/synth/$(DEPDIR)/libmimic_la-cst_ffeatures.Plo@am__quote@
-@AMDEP_TRUE@@am__include@ @am__quote@src/synth/$(DEPDIR)/libmimic_la-cst_phoneset.Plo@am__quote@
-@AMDEP_TRUE@@am__include@ @am__quote@src/synth/$(DEPDIR)/libmimic_la-cst_ssml.Plo@am__quote@
-@AMDEP_TRUE@@am__include@ @am__quote@src/synth/$(DEPDIR)/libmimic_la-cst_synth.Plo@am__quote@
-@AMDEP_TRUE@@am__include@ @am__quote@src/synth/$(DEPDIR)/libmimic_la-cst_utt_utils.Plo@am__quote@
-@AMDEP_TRUE@@am__include@ @am__quote@src/synth/$(DEPDIR)/libmimic_la-cst_voice.Plo@am__quote@
-@AMDEP_TRUE@@am__include@ @am__quote@src/synth/$(DEPDIR)/libmimic_la-mimic.Plo@am__quote@
-@AMDEP_TRUE@@am__include@ @am__quote@src/utils/$(DEPDIR)/libmimic_la-cst_alloc.Plo@am__quote@
-@AMDEP_TRUE@@am__include@ @am__quote@src/utils/$(DEPDIR)/libmimic_la-cst_args.Plo@am__quote@
-@AMDEP_TRUE@@am__include@ @am__quote@src/utils/$(DEPDIR)/libmimic_la-cst_endian.Plo@am__quote@
-@AMDEP_TRUE@@am__include@ @am__quote@src/utils/$(DEPDIR)/libmimic_la-cst_error.Plo@am__quote@
-@AMDEP_TRUE@@am__include@ @am__quote@src/utils/$(DEPDIR)/libmimic_la-cst_features.Plo@am__quote@
-@AMDEP_TRUE@@am__include@ @am__quote@src/utils/$(DEPDIR)/libmimic_la-cst_file_stdio.Plo@am__quote@
-@AMDEP_TRUE@@am__include@ @am__quote@src/utils/$(DEPDIR)/libmimic_la-cst_mmap_none.Plo@am__quote@
-@AMDEP_TRUE@@am__include@ @am__quote@src/utils/$(DEPDIR)/libmimic_la-cst_mmap_posix.Plo@am__quote@
-@AMDEP_TRUE@@am__include@ @am__quote@src/utils/$(DEPDIR)/libmimic_la-cst_mmap_win32.Plo@am__quote@
-@AMDEP_TRUE@@am__include@ @am__quote@src/utils/$(DEPDIR)/libmimic_la-cst_socket.Plo@am__quote@
-@AMDEP_TRUE@@am__include@ @am__quote@src/utils/$(DEPDIR)/libmimic_la-cst_string.Plo@am__quote@
-@AMDEP_TRUE@@am__include@ @am__quote@src/utils/$(DEPDIR)/libmimic_la-cst_tokenstream.Plo@am__quote@
-@AMDEP_TRUE@@am__include@ @am__quote@src/utils/$(DEPDIR)/libmimic_la-cst_url.Plo@am__quote@
-@AMDEP_TRUE@@am__include@ @am__quote@src/utils/$(DEPDIR)/libmimic_la-cst_val.Plo@am__quote@
-@AMDEP_TRUE@@am__include@ @am__quote@src/utils/$(DEPDIR)/libmimic_la-cst_val_const.Plo@am__quote@
-@AMDEP_TRUE@@am__include@ @am__quote@src/utils/$(DEPDIR)/libmimic_la-cst_val_user.Plo@am__quote@
-@AMDEP_TRUE@@am__include@ @am__quote@src/utils/$(DEPDIR)/libmimic_la-cst_wchar.Plo@am__quote@
-@AMDEP_TRUE@@am__include@ @am__quote@src/wavesynth/$(DEPDIR)/libmimic_la-cst_clunits.Plo@am__quote@
-@AMDEP_TRUE@@am__include@ @am__quote@src/wavesynth/$(DEPDIR)/libmimic_la-cst_diphone.Plo@am__quote@
-@AMDEP_TRUE@@am__include@ @am__quote@src/wavesynth/$(DEPDIR)/libmimic_la-cst_reflpc.Plo@am__quote@
-@AMDEP_TRUE@@am__include@ @am__quote@src/wavesynth/$(DEPDIR)/libmimic_la-cst_sigpr.Plo@am__quote@
-@AMDEP_TRUE@@am__include@ @am__quote@src/wavesynth/$(DEPDIR)/libmimic_la-cst_sts.Plo@am__quote@
-@AMDEP_TRUE@@am__include@ @am__quote@src/wavesynth/$(DEPDIR)/libmimic_la-cst_units.Plo@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@src/audio/$(DEPDIR)/libttsmimic_la-au_alsa.Plo@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@src/audio/$(DEPDIR)/libttsmimic_la-au_command.Plo@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@src/audio/$(DEPDIR)/libttsmimic_la-au_none.Plo@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@src/audio/$(DEPDIR)/libttsmimic_la-au_oss.Plo@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@src/audio/$(DEPDIR)/libttsmimic_la-au_portaudio.Plo@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@src/audio/$(DEPDIR)/libttsmimic_la-au_pulseaudio.Plo@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@src/audio/$(DEPDIR)/libttsmimic_la-au_streaming.Plo@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@src/audio/$(DEPDIR)/libttsmimic_la-au_sun.Plo@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@src/audio/$(DEPDIR)/libttsmimic_la-au_wince.Plo@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@src/audio/$(DEPDIR)/libttsmimic_la-auclient.Plo@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@src/audio/$(DEPDIR)/libttsmimic_la-audio.Plo@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@src/audio/$(DEPDIR)/libttsmimic_la-auserver.Plo@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@src/cg/$(DEPDIR)/libttsmimic_la-cst_cg.Plo@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@src/cg/$(DEPDIR)/libttsmimic_la-cst_cg_dump_voice.Plo@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@src/cg/$(DEPDIR)/libttsmimic_la-cst_cg_load_voice.Plo@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@src/cg/$(DEPDIR)/libttsmimic_la-cst_cg_map.Plo@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@src/cg/$(DEPDIR)/libttsmimic_la-cst_mlpg.Plo@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@src/cg/$(DEPDIR)/libttsmimic_la-cst_mlsa.Plo@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@src/cg/$(DEPDIR)/libttsmimic_la-cst_spamf0.Plo@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@src/cg/$(DEPDIR)/libttsmimic_la-cst_vc.Plo@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@src/hrg/$(DEPDIR)/libttsmimic_la-cst_ffeature.Plo@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@src/hrg/$(DEPDIR)/libttsmimic_la-cst_item.Plo@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@src/hrg/$(DEPDIR)/libttsmimic_la-cst_rel_io.Plo@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@src/hrg/$(DEPDIR)/libttsmimic_la-cst_relation.Plo@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@src/hrg/$(DEPDIR)/libttsmimic_la-cst_utterance.Plo@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@src/lexicon/$(DEPDIR)/libttsmimic_la-cst_lexicon.Plo@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@src/lexicon/$(DEPDIR)/libttsmimic_la-cst_lts.Plo@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@src/lexicon/$(DEPDIR)/libttsmimic_la-cst_lts_rewrites.Plo@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@src/regex/$(DEPDIR)/libttsmimic_la-cst_regex.Plo@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@src/regex/$(DEPDIR)/libttsmimic_la-regexp.Plo@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@src/regex/$(DEPDIR)/libttsmimic_la-regsub.Plo@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@src/speech/$(DEPDIR)/libttsmimic_la-cst_lpcres.Plo@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@src/speech/$(DEPDIR)/libttsmimic_la-cst_track.Plo@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@src/speech/$(DEPDIR)/libttsmimic_la-cst_track_io.Plo@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@src/speech/$(DEPDIR)/libttsmimic_la-cst_wave.Plo@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@src/speech/$(DEPDIR)/libttsmimic_la-cst_wave_io.Plo@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@src/speech/$(DEPDIR)/libttsmimic_la-cst_wave_utils.Plo@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@src/speech/$(DEPDIR)/libttsmimic_la-g721.Plo@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@src/speech/$(DEPDIR)/libttsmimic_la-g723_24.Plo@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@src/speech/$(DEPDIR)/libttsmimic_la-g723_40.Plo@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@src/speech/$(DEPDIR)/libttsmimic_la-g72x.Plo@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@src/speech/$(DEPDIR)/libttsmimic_la-rateconv.Plo@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@src/stats/$(DEPDIR)/libttsmimic_la-cst_cart.Plo@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@src/stats/$(DEPDIR)/libttsmimic_la-cst_ss.Plo@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@src/stats/$(DEPDIR)/libttsmimic_la-cst_viterbi.Plo@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@src/synth/$(DEPDIR)/libttsmimic_la-cst_ffeatures.Plo@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@src/synth/$(DEPDIR)/libttsmimic_la-cst_phoneset.Plo@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@src/synth/$(DEPDIR)/libttsmimic_la-cst_ssml.Plo@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@src/synth/$(DEPDIR)/libttsmimic_la-cst_synth.Plo@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@src/synth/$(DEPDIR)/libttsmimic_la-cst_utt_utils.Plo@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@src/synth/$(DEPDIR)/libttsmimic_la-cst_voice.Plo@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@src/synth/$(DEPDIR)/libttsmimic_la-mimic.Plo@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@src/utils/$(DEPDIR)/libttsmimic_la-cst_alloc.Plo@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@src/utils/$(DEPDIR)/libttsmimic_la-cst_args.Plo@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@src/utils/$(DEPDIR)/libttsmimic_la-cst_endian.Plo@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@src/utils/$(DEPDIR)/libttsmimic_la-cst_error.Plo@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@src/utils/$(DEPDIR)/libttsmimic_la-cst_features.Plo@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@src/utils/$(DEPDIR)/libttsmimic_la-cst_file_stdio.Plo@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@src/utils/$(DEPDIR)/libttsmimic_la-cst_mmap_none.Plo@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@src/utils/$(DEPDIR)/libttsmimic_la-cst_mmap_posix.Plo@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@src/utils/$(DEPDIR)/libttsmimic_la-cst_mmap_win32.Plo@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@src/utils/$(DEPDIR)/libttsmimic_la-cst_socket.Plo@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@src/utils/$(DEPDIR)/libttsmimic_la-cst_string.Plo@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@src/utils/$(DEPDIR)/libttsmimic_la-cst_tokenstream.Plo@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@src/utils/$(DEPDIR)/libttsmimic_la-cst_url.Plo@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@src/utils/$(DEPDIR)/libttsmimic_la-cst_val.Plo@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@src/utils/$(DEPDIR)/libttsmimic_la-cst_val_const.Plo@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@src/utils/$(DEPDIR)/libttsmimic_la-cst_val_user.Plo@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@src/utils/$(DEPDIR)/libttsmimic_la-cst_wchar.Plo@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@src/wavesynth/$(DEPDIR)/libttsmimic_la-cst_clunits.Plo@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@src/wavesynth/$(DEPDIR)/libttsmimic_la-cst_diphone.Plo@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@src/wavesynth/$(DEPDIR)/libttsmimic_la-cst_reflpc.Plo@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@src/wavesynth/$(DEPDIR)/libttsmimic_la-cst_sigpr.Plo@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@src/wavesynth/$(DEPDIR)/libttsmimic_la-cst_sts.Plo@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@src/wavesynth/$(DEPDIR)/libttsmimic_la-cst_units.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@testsuite/$(DEPDIR)/asciiS2U_main.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@testsuite/$(DEPDIR)/asciiU2S_main.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@testsuite/$(DEPDIR)/bin2ascii_main.Po@am__quote@
@@ -2928,950 +2944,950 @@ distclean-compile:
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LTCOMPILE) -c -o $@ $<
 
-src/audio/libmimic_la-au_alsa.lo: src/audio/au_alsa.c
-@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_la_CFLAGS) $(CFLAGS) -MT src/audio/libmimic_la-au_alsa.lo -MD -MP -MF src/audio/$(DEPDIR)/libmimic_la-au_alsa.Tpo -c -o src/audio/libmimic_la-au_alsa.lo `test -f 'src/audio/au_alsa.c' || echo '$(srcdir)/'`src/audio/au_alsa.c
-@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) src/audio/$(DEPDIR)/libmimic_la-au_alsa.Tpo src/audio/$(DEPDIR)/libmimic_la-au_alsa.Plo
-@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='src/audio/au_alsa.c' object='src/audio/libmimic_la-au_alsa.lo' libtool=yes @AMDEPBACKSLASH@
+src/audio/libttsmimic_la-au_alsa.lo: src/audio/au_alsa.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_la_CFLAGS) $(CFLAGS) -MT src/audio/libttsmimic_la-au_alsa.lo -MD -MP -MF src/audio/$(DEPDIR)/libttsmimic_la-au_alsa.Tpo -c -o src/audio/libttsmimic_la-au_alsa.lo `test -f 'src/audio/au_alsa.c' || echo '$(srcdir)/'`src/audio/au_alsa.c
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) src/audio/$(DEPDIR)/libttsmimic_la-au_alsa.Tpo src/audio/$(DEPDIR)/libttsmimic_la-au_alsa.Plo
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='src/audio/au_alsa.c' object='src/audio/libttsmimic_la-au_alsa.lo' libtool=yes @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_la_CFLAGS) $(CFLAGS) -c -o src/audio/libmimic_la-au_alsa.lo `test -f 'src/audio/au_alsa.c' || echo '$(srcdir)/'`src/audio/au_alsa.c
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_la_CFLAGS) $(CFLAGS) -c -o src/audio/libttsmimic_la-au_alsa.lo `test -f 'src/audio/au_alsa.c' || echo '$(srcdir)/'`src/audio/au_alsa.c
 
-src/audio/libmimic_la-auclient.lo: src/audio/auclient.c
-@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_la_CFLAGS) $(CFLAGS) -MT src/audio/libmimic_la-auclient.lo -MD -MP -MF src/audio/$(DEPDIR)/libmimic_la-auclient.Tpo -c -o src/audio/libmimic_la-auclient.lo `test -f 'src/audio/auclient.c' || echo '$(srcdir)/'`src/audio/auclient.c
-@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) src/audio/$(DEPDIR)/libmimic_la-auclient.Tpo src/audio/$(DEPDIR)/libmimic_la-auclient.Plo
-@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='src/audio/auclient.c' object='src/audio/libmimic_la-auclient.lo' libtool=yes @AMDEPBACKSLASH@
+src/audio/libttsmimic_la-auclient.lo: src/audio/auclient.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_la_CFLAGS) $(CFLAGS) -MT src/audio/libttsmimic_la-auclient.lo -MD -MP -MF src/audio/$(DEPDIR)/libttsmimic_la-auclient.Tpo -c -o src/audio/libttsmimic_la-auclient.lo `test -f 'src/audio/auclient.c' || echo '$(srcdir)/'`src/audio/auclient.c
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) src/audio/$(DEPDIR)/libttsmimic_la-auclient.Tpo src/audio/$(DEPDIR)/libttsmimic_la-auclient.Plo
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='src/audio/auclient.c' object='src/audio/libttsmimic_la-auclient.lo' libtool=yes @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_la_CFLAGS) $(CFLAGS) -c -o src/audio/libmimic_la-auclient.lo `test -f 'src/audio/auclient.c' || echo '$(srcdir)/'`src/audio/auclient.c
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_la_CFLAGS) $(CFLAGS) -c -o src/audio/libttsmimic_la-auclient.lo `test -f 'src/audio/auclient.c' || echo '$(srcdir)/'`src/audio/auclient.c
 
-src/audio/libmimic_la-au_command.lo: src/audio/au_command.c
-@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_la_CFLAGS) $(CFLAGS) -MT src/audio/libmimic_la-au_command.lo -MD -MP -MF src/audio/$(DEPDIR)/libmimic_la-au_command.Tpo -c -o src/audio/libmimic_la-au_command.lo `test -f 'src/audio/au_command.c' || echo '$(srcdir)/'`src/audio/au_command.c
-@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) src/audio/$(DEPDIR)/libmimic_la-au_command.Tpo src/audio/$(DEPDIR)/libmimic_la-au_command.Plo
-@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='src/audio/au_command.c' object='src/audio/libmimic_la-au_command.lo' libtool=yes @AMDEPBACKSLASH@
+src/audio/libttsmimic_la-au_command.lo: src/audio/au_command.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_la_CFLAGS) $(CFLAGS) -MT src/audio/libttsmimic_la-au_command.lo -MD -MP -MF src/audio/$(DEPDIR)/libttsmimic_la-au_command.Tpo -c -o src/audio/libttsmimic_la-au_command.lo `test -f 'src/audio/au_command.c' || echo '$(srcdir)/'`src/audio/au_command.c
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) src/audio/$(DEPDIR)/libttsmimic_la-au_command.Tpo src/audio/$(DEPDIR)/libttsmimic_la-au_command.Plo
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='src/audio/au_command.c' object='src/audio/libttsmimic_la-au_command.lo' libtool=yes @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_la_CFLAGS) $(CFLAGS) -c -o src/audio/libmimic_la-au_command.lo `test -f 'src/audio/au_command.c' || echo '$(srcdir)/'`src/audio/au_command.c
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_la_CFLAGS) $(CFLAGS) -c -o src/audio/libttsmimic_la-au_command.lo `test -f 'src/audio/au_command.c' || echo '$(srcdir)/'`src/audio/au_command.c
 
-src/audio/libmimic_la-audio.lo: src/audio/audio.c
-@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_la_CFLAGS) $(CFLAGS) -MT src/audio/libmimic_la-audio.lo -MD -MP -MF src/audio/$(DEPDIR)/libmimic_la-audio.Tpo -c -o src/audio/libmimic_la-audio.lo `test -f 'src/audio/audio.c' || echo '$(srcdir)/'`src/audio/audio.c
-@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) src/audio/$(DEPDIR)/libmimic_la-audio.Tpo src/audio/$(DEPDIR)/libmimic_la-audio.Plo
-@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='src/audio/audio.c' object='src/audio/libmimic_la-audio.lo' libtool=yes @AMDEPBACKSLASH@
+src/audio/libttsmimic_la-audio.lo: src/audio/audio.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_la_CFLAGS) $(CFLAGS) -MT src/audio/libttsmimic_la-audio.lo -MD -MP -MF src/audio/$(DEPDIR)/libttsmimic_la-audio.Tpo -c -o src/audio/libttsmimic_la-audio.lo `test -f 'src/audio/audio.c' || echo '$(srcdir)/'`src/audio/audio.c
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) src/audio/$(DEPDIR)/libttsmimic_la-audio.Tpo src/audio/$(DEPDIR)/libttsmimic_la-audio.Plo
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='src/audio/audio.c' object='src/audio/libttsmimic_la-audio.lo' libtool=yes @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_la_CFLAGS) $(CFLAGS) -c -o src/audio/libmimic_la-audio.lo `test -f 'src/audio/audio.c' || echo '$(srcdir)/'`src/audio/audio.c
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_la_CFLAGS) $(CFLAGS) -c -o src/audio/libttsmimic_la-audio.lo `test -f 'src/audio/audio.c' || echo '$(srcdir)/'`src/audio/audio.c
 
-src/audio/libmimic_la-au_none.lo: src/audio/au_none.c
-@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_la_CFLAGS) $(CFLAGS) -MT src/audio/libmimic_la-au_none.lo -MD -MP -MF src/audio/$(DEPDIR)/libmimic_la-au_none.Tpo -c -o src/audio/libmimic_la-au_none.lo `test -f 'src/audio/au_none.c' || echo '$(srcdir)/'`src/audio/au_none.c
-@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) src/audio/$(DEPDIR)/libmimic_la-au_none.Tpo src/audio/$(DEPDIR)/libmimic_la-au_none.Plo
-@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='src/audio/au_none.c' object='src/audio/libmimic_la-au_none.lo' libtool=yes @AMDEPBACKSLASH@
+src/audio/libttsmimic_la-au_none.lo: src/audio/au_none.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_la_CFLAGS) $(CFLAGS) -MT src/audio/libttsmimic_la-au_none.lo -MD -MP -MF src/audio/$(DEPDIR)/libttsmimic_la-au_none.Tpo -c -o src/audio/libttsmimic_la-au_none.lo `test -f 'src/audio/au_none.c' || echo '$(srcdir)/'`src/audio/au_none.c
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) src/audio/$(DEPDIR)/libttsmimic_la-au_none.Tpo src/audio/$(DEPDIR)/libttsmimic_la-au_none.Plo
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='src/audio/au_none.c' object='src/audio/libttsmimic_la-au_none.lo' libtool=yes @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_la_CFLAGS) $(CFLAGS) -c -o src/audio/libmimic_la-au_none.lo `test -f 'src/audio/au_none.c' || echo '$(srcdir)/'`src/audio/au_none.c
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_la_CFLAGS) $(CFLAGS) -c -o src/audio/libttsmimic_la-au_none.lo `test -f 'src/audio/au_none.c' || echo '$(srcdir)/'`src/audio/au_none.c
 
-src/audio/libmimic_la-au_oss.lo: src/audio/au_oss.c
-@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_la_CFLAGS) $(CFLAGS) -MT src/audio/libmimic_la-au_oss.lo -MD -MP -MF src/audio/$(DEPDIR)/libmimic_la-au_oss.Tpo -c -o src/audio/libmimic_la-au_oss.lo `test -f 'src/audio/au_oss.c' || echo '$(srcdir)/'`src/audio/au_oss.c
-@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) src/audio/$(DEPDIR)/libmimic_la-au_oss.Tpo src/audio/$(DEPDIR)/libmimic_la-au_oss.Plo
-@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='src/audio/au_oss.c' object='src/audio/libmimic_la-au_oss.lo' libtool=yes @AMDEPBACKSLASH@
+src/audio/libttsmimic_la-au_oss.lo: src/audio/au_oss.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_la_CFLAGS) $(CFLAGS) -MT src/audio/libttsmimic_la-au_oss.lo -MD -MP -MF src/audio/$(DEPDIR)/libttsmimic_la-au_oss.Tpo -c -o src/audio/libttsmimic_la-au_oss.lo `test -f 'src/audio/au_oss.c' || echo '$(srcdir)/'`src/audio/au_oss.c
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) src/audio/$(DEPDIR)/libttsmimic_la-au_oss.Tpo src/audio/$(DEPDIR)/libttsmimic_la-au_oss.Plo
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='src/audio/au_oss.c' object='src/audio/libttsmimic_la-au_oss.lo' libtool=yes @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_la_CFLAGS) $(CFLAGS) -c -o src/audio/libmimic_la-au_oss.lo `test -f 'src/audio/au_oss.c' || echo '$(srcdir)/'`src/audio/au_oss.c
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_la_CFLAGS) $(CFLAGS) -c -o src/audio/libttsmimic_la-au_oss.lo `test -f 'src/audio/au_oss.c' || echo '$(srcdir)/'`src/audio/au_oss.c
 
-src/audio/libmimic_la-au_portaudio.lo: src/audio/au_portaudio.c
-@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_la_CFLAGS) $(CFLAGS) -MT src/audio/libmimic_la-au_portaudio.lo -MD -MP -MF src/audio/$(DEPDIR)/libmimic_la-au_portaudio.Tpo -c -o src/audio/libmimic_la-au_portaudio.lo `test -f 'src/audio/au_portaudio.c' || echo '$(srcdir)/'`src/audio/au_portaudio.c
-@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) src/audio/$(DEPDIR)/libmimic_la-au_portaudio.Tpo src/audio/$(DEPDIR)/libmimic_la-au_portaudio.Plo
-@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='src/audio/au_portaudio.c' object='src/audio/libmimic_la-au_portaudio.lo' libtool=yes @AMDEPBACKSLASH@
+src/audio/libttsmimic_la-au_portaudio.lo: src/audio/au_portaudio.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_la_CFLAGS) $(CFLAGS) -MT src/audio/libttsmimic_la-au_portaudio.lo -MD -MP -MF src/audio/$(DEPDIR)/libttsmimic_la-au_portaudio.Tpo -c -o src/audio/libttsmimic_la-au_portaudio.lo `test -f 'src/audio/au_portaudio.c' || echo '$(srcdir)/'`src/audio/au_portaudio.c
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) src/audio/$(DEPDIR)/libttsmimic_la-au_portaudio.Tpo src/audio/$(DEPDIR)/libttsmimic_la-au_portaudio.Plo
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='src/audio/au_portaudio.c' object='src/audio/libttsmimic_la-au_portaudio.lo' libtool=yes @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_la_CFLAGS) $(CFLAGS) -c -o src/audio/libmimic_la-au_portaudio.lo `test -f 'src/audio/au_portaudio.c' || echo '$(srcdir)/'`src/audio/au_portaudio.c
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_la_CFLAGS) $(CFLAGS) -c -o src/audio/libttsmimic_la-au_portaudio.lo `test -f 'src/audio/au_portaudio.c' || echo '$(srcdir)/'`src/audio/au_portaudio.c
 
-src/audio/libmimic_la-au_pulseaudio.lo: src/audio/au_pulseaudio.c
-@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_la_CFLAGS) $(CFLAGS) -MT src/audio/libmimic_la-au_pulseaudio.lo -MD -MP -MF src/audio/$(DEPDIR)/libmimic_la-au_pulseaudio.Tpo -c -o src/audio/libmimic_la-au_pulseaudio.lo `test -f 'src/audio/au_pulseaudio.c' || echo '$(srcdir)/'`src/audio/au_pulseaudio.c
-@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) src/audio/$(DEPDIR)/libmimic_la-au_pulseaudio.Tpo src/audio/$(DEPDIR)/libmimic_la-au_pulseaudio.Plo
-@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='src/audio/au_pulseaudio.c' object='src/audio/libmimic_la-au_pulseaudio.lo' libtool=yes @AMDEPBACKSLASH@
+src/audio/libttsmimic_la-au_pulseaudio.lo: src/audio/au_pulseaudio.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_la_CFLAGS) $(CFLAGS) -MT src/audio/libttsmimic_la-au_pulseaudio.lo -MD -MP -MF src/audio/$(DEPDIR)/libttsmimic_la-au_pulseaudio.Tpo -c -o src/audio/libttsmimic_la-au_pulseaudio.lo `test -f 'src/audio/au_pulseaudio.c' || echo '$(srcdir)/'`src/audio/au_pulseaudio.c
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) src/audio/$(DEPDIR)/libttsmimic_la-au_pulseaudio.Tpo src/audio/$(DEPDIR)/libttsmimic_la-au_pulseaudio.Plo
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='src/audio/au_pulseaudio.c' object='src/audio/libttsmimic_la-au_pulseaudio.lo' libtool=yes @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_la_CFLAGS) $(CFLAGS) -c -o src/audio/libmimic_la-au_pulseaudio.lo `test -f 'src/audio/au_pulseaudio.c' || echo '$(srcdir)/'`src/audio/au_pulseaudio.c
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_la_CFLAGS) $(CFLAGS) -c -o src/audio/libttsmimic_la-au_pulseaudio.lo `test -f 'src/audio/au_pulseaudio.c' || echo '$(srcdir)/'`src/audio/au_pulseaudio.c
 
-src/audio/libmimic_la-auserver.lo: src/audio/auserver.c
-@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_la_CFLAGS) $(CFLAGS) -MT src/audio/libmimic_la-auserver.lo -MD -MP -MF src/audio/$(DEPDIR)/libmimic_la-auserver.Tpo -c -o src/audio/libmimic_la-auserver.lo `test -f 'src/audio/auserver.c' || echo '$(srcdir)/'`src/audio/auserver.c
-@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) src/audio/$(DEPDIR)/libmimic_la-auserver.Tpo src/audio/$(DEPDIR)/libmimic_la-auserver.Plo
-@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='src/audio/auserver.c' object='src/audio/libmimic_la-auserver.lo' libtool=yes @AMDEPBACKSLASH@
+src/audio/libttsmimic_la-auserver.lo: src/audio/auserver.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_la_CFLAGS) $(CFLAGS) -MT src/audio/libttsmimic_la-auserver.lo -MD -MP -MF src/audio/$(DEPDIR)/libttsmimic_la-auserver.Tpo -c -o src/audio/libttsmimic_la-auserver.lo `test -f 'src/audio/auserver.c' || echo '$(srcdir)/'`src/audio/auserver.c
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) src/audio/$(DEPDIR)/libttsmimic_la-auserver.Tpo src/audio/$(DEPDIR)/libttsmimic_la-auserver.Plo
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='src/audio/auserver.c' object='src/audio/libttsmimic_la-auserver.lo' libtool=yes @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_la_CFLAGS) $(CFLAGS) -c -o src/audio/libmimic_la-auserver.lo `test -f 'src/audio/auserver.c' || echo '$(srcdir)/'`src/audio/auserver.c
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_la_CFLAGS) $(CFLAGS) -c -o src/audio/libttsmimic_la-auserver.lo `test -f 'src/audio/auserver.c' || echo '$(srcdir)/'`src/audio/auserver.c
 
-src/audio/libmimic_la-au_streaming.lo: src/audio/au_streaming.c
-@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_la_CFLAGS) $(CFLAGS) -MT src/audio/libmimic_la-au_streaming.lo -MD -MP -MF src/audio/$(DEPDIR)/libmimic_la-au_streaming.Tpo -c -o src/audio/libmimic_la-au_streaming.lo `test -f 'src/audio/au_streaming.c' || echo '$(srcdir)/'`src/audio/au_streaming.c
-@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) src/audio/$(DEPDIR)/libmimic_la-au_streaming.Tpo src/audio/$(DEPDIR)/libmimic_la-au_streaming.Plo
-@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='src/audio/au_streaming.c' object='src/audio/libmimic_la-au_streaming.lo' libtool=yes @AMDEPBACKSLASH@
+src/audio/libttsmimic_la-au_streaming.lo: src/audio/au_streaming.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_la_CFLAGS) $(CFLAGS) -MT src/audio/libttsmimic_la-au_streaming.lo -MD -MP -MF src/audio/$(DEPDIR)/libttsmimic_la-au_streaming.Tpo -c -o src/audio/libttsmimic_la-au_streaming.lo `test -f 'src/audio/au_streaming.c' || echo '$(srcdir)/'`src/audio/au_streaming.c
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) src/audio/$(DEPDIR)/libttsmimic_la-au_streaming.Tpo src/audio/$(DEPDIR)/libttsmimic_la-au_streaming.Plo
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='src/audio/au_streaming.c' object='src/audio/libttsmimic_la-au_streaming.lo' libtool=yes @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_la_CFLAGS) $(CFLAGS) -c -o src/audio/libmimic_la-au_streaming.lo `test -f 'src/audio/au_streaming.c' || echo '$(srcdir)/'`src/audio/au_streaming.c
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_la_CFLAGS) $(CFLAGS) -c -o src/audio/libttsmimic_la-au_streaming.lo `test -f 'src/audio/au_streaming.c' || echo '$(srcdir)/'`src/audio/au_streaming.c
 
-src/audio/libmimic_la-au_sun.lo: src/audio/au_sun.c
-@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_la_CFLAGS) $(CFLAGS) -MT src/audio/libmimic_la-au_sun.lo -MD -MP -MF src/audio/$(DEPDIR)/libmimic_la-au_sun.Tpo -c -o src/audio/libmimic_la-au_sun.lo `test -f 'src/audio/au_sun.c' || echo '$(srcdir)/'`src/audio/au_sun.c
-@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) src/audio/$(DEPDIR)/libmimic_la-au_sun.Tpo src/audio/$(DEPDIR)/libmimic_la-au_sun.Plo
-@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='src/audio/au_sun.c' object='src/audio/libmimic_la-au_sun.lo' libtool=yes @AMDEPBACKSLASH@
+src/audio/libttsmimic_la-au_sun.lo: src/audio/au_sun.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_la_CFLAGS) $(CFLAGS) -MT src/audio/libttsmimic_la-au_sun.lo -MD -MP -MF src/audio/$(DEPDIR)/libttsmimic_la-au_sun.Tpo -c -o src/audio/libttsmimic_la-au_sun.lo `test -f 'src/audio/au_sun.c' || echo '$(srcdir)/'`src/audio/au_sun.c
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) src/audio/$(DEPDIR)/libttsmimic_la-au_sun.Tpo src/audio/$(DEPDIR)/libttsmimic_la-au_sun.Plo
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='src/audio/au_sun.c' object='src/audio/libttsmimic_la-au_sun.lo' libtool=yes @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_la_CFLAGS) $(CFLAGS) -c -o src/audio/libmimic_la-au_sun.lo `test -f 'src/audio/au_sun.c' || echo '$(srcdir)/'`src/audio/au_sun.c
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_la_CFLAGS) $(CFLAGS) -c -o src/audio/libttsmimic_la-au_sun.lo `test -f 'src/audio/au_sun.c' || echo '$(srcdir)/'`src/audio/au_sun.c
 
-src/audio/libmimic_la-au_wince.lo: src/audio/au_wince.c
-@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_la_CFLAGS) $(CFLAGS) -MT src/audio/libmimic_la-au_wince.lo -MD -MP -MF src/audio/$(DEPDIR)/libmimic_la-au_wince.Tpo -c -o src/audio/libmimic_la-au_wince.lo `test -f 'src/audio/au_wince.c' || echo '$(srcdir)/'`src/audio/au_wince.c
-@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) src/audio/$(DEPDIR)/libmimic_la-au_wince.Tpo src/audio/$(DEPDIR)/libmimic_la-au_wince.Plo
-@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='src/audio/au_wince.c' object='src/audio/libmimic_la-au_wince.lo' libtool=yes @AMDEPBACKSLASH@
+src/audio/libttsmimic_la-au_wince.lo: src/audio/au_wince.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_la_CFLAGS) $(CFLAGS) -MT src/audio/libttsmimic_la-au_wince.lo -MD -MP -MF src/audio/$(DEPDIR)/libttsmimic_la-au_wince.Tpo -c -o src/audio/libttsmimic_la-au_wince.lo `test -f 'src/audio/au_wince.c' || echo '$(srcdir)/'`src/audio/au_wince.c
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) src/audio/$(DEPDIR)/libttsmimic_la-au_wince.Tpo src/audio/$(DEPDIR)/libttsmimic_la-au_wince.Plo
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='src/audio/au_wince.c' object='src/audio/libttsmimic_la-au_wince.lo' libtool=yes @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_la_CFLAGS) $(CFLAGS) -c -o src/audio/libmimic_la-au_wince.lo `test -f 'src/audio/au_wince.c' || echo '$(srcdir)/'`src/audio/au_wince.c
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_la_CFLAGS) $(CFLAGS) -c -o src/audio/libttsmimic_la-au_wince.lo `test -f 'src/audio/au_wince.c' || echo '$(srcdir)/'`src/audio/au_wince.c
 
-src/cg/libmimic_la-cst_cg.lo: src/cg/cst_cg.c
-@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_la_CFLAGS) $(CFLAGS) -MT src/cg/libmimic_la-cst_cg.lo -MD -MP -MF src/cg/$(DEPDIR)/libmimic_la-cst_cg.Tpo -c -o src/cg/libmimic_la-cst_cg.lo `test -f 'src/cg/cst_cg.c' || echo '$(srcdir)/'`src/cg/cst_cg.c
-@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) src/cg/$(DEPDIR)/libmimic_la-cst_cg.Tpo src/cg/$(DEPDIR)/libmimic_la-cst_cg.Plo
-@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='src/cg/cst_cg.c' object='src/cg/libmimic_la-cst_cg.lo' libtool=yes @AMDEPBACKSLASH@
+src/cg/libttsmimic_la-cst_cg.lo: src/cg/cst_cg.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_la_CFLAGS) $(CFLAGS) -MT src/cg/libttsmimic_la-cst_cg.lo -MD -MP -MF src/cg/$(DEPDIR)/libttsmimic_la-cst_cg.Tpo -c -o src/cg/libttsmimic_la-cst_cg.lo `test -f 'src/cg/cst_cg.c' || echo '$(srcdir)/'`src/cg/cst_cg.c
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) src/cg/$(DEPDIR)/libttsmimic_la-cst_cg.Tpo src/cg/$(DEPDIR)/libttsmimic_la-cst_cg.Plo
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='src/cg/cst_cg.c' object='src/cg/libttsmimic_la-cst_cg.lo' libtool=yes @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_la_CFLAGS) $(CFLAGS) -c -o src/cg/libmimic_la-cst_cg.lo `test -f 'src/cg/cst_cg.c' || echo '$(srcdir)/'`src/cg/cst_cg.c
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_la_CFLAGS) $(CFLAGS) -c -o src/cg/libttsmimic_la-cst_cg.lo `test -f 'src/cg/cst_cg.c' || echo '$(srcdir)/'`src/cg/cst_cg.c
 
-src/cg/libmimic_la-cst_mlsa.lo: src/cg/cst_mlsa.c
-@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_la_CFLAGS) $(CFLAGS) -MT src/cg/libmimic_la-cst_mlsa.lo -MD -MP -MF src/cg/$(DEPDIR)/libmimic_la-cst_mlsa.Tpo -c -o src/cg/libmimic_la-cst_mlsa.lo `test -f 'src/cg/cst_mlsa.c' || echo '$(srcdir)/'`src/cg/cst_mlsa.c
-@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) src/cg/$(DEPDIR)/libmimic_la-cst_mlsa.Tpo src/cg/$(DEPDIR)/libmimic_la-cst_mlsa.Plo
-@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='src/cg/cst_mlsa.c' object='src/cg/libmimic_la-cst_mlsa.lo' libtool=yes @AMDEPBACKSLASH@
+src/cg/libttsmimic_la-cst_mlsa.lo: src/cg/cst_mlsa.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_la_CFLAGS) $(CFLAGS) -MT src/cg/libttsmimic_la-cst_mlsa.lo -MD -MP -MF src/cg/$(DEPDIR)/libttsmimic_la-cst_mlsa.Tpo -c -o src/cg/libttsmimic_la-cst_mlsa.lo `test -f 'src/cg/cst_mlsa.c' || echo '$(srcdir)/'`src/cg/cst_mlsa.c
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) src/cg/$(DEPDIR)/libttsmimic_la-cst_mlsa.Tpo src/cg/$(DEPDIR)/libttsmimic_la-cst_mlsa.Plo
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='src/cg/cst_mlsa.c' object='src/cg/libttsmimic_la-cst_mlsa.lo' libtool=yes @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_la_CFLAGS) $(CFLAGS) -c -o src/cg/libmimic_la-cst_mlsa.lo `test -f 'src/cg/cst_mlsa.c' || echo '$(srcdir)/'`src/cg/cst_mlsa.c
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_la_CFLAGS) $(CFLAGS) -c -o src/cg/libttsmimic_la-cst_mlsa.lo `test -f 'src/cg/cst_mlsa.c' || echo '$(srcdir)/'`src/cg/cst_mlsa.c
 
-src/cg/libmimic_la-cst_mlpg.lo: src/cg/cst_mlpg.c
-@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_la_CFLAGS) $(CFLAGS) -MT src/cg/libmimic_la-cst_mlpg.lo -MD -MP -MF src/cg/$(DEPDIR)/libmimic_la-cst_mlpg.Tpo -c -o src/cg/libmimic_la-cst_mlpg.lo `test -f 'src/cg/cst_mlpg.c' || echo '$(srcdir)/'`src/cg/cst_mlpg.c
-@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) src/cg/$(DEPDIR)/libmimic_la-cst_mlpg.Tpo src/cg/$(DEPDIR)/libmimic_la-cst_mlpg.Plo
-@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='src/cg/cst_mlpg.c' object='src/cg/libmimic_la-cst_mlpg.lo' libtool=yes @AMDEPBACKSLASH@
+src/cg/libttsmimic_la-cst_mlpg.lo: src/cg/cst_mlpg.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_la_CFLAGS) $(CFLAGS) -MT src/cg/libttsmimic_la-cst_mlpg.lo -MD -MP -MF src/cg/$(DEPDIR)/libttsmimic_la-cst_mlpg.Tpo -c -o src/cg/libttsmimic_la-cst_mlpg.lo `test -f 'src/cg/cst_mlpg.c' || echo '$(srcdir)/'`src/cg/cst_mlpg.c
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) src/cg/$(DEPDIR)/libttsmimic_la-cst_mlpg.Tpo src/cg/$(DEPDIR)/libttsmimic_la-cst_mlpg.Plo
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='src/cg/cst_mlpg.c' object='src/cg/libttsmimic_la-cst_mlpg.lo' libtool=yes @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_la_CFLAGS) $(CFLAGS) -c -o src/cg/libmimic_la-cst_mlpg.lo `test -f 'src/cg/cst_mlpg.c' || echo '$(srcdir)/'`src/cg/cst_mlpg.c
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_la_CFLAGS) $(CFLAGS) -c -o src/cg/libttsmimic_la-cst_mlpg.lo `test -f 'src/cg/cst_mlpg.c' || echo '$(srcdir)/'`src/cg/cst_mlpg.c
 
-src/cg/libmimic_la-cst_vc.lo: src/cg/cst_vc.c
-@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_la_CFLAGS) $(CFLAGS) -MT src/cg/libmimic_la-cst_vc.lo -MD -MP -MF src/cg/$(DEPDIR)/libmimic_la-cst_vc.Tpo -c -o src/cg/libmimic_la-cst_vc.lo `test -f 'src/cg/cst_vc.c' || echo '$(srcdir)/'`src/cg/cst_vc.c
-@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) src/cg/$(DEPDIR)/libmimic_la-cst_vc.Tpo src/cg/$(DEPDIR)/libmimic_la-cst_vc.Plo
-@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='src/cg/cst_vc.c' object='src/cg/libmimic_la-cst_vc.lo' libtool=yes @AMDEPBACKSLASH@
+src/cg/libttsmimic_la-cst_vc.lo: src/cg/cst_vc.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_la_CFLAGS) $(CFLAGS) -MT src/cg/libttsmimic_la-cst_vc.lo -MD -MP -MF src/cg/$(DEPDIR)/libttsmimic_la-cst_vc.Tpo -c -o src/cg/libttsmimic_la-cst_vc.lo `test -f 'src/cg/cst_vc.c' || echo '$(srcdir)/'`src/cg/cst_vc.c
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) src/cg/$(DEPDIR)/libttsmimic_la-cst_vc.Tpo src/cg/$(DEPDIR)/libttsmimic_la-cst_vc.Plo
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='src/cg/cst_vc.c' object='src/cg/libttsmimic_la-cst_vc.lo' libtool=yes @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_la_CFLAGS) $(CFLAGS) -c -o src/cg/libmimic_la-cst_vc.lo `test -f 'src/cg/cst_vc.c' || echo '$(srcdir)/'`src/cg/cst_vc.c
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_la_CFLAGS) $(CFLAGS) -c -o src/cg/libttsmimic_la-cst_vc.lo `test -f 'src/cg/cst_vc.c' || echo '$(srcdir)/'`src/cg/cst_vc.c
 
-src/cg/libmimic_la-cst_cg_load_voice.lo: src/cg/cst_cg_load_voice.c
-@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_la_CFLAGS) $(CFLAGS) -MT src/cg/libmimic_la-cst_cg_load_voice.lo -MD -MP -MF src/cg/$(DEPDIR)/libmimic_la-cst_cg_load_voice.Tpo -c -o src/cg/libmimic_la-cst_cg_load_voice.lo `test -f 'src/cg/cst_cg_load_voice.c' || echo '$(srcdir)/'`src/cg/cst_cg_load_voice.c
-@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) src/cg/$(DEPDIR)/libmimic_la-cst_cg_load_voice.Tpo src/cg/$(DEPDIR)/libmimic_la-cst_cg_load_voice.Plo
-@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='src/cg/cst_cg_load_voice.c' object='src/cg/libmimic_la-cst_cg_load_voice.lo' libtool=yes @AMDEPBACKSLASH@
+src/cg/libttsmimic_la-cst_cg_load_voice.lo: src/cg/cst_cg_load_voice.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_la_CFLAGS) $(CFLAGS) -MT src/cg/libttsmimic_la-cst_cg_load_voice.lo -MD -MP -MF src/cg/$(DEPDIR)/libttsmimic_la-cst_cg_load_voice.Tpo -c -o src/cg/libttsmimic_la-cst_cg_load_voice.lo `test -f 'src/cg/cst_cg_load_voice.c' || echo '$(srcdir)/'`src/cg/cst_cg_load_voice.c
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) src/cg/$(DEPDIR)/libttsmimic_la-cst_cg_load_voice.Tpo src/cg/$(DEPDIR)/libttsmimic_la-cst_cg_load_voice.Plo
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='src/cg/cst_cg_load_voice.c' object='src/cg/libttsmimic_la-cst_cg_load_voice.lo' libtool=yes @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_la_CFLAGS) $(CFLAGS) -c -o src/cg/libmimic_la-cst_cg_load_voice.lo `test -f 'src/cg/cst_cg_load_voice.c' || echo '$(srcdir)/'`src/cg/cst_cg_load_voice.c
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_la_CFLAGS) $(CFLAGS) -c -o src/cg/libttsmimic_la-cst_cg_load_voice.lo `test -f 'src/cg/cst_cg_load_voice.c' || echo '$(srcdir)/'`src/cg/cst_cg_load_voice.c
 
-src/cg/libmimic_la-cst_cg_dump_voice.lo: src/cg/cst_cg_dump_voice.c
-@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_la_CFLAGS) $(CFLAGS) -MT src/cg/libmimic_la-cst_cg_dump_voice.lo -MD -MP -MF src/cg/$(DEPDIR)/libmimic_la-cst_cg_dump_voice.Tpo -c -o src/cg/libmimic_la-cst_cg_dump_voice.lo `test -f 'src/cg/cst_cg_dump_voice.c' || echo '$(srcdir)/'`src/cg/cst_cg_dump_voice.c
-@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) src/cg/$(DEPDIR)/libmimic_la-cst_cg_dump_voice.Tpo src/cg/$(DEPDIR)/libmimic_la-cst_cg_dump_voice.Plo
-@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='src/cg/cst_cg_dump_voice.c' object='src/cg/libmimic_la-cst_cg_dump_voice.lo' libtool=yes @AMDEPBACKSLASH@
+src/cg/libttsmimic_la-cst_cg_dump_voice.lo: src/cg/cst_cg_dump_voice.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_la_CFLAGS) $(CFLAGS) -MT src/cg/libttsmimic_la-cst_cg_dump_voice.lo -MD -MP -MF src/cg/$(DEPDIR)/libttsmimic_la-cst_cg_dump_voice.Tpo -c -o src/cg/libttsmimic_la-cst_cg_dump_voice.lo `test -f 'src/cg/cst_cg_dump_voice.c' || echo '$(srcdir)/'`src/cg/cst_cg_dump_voice.c
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) src/cg/$(DEPDIR)/libttsmimic_la-cst_cg_dump_voice.Tpo src/cg/$(DEPDIR)/libttsmimic_la-cst_cg_dump_voice.Plo
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='src/cg/cst_cg_dump_voice.c' object='src/cg/libttsmimic_la-cst_cg_dump_voice.lo' libtool=yes @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_la_CFLAGS) $(CFLAGS) -c -o src/cg/libmimic_la-cst_cg_dump_voice.lo `test -f 'src/cg/cst_cg_dump_voice.c' || echo '$(srcdir)/'`src/cg/cst_cg_dump_voice.c
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_la_CFLAGS) $(CFLAGS) -c -o src/cg/libttsmimic_la-cst_cg_dump_voice.lo `test -f 'src/cg/cst_cg_dump_voice.c' || echo '$(srcdir)/'`src/cg/cst_cg_dump_voice.c
 
-src/cg/libmimic_la-cst_cg_map.lo: src/cg/cst_cg_map.c
-@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_la_CFLAGS) $(CFLAGS) -MT src/cg/libmimic_la-cst_cg_map.lo -MD -MP -MF src/cg/$(DEPDIR)/libmimic_la-cst_cg_map.Tpo -c -o src/cg/libmimic_la-cst_cg_map.lo `test -f 'src/cg/cst_cg_map.c' || echo '$(srcdir)/'`src/cg/cst_cg_map.c
-@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) src/cg/$(DEPDIR)/libmimic_la-cst_cg_map.Tpo src/cg/$(DEPDIR)/libmimic_la-cst_cg_map.Plo
-@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='src/cg/cst_cg_map.c' object='src/cg/libmimic_la-cst_cg_map.lo' libtool=yes @AMDEPBACKSLASH@
+src/cg/libttsmimic_la-cst_cg_map.lo: src/cg/cst_cg_map.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_la_CFLAGS) $(CFLAGS) -MT src/cg/libttsmimic_la-cst_cg_map.lo -MD -MP -MF src/cg/$(DEPDIR)/libttsmimic_la-cst_cg_map.Tpo -c -o src/cg/libttsmimic_la-cst_cg_map.lo `test -f 'src/cg/cst_cg_map.c' || echo '$(srcdir)/'`src/cg/cst_cg_map.c
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) src/cg/$(DEPDIR)/libttsmimic_la-cst_cg_map.Tpo src/cg/$(DEPDIR)/libttsmimic_la-cst_cg_map.Plo
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='src/cg/cst_cg_map.c' object='src/cg/libttsmimic_la-cst_cg_map.lo' libtool=yes @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_la_CFLAGS) $(CFLAGS) -c -o src/cg/libmimic_la-cst_cg_map.lo `test -f 'src/cg/cst_cg_map.c' || echo '$(srcdir)/'`src/cg/cst_cg_map.c
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_la_CFLAGS) $(CFLAGS) -c -o src/cg/libttsmimic_la-cst_cg_map.lo `test -f 'src/cg/cst_cg_map.c' || echo '$(srcdir)/'`src/cg/cst_cg_map.c
 
-src/cg/libmimic_la-cst_spamf0.lo: src/cg/cst_spamf0.c
-@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_la_CFLAGS) $(CFLAGS) -MT src/cg/libmimic_la-cst_spamf0.lo -MD -MP -MF src/cg/$(DEPDIR)/libmimic_la-cst_spamf0.Tpo -c -o src/cg/libmimic_la-cst_spamf0.lo `test -f 'src/cg/cst_spamf0.c' || echo '$(srcdir)/'`src/cg/cst_spamf0.c
-@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) src/cg/$(DEPDIR)/libmimic_la-cst_spamf0.Tpo src/cg/$(DEPDIR)/libmimic_la-cst_spamf0.Plo
-@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='src/cg/cst_spamf0.c' object='src/cg/libmimic_la-cst_spamf0.lo' libtool=yes @AMDEPBACKSLASH@
+src/cg/libttsmimic_la-cst_spamf0.lo: src/cg/cst_spamf0.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_la_CFLAGS) $(CFLAGS) -MT src/cg/libttsmimic_la-cst_spamf0.lo -MD -MP -MF src/cg/$(DEPDIR)/libttsmimic_la-cst_spamf0.Tpo -c -o src/cg/libttsmimic_la-cst_spamf0.lo `test -f 'src/cg/cst_spamf0.c' || echo '$(srcdir)/'`src/cg/cst_spamf0.c
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) src/cg/$(DEPDIR)/libttsmimic_la-cst_spamf0.Tpo src/cg/$(DEPDIR)/libttsmimic_la-cst_spamf0.Plo
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='src/cg/cst_spamf0.c' object='src/cg/libttsmimic_la-cst_spamf0.lo' libtool=yes @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_la_CFLAGS) $(CFLAGS) -c -o src/cg/libmimic_la-cst_spamf0.lo `test -f 'src/cg/cst_spamf0.c' || echo '$(srcdir)/'`src/cg/cst_spamf0.c
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_la_CFLAGS) $(CFLAGS) -c -o src/cg/libttsmimic_la-cst_spamf0.lo `test -f 'src/cg/cst_spamf0.c' || echo '$(srcdir)/'`src/cg/cst_spamf0.c
 
-src/hrg/libmimic_la-cst_utterance.lo: src/hrg/cst_utterance.c
-@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_la_CFLAGS) $(CFLAGS) -MT src/hrg/libmimic_la-cst_utterance.lo -MD -MP -MF src/hrg/$(DEPDIR)/libmimic_la-cst_utterance.Tpo -c -o src/hrg/libmimic_la-cst_utterance.lo `test -f 'src/hrg/cst_utterance.c' || echo '$(srcdir)/'`src/hrg/cst_utterance.c
-@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) src/hrg/$(DEPDIR)/libmimic_la-cst_utterance.Tpo src/hrg/$(DEPDIR)/libmimic_la-cst_utterance.Plo
-@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='src/hrg/cst_utterance.c' object='src/hrg/libmimic_la-cst_utterance.lo' libtool=yes @AMDEPBACKSLASH@
+src/hrg/libttsmimic_la-cst_utterance.lo: src/hrg/cst_utterance.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_la_CFLAGS) $(CFLAGS) -MT src/hrg/libttsmimic_la-cst_utterance.lo -MD -MP -MF src/hrg/$(DEPDIR)/libttsmimic_la-cst_utterance.Tpo -c -o src/hrg/libttsmimic_la-cst_utterance.lo `test -f 'src/hrg/cst_utterance.c' || echo '$(srcdir)/'`src/hrg/cst_utterance.c
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) src/hrg/$(DEPDIR)/libttsmimic_la-cst_utterance.Tpo src/hrg/$(DEPDIR)/libttsmimic_la-cst_utterance.Plo
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='src/hrg/cst_utterance.c' object='src/hrg/libttsmimic_la-cst_utterance.lo' libtool=yes @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_la_CFLAGS) $(CFLAGS) -c -o src/hrg/libmimic_la-cst_utterance.lo `test -f 'src/hrg/cst_utterance.c' || echo '$(srcdir)/'`src/hrg/cst_utterance.c
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_la_CFLAGS) $(CFLAGS) -c -o src/hrg/libttsmimic_la-cst_utterance.lo `test -f 'src/hrg/cst_utterance.c' || echo '$(srcdir)/'`src/hrg/cst_utterance.c
 
-src/hrg/libmimic_la-cst_relation.lo: src/hrg/cst_relation.c
-@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_la_CFLAGS) $(CFLAGS) -MT src/hrg/libmimic_la-cst_relation.lo -MD -MP -MF src/hrg/$(DEPDIR)/libmimic_la-cst_relation.Tpo -c -o src/hrg/libmimic_la-cst_relation.lo `test -f 'src/hrg/cst_relation.c' || echo '$(srcdir)/'`src/hrg/cst_relation.c
-@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) src/hrg/$(DEPDIR)/libmimic_la-cst_relation.Tpo src/hrg/$(DEPDIR)/libmimic_la-cst_relation.Plo
-@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='src/hrg/cst_relation.c' object='src/hrg/libmimic_la-cst_relation.lo' libtool=yes @AMDEPBACKSLASH@
+src/hrg/libttsmimic_la-cst_relation.lo: src/hrg/cst_relation.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_la_CFLAGS) $(CFLAGS) -MT src/hrg/libttsmimic_la-cst_relation.lo -MD -MP -MF src/hrg/$(DEPDIR)/libttsmimic_la-cst_relation.Tpo -c -o src/hrg/libttsmimic_la-cst_relation.lo `test -f 'src/hrg/cst_relation.c' || echo '$(srcdir)/'`src/hrg/cst_relation.c
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) src/hrg/$(DEPDIR)/libttsmimic_la-cst_relation.Tpo src/hrg/$(DEPDIR)/libttsmimic_la-cst_relation.Plo
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='src/hrg/cst_relation.c' object='src/hrg/libttsmimic_la-cst_relation.lo' libtool=yes @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_la_CFLAGS) $(CFLAGS) -c -o src/hrg/libmimic_la-cst_relation.lo `test -f 'src/hrg/cst_relation.c' || echo '$(srcdir)/'`src/hrg/cst_relation.c
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_la_CFLAGS) $(CFLAGS) -c -o src/hrg/libttsmimic_la-cst_relation.lo `test -f 'src/hrg/cst_relation.c' || echo '$(srcdir)/'`src/hrg/cst_relation.c
 
-src/hrg/libmimic_la-cst_item.lo: src/hrg/cst_item.c
-@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_la_CFLAGS) $(CFLAGS) -MT src/hrg/libmimic_la-cst_item.lo -MD -MP -MF src/hrg/$(DEPDIR)/libmimic_la-cst_item.Tpo -c -o src/hrg/libmimic_la-cst_item.lo `test -f 'src/hrg/cst_item.c' || echo '$(srcdir)/'`src/hrg/cst_item.c
-@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) src/hrg/$(DEPDIR)/libmimic_la-cst_item.Tpo src/hrg/$(DEPDIR)/libmimic_la-cst_item.Plo
-@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='src/hrg/cst_item.c' object='src/hrg/libmimic_la-cst_item.lo' libtool=yes @AMDEPBACKSLASH@
+src/hrg/libttsmimic_la-cst_item.lo: src/hrg/cst_item.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_la_CFLAGS) $(CFLAGS) -MT src/hrg/libttsmimic_la-cst_item.lo -MD -MP -MF src/hrg/$(DEPDIR)/libttsmimic_la-cst_item.Tpo -c -o src/hrg/libttsmimic_la-cst_item.lo `test -f 'src/hrg/cst_item.c' || echo '$(srcdir)/'`src/hrg/cst_item.c
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) src/hrg/$(DEPDIR)/libttsmimic_la-cst_item.Tpo src/hrg/$(DEPDIR)/libttsmimic_la-cst_item.Plo
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='src/hrg/cst_item.c' object='src/hrg/libttsmimic_la-cst_item.lo' libtool=yes @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_la_CFLAGS) $(CFLAGS) -c -o src/hrg/libmimic_la-cst_item.lo `test -f 'src/hrg/cst_item.c' || echo '$(srcdir)/'`src/hrg/cst_item.c
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_la_CFLAGS) $(CFLAGS) -c -o src/hrg/libttsmimic_la-cst_item.lo `test -f 'src/hrg/cst_item.c' || echo '$(srcdir)/'`src/hrg/cst_item.c
 
-src/hrg/libmimic_la-cst_ffeature.lo: src/hrg/cst_ffeature.c
-@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_la_CFLAGS) $(CFLAGS) -MT src/hrg/libmimic_la-cst_ffeature.lo -MD -MP -MF src/hrg/$(DEPDIR)/libmimic_la-cst_ffeature.Tpo -c -o src/hrg/libmimic_la-cst_ffeature.lo `test -f 'src/hrg/cst_ffeature.c' || echo '$(srcdir)/'`src/hrg/cst_ffeature.c
-@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) src/hrg/$(DEPDIR)/libmimic_la-cst_ffeature.Tpo src/hrg/$(DEPDIR)/libmimic_la-cst_ffeature.Plo
-@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='src/hrg/cst_ffeature.c' object='src/hrg/libmimic_la-cst_ffeature.lo' libtool=yes @AMDEPBACKSLASH@
+src/hrg/libttsmimic_la-cst_ffeature.lo: src/hrg/cst_ffeature.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_la_CFLAGS) $(CFLAGS) -MT src/hrg/libttsmimic_la-cst_ffeature.lo -MD -MP -MF src/hrg/$(DEPDIR)/libttsmimic_la-cst_ffeature.Tpo -c -o src/hrg/libttsmimic_la-cst_ffeature.lo `test -f 'src/hrg/cst_ffeature.c' || echo '$(srcdir)/'`src/hrg/cst_ffeature.c
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) src/hrg/$(DEPDIR)/libttsmimic_la-cst_ffeature.Tpo src/hrg/$(DEPDIR)/libttsmimic_la-cst_ffeature.Plo
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='src/hrg/cst_ffeature.c' object='src/hrg/libttsmimic_la-cst_ffeature.lo' libtool=yes @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_la_CFLAGS) $(CFLAGS) -c -o src/hrg/libmimic_la-cst_ffeature.lo `test -f 'src/hrg/cst_ffeature.c' || echo '$(srcdir)/'`src/hrg/cst_ffeature.c
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_la_CFLAGS) $(CFLAGS) -c -o src/hrg/libttsmimic_la-cst_ffeature.lo `test -f 'src/hrg/cst_ffeature.c' || echo '$(srcdir)/'`src/hrg/cst_ffeature.c
 
-src/hrg/libmimic_la-cst_rel_io.lo: src/hrg/cst_rel_io.c
-@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_la_CFLAGS) $(CFLAGS) -MT src/hrg/libmimic_la-cst_rel_io.lo -MD -MP -MF src/hrg/$(DEPDIR)/libmimic_la-cst_rel_io.Tpo -c -o src/hrg/libmimic_la-cst_rel_io.lo `test -f 'src/hrg/cst_rel_io.c' || echo '$(srcdir)/'`src/hrg/cst_rel_io.c
-@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) src/hrg/$(DEPDIR)/libmimic_la-cst_rel_io.Tpo src/hrg/$(DEPDIR)/libmimic_la-cst_rel_io.Plo
-@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='src/hrg/cst_rel_io.c' object='src/hrg/libmimic_la-cst_rel_io.lo' libtool=yes @AMDEPBACKSLASH@
+src/hrg/libttsmimic_la-cst_rel_io.lo: src/hrg/cst_rel_io.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_la_CFLAGS) $(CFLAGS) -MT src/hrg/libttsmimic_la-cst_rel_io.lo -MD -MP -MF src/hrg/$(DEPDIR)/libttsmimic_la-cst_rel_io.Tpo -c -o src/hrg/libttsmimic_la-cst_rel_io.lo `test -f 'src/hrg/cst_rel_io.c' || echo '$(srcdir)/'`src/hrg/cst_rel_io.c
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) src/hrg/$(DEPDIR)/libttsmimic_la-cst_rel_io.Tpo src/hrg/$(DEPDIR)/libttsmimic_la-cst_rel_io.Plo
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='src/hrg/cst_rel_io.c' object='src/hrg/libttsmimic_la-cst_rel_io.lo' libtool=yes @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_la_CFLAGS) $(CFLAGS) -c -o src/hrg/libmimic_la-cst_rel_io.lo `test -f 'src/hrg/cst_rel_io.c' || echo '$(srcdir)/'`src/hrg/cst_rel_io.c
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_la_CFLAGS) $(CFLAGS) -c -o src/hrg/libttsmimic_la-cst_rel_io.lo `test -f 'src/hrg/cst_rel_io.c' || echo '$(srcdir)/'`src/hrg/cst_rel_io.c
 
-src/lexicon/libmimic_la-cst_lexicon.lo: src/lexicon/cst_lexicon.c
-@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_la_CFLAGS) $(CFLAGS) -MT src/lexicon/libmimic_la-cst_lexicon.lo -MD -MP -MF src/lexicon/$(DEPDIR)/libmimic_la-cst_lexicon.Tpo -c -o src/lexicon/libmimic_la-cst_lexicon.lo `test -f 'src/lexicon/cst_lexicon.c' || echo '$(srcdir)/'`src/lexicon/cst_lexicon.c
-@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) src/lexicon/$(DEPDIR)/libmimic_la-cst_lexicon.Tpo src/lexicon/$(DEPDIR)/libmimic_la-cst_lexicon.Plo
-@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='src/lexicon/cst_lexicon.c' object='src/lexicon/libmimic_la-cst_lexicon.lo' libtool=yes @AMDEPBACKSLASH@
+src/lexicon/libttsmimic_la-cst_lexicon.lo: src/lexicon/cst_lexicon.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_la_CFLAGS) $(CFLAGS) -MT src/lexicon/libttsmimic_la-cst_lexicon.lo -MD -MP -MF src/lexicon/$(DEPDIR)/libttsmimic_la-cst_lexicon.Tpo -c -o src/lexicon/libttsmimic_la-cst_lexicon.lo `test -f 'src/lexicon/cst_lexicon.c' || echo '$(srcdir)/'`src/lexicon/cst_lexicon.c
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) src/lexicon/$(DEPDIR)/libttsmimic_la-cst_lexicon.Tpo src/lexicon/$(DEPDIR)/libttsmimic_la-cst_lexicon.Plo
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='src/lexicon/cst_lexicon.c' object='src/lexicon/libttsmimic_la-cst_lexicon.lo' libtool=yes @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_la_CFLAGS) $(CFLAGS) -c -o src/lexicon/libmimic_la-cst_lexicon.lo `test -f 'src/lexicon/cst_lexicon.c' || echo '$(srcdir)/'`src/lexicon/cst_lexicon.c
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_la_CFLAGS) $(CFLAGS) -c -o src/lexicon/libttsmimic_la-cst_lexicon.lo `test -f 'src/lexicon/cst_lexicon.c' || echo '$(srcdir)/'`src/lexicon/cst_lexicon.c
 
-src/lexicon/libmimic_la-cst_lts.lo: src/lexicon/cst_lts.c
-@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_la_CFLAGS) $(CFLAGS) -MT src/lexicon/libmimic_la-cst_lts.lo -MD -MP -MF src/lexicon/$(DEPDIR)/libmimic_la-cst_lts.Tpo -c -o src/lexicon/libmimic_la-cst_lts.lo `test -f 'src/lexicon/cst_lts.c' || echo '$(srcdir)/'`src/lexicon/cst_lts.c
-@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) src/lexicon/$(DEPDIR)/libmimic_la-cst_lts.Tpo src/lexicon/$(DEPDIR)/libmimic_la-cst_lts.Plo
-@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='src/lexicon/cst_lts.c' object='src/lexicon/libmimic_la-cst_lts.lo' libtool=yes @AMDEPBACKSLASH@
+src/lexicon/libttsmimic_la-cst_lts.lo: src/lexicon/cst_lts.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_la_CFLAGS) $(CFLAGS) -MT src/lexicon/libttsmimic_la-cst_lts.lo -MD -MP -MF src/lexicon/$(DEPDIR)/libttsmimic_la-cst_lts.Tpo -c -o src/lexicon/libttsmimic_la-cst_lts.lo `test -f 'src/lexicon/cst_lts.c' || echo '$(srcdir)/'`src/lexicon/cst_lts.c
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) src/lexicon/$(DEPDIR)/libttsmimic_la-cst_lts.Tpo src/lexicon/$(DEPDIR)/libttsmimic_la-cst_lts.Plo
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='src/lexicon/cst_lts.c' object='src/lexicon/libttsmimic_la-cst_lts.lo' libtool=yes @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_la_CFLAGS) $(CFLAGS) -c -o src/lexicon/libmimic_la-cst_lts.lo `test -f 'src/lexicon/cst_lts.c' || echo '$(srcdir)/'`src/lexicon/cst_lts.c
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_la_CFLAGS) $(CFLAGS) -c -o src/lexicon/libttsmimic_la-cst_lts.lo `test -f 'src/lexicon/cst_lts.c' || echo '$(srcdir)/'`src/lexicon/cst_lts.c
 
-src/lexicon/libmimic_la-cst_lts_rewrites.lo: src/lexicon/cst_lts_rewrites.c
-@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_la_CFLAGS) $(CFLAGS) -MT src/lexicon/libmimic_la-cst_lts_rewrites.lo -MD -MP -MF src/lexicon/$(DEPDIR)/libmimic_la-cst_lts_rewrites.Tpo -c -o src/lexicon/libmimic_la-cst_lts_rewrites.lo `test -f 'src/lexicon/cst_lts_rewrites.c' || echo '$(srcdir)/'`src/lexicon/cst_lts_rewrites.c
-@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) src/lexicon/$(DEPDIR)/libmimic_la-cst_lts_rewrites.Tpo src/lexicon/$(DEPDIR)/libmimic_la-cst_lts_rewrites.Plo
-@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='src/lexicon/cst_lts_rewrites.c' object='src/lexicon/libmimic_la-cst_lts_rewrites.lo' libtool=yes @AMDEPBACKSLASH@
+src/lexicon/libttsmimic_la-cst_lts_rewrites.lo: src/lexicon/cst_lts_rewrites.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_la_CFLAGS) $(CFLAGS) -MT src/lexicon/libttsmimic_la-cst_lts_rewrites.lo -MD -MP -MF src/lexicon/$(DEPDIR)/libttsmimic_la-cst_lts_rewrites.Tpo -c -o src/lexicon/libttsmimic_la-cst_lts_rewrites.lo `test -f 'src/lexicon/cst_lts_rewrites.c' || echo '$(srcdir)/'`src/lexicon/cst_lts_rewrites.c
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) src/lexicon/$(DEPDIR)/libttsmimic_la-cst_lts_rewrites.Tpo src/lexicon/$(DEPDIR)/libttsmimic_la-cst_lts_rewrites.Plo
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='src/lexicon/cst_lts_rewrites.c' object='src/lexicon/libttsmimic_la-cst_lts_rewrites.lo' libtool=yes @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_la_CFLAGS) $(CFLAGS) -c -o src/lexicon/libmimic_la-cst_lts_rewrites.lo `test -f 'src/lexicon/cst_lts_rewrites.c' || echo '$(srcdir)/'`src/lexicon/cst_lts_rewrites.c
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_la_CFLAGS) $(CFLAGS) -c -o src/lexicon/libttsmimic_la-cst_lts_rewrites.lo `test -f 'src/lexicon/cst_lts_rewrites.c' || echo '$(srcdir)/'`src/lexicon/cst_lts_rewrites.c
 
-src/regex/libmimic_la-cst_regex.lo: src/regex/cst_regex.c
-@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_la_CFLAGS) $(CFLAGS) -MT src/regex/libmimic_la-cst_regex.lo -MD -MP -MF src/regex/$(DEPDIR)/libmimic_la-cst_regex.Tpo -c -o src/regex/libmimic_la-cst_regex.lo `test -f 'src/regex/cst_regex.c' || echo '$(srcdir)/'`src/regex/cst_regex.c
-@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) src/regex/$(DEPDIR)/libmimic_la-cst_regex.Tpo src/regex/$(DEPDIR)/libmimic_la-cst_regex.Plo
-@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='src/regex/cst_regex.c' object='src/regex/libmimic_la-cst_regex.lo' libtool=yes @AMDEPBACKSLASH@
+src/regex/libttsmimic_la-cst_regex.lo: src/regex/cst_regex.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_la_CFLAGS) $(CFLAGS) -MT src/regex/libttsmimic_la-cst_regex.lo -MD -MP -MF src/regex/$(DEPDIR)/libttsmimic_la-cst_regex.Tpo -c -o src/regex/libttsmimic_la-cst_regex.lo `test -f 'src/regex/cst_regex.c' || echo '$(srcdir)/'`src/regex/cst_regex.c
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) src/regex/$(DEPDIR)/libttsmimic_la-cst_regex.Tpo src/regex/$(DEPDIR)/libttsmimic_la-cst_regex.Plo
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='src/regex/cst_regex.c' object='src/regex/libttsmimic_la-cst_regex.lo' libtool=yes @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_la_CFLAGS) $(CFLAGS) -c -o src/regex/libmimic_la-cst_regex.lo `test -f 'src/regex/cst_regex.c' || echo '$(srcdir)/'`src/regex/cst_regex.c
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_la_CFLAGS) $(CFLAGS) -c -o src/regex/libttsmimic_la-cst_regex.lo `test -f 'src/regex/cst_regex.c' || echo '$(srcdir)/'`src/regex/cst_regex.c
 
-src/regex/libmimic_la-regexp.lo: src/regex/regexp.c
-@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_la_CFLAGS) $(CFLAGS) -MT src/regex/libmimic_la-regexp.lo -MD -MP -MF src/regex/$(DEPDIR)/libmimic_la-regexp.Tpo -c -o src/regex/libmimic_la-regexp.lo `test -f 'src/regex/regexp.c' || echo '$(srcdir)/'`src/regex/regexp.c
-@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) src/regex/$(DEPDIR)/libmimic_la-regexp.Tpo src/regex/$(DEPDIR)/libmimic_la-regexp.Plo
-@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='src/regex/regexp.c' object='src/regex/libmimic_la-regexp.lo' libtool=yes @AMDEPBACKSLASH@
+src/regex/libttsmimic_la-regexp.lo: src/regex/regexp.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_la_CFLAGS) $(CFLAGS) -MT src/regex/libttsmimic_la-regexp.lo -MD -MP -MF src/regex/$(DEPDIR)/libttsmimic_la-regexp.Tpo -c -o src/regex/libttsmimic_la-regexp.lo `test -f 'src/regex/regexp.c' || echo '$(srcdir)/'`src/regex/regexp.c
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) src/regex/$(DEPDIR)/libttsmimic_la-regexp.Tpo src/regex/$(DEPDIR)/libttsmimic_la-regexp.Plo
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='src/regex/regexp.c' object='src/regex/libttsmimic_la-regexp.lo' libtool=yes @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_la_CFLAGS) $(CFLAGS) -c -o src/regex/libmimic_la-regexp.lo `test -f 'src/regex/regexp.c' || echo '$(srcdir)/'`src/regex/regexp.c
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_la_CFLAGS) $(CFLAGS) -c -o src/regex/libttsmimic_la-regexp.lo `test -f 'src/regex/regexp.c' || echo '$(srcdir)/'`src/regex/regexp.c
 
-src/regex/libmimic_la-regsub.lo: src/regex/regsub.c
-@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_la_CFLAGS) $(CFLAGS) -MT src/regex/libmimic_la-regsub.lo -MD -MP -MF src/regex/$(DEPDIR)/libmimic_la-regsub.Tpo -c -o src/regex/libmimic_la-regsub.lo `test -f 'src/regex/regsub.c' || echo '$(srcdir)/'`src/regex/regsub.c
-@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) src/regex/$(DEPDIR)/libmimic_la-regsub.Tpo src/regex/$(DEPDIR)/libmimic_la-regsub.Plo
-@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='src/regex/regsub.c' object='src/regex/libmimic_la-regsub.lo' libtool=yes @AMDEPBACKSLASH@
+src/regex/libttsmimic_la-regsub.lo: src/regex/regsub.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_la_CFLAGS) $(CFLAGS) -MT src/regex/libttsmimic_la-regsub.lo -MD -MP -MF src/regex/$(DEPDIR)/libttsmimic_la-regsub.Tpo -c -o src/regex/libttsmimic_la-regsub.lo `test -f 'src/regex/regsub.c' || echo '$(srcdir)/'`src/regex/regsub.c
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) src/regex/$(DEPDIR)/libttsmimic_la-regsub.Tpo src/regex/$(DEPDIR)/libttsmimic_la-regsub.Plo
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='src/regex/regsub.c' object='src/regex/libttsmimic_la-regsub.lo' libtool=yes @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_la_CFLAGS) $(CFLAGS) -c -o src/regex/libmimic_la-regsub.lo `test -f 'src/regex/regsub.c' || echo '$(srcdir)/'`src/regex/regsub.c
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_la_CFLAGS) $(CFLAGS) -c -o src/regex/libttsmimic_la-regsub.lo `test -f 'src/regex/regsub.c' || echo '$(srcdir)/'`src/regex/regsub.c
 
-src/speech/libmimic_la-cst_lpcres.lo: src/speech/cst_lpcres.c
-@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_la_CFLAGS) $(CFLAGS) -MT src/speech/libmimic_la-cst_lpcres.lo -MD -MP -MF src/speech/$(DEPDIR)/libmimic_la-cst_lpcres.Tpo -c -o src/speech/libmimic_la-cst_lpcres.lo `test -f 'src/speech/cst_lpcres.c' || echo '$(srcdir)/'`src/speech/cst_lpcres.c
-@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) src/speech/$(DEPDIR)/libmimic_la-cst_lpcres.Tpo src/speech/$(DEPDIR)/libmimic_la-cst_lpcres.Plo
-@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='src/speech/cst_lpcres.c' object='src/speech/libmimic_la-cst_lpcres.lo' libtool=yes @AMDEPBACKSLASH@
+src/speech/libttsmimic_la-cst_lpcres.lo: src/speech/cst_lpcres.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_la_CFLAGS) $(CFLAGS) -MT src/speech/libttsmimic_la-cst_lpcres.lo -MD -MP -MF src/speech/$(DEPDIR)/libttsmimic_la-cst_lpcres.Tpo -c -o src/speech/libttsmimic_la-cst_lpcres.lo `test -f 'src/speech/cst_lpcres.c' || echo '$(srcdir)/'`src/speech/cst_lpcres.c
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) src/speech/$(DEPDIR)/libttsmimic_la-cst_lpcres.Tpo src/speech/$(DEPDIR)/libttsmimic_la-cst_lpcres.Plo
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='src/speech/cst_lpcres.c' object='src/speech/libttsmimic_la-cst_lpcres.lo' libtool=yes @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_la_CFLAGS) $(CFLAGS) -c -o src/speech/libmimic_la-cst_lpcres.lo `test -f 'src/speech/cst_lpcres.c' || echo '$(srcdir)/'`src/speech/cst_lpcres.c
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_la_CFLAGS) $(CFLAGS) -c -o src/speech/libttsmimic_la-cst_lpcres.lo `test -f 'src/speech/cst_lpcres.c' || echo '$(srcdir)/'`src/speech/cst_lpcres.c
 
-src/speech/libmimic_la-cst_track.lo: src/speech/cst_track.c
-@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_la_CFLAGS) $(CFLAGS) -MT src/speech/libmimic_la-cst_track.lo -MD -MP -MF src/speech/$(DEPDIR)/libmimic_la-cst_track.Tpo -c -o src/speech/libmimic_la-cst_track.lo `test -f 'src/speech/cst_track.c' || echo '$(srcdir)/'`src/speech/cst_track.c
-@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) src/speech/$(DEPDIR)/libmimic_la-cst_track.Tpo src/speech/$(DEPDIR)/libmimic_la-cst_track.Plo
-@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='src/speech/cst_track.c' object='src/speech/libmimic_la-cst_track.lo' libtool=yes @AMDEPBACKSLASH@
+src/speech/libttsmimic_la-cst_track.lo: src/speech/cst_track.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_la_CFLAGS) $(CFLAGS) -MT src/speech/libttsmimic_la-cst_track.lo -MD -MP -MF src/speech/$(DEPDIR)/libttsmimic_la-cst_track.Tpo -c -o src/speech/libttsmimic_la-cst_track.lo `test -f 'src/speech/cst_track.c' || echo '$(srcdir)/'`src/speech/cst_track.c
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) src/speech/$(DEPDIR)/libttsmimic_la-cst_track.Tpo src/speech/$(DEPDIR)/libttsmimic_la-cst_track.Plo
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='src/speech/cst_track.c' object='src/speech/libttsmimic_la-cst_track.lo' libtool=yes @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_la_CFLAGS) $(CFLAGS) -c -o src/speech/libmimic_la-cst_track.lo `test -f 'src/speech/cst_track.c' || echo '$(srcdir)/'`src/speech/cst_track.c
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_la_CFLAGS) $(CFLAGS) -c -o src/speech/libttsmimic_la-cst_track.lo `test -f 'src/speech/cst_track.c' || echo '$(srcdir)/'`src/speech/cst_track.c
 
-src/speech/libmimic_la-cst_track_io.lo: src/speech/cst_track_io.c
-@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_la_CFLAGS) $(CFLAGS) -MT src/speech/libmimic_la-cst_track_io.lo -MD -MP -MF src/speech/$(DEPDIR)/libmimic_la-cst_track_io.Tpo -c -o src/speech/libmimic_la-cst_track_io.lo `test -f 'src/speech/cst_track_io.c' || echo '$(srcdir)/'`src/speech/cst_track_io.c
-@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) src/speech/$(DEPDIR)/libmimic_la-cst_track_io.Tpo src/speech/$(DEPDIR)/libmimic_la-cst_track_io.Plo
-@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='src/speech/cst_track_io.c' object='src/speech/libmimic_la-cst_track_io.lo' libtool=yes @AMDEPBACKSLASH@
+src/speech/libttsmimic_la-cst_track_io.lo: src/speech/cst_track_io.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_la_CFLAGS) $(CFLAGS) -MT src/speech/libttsmimic_la-cst_track_io.lo -MD -MP -MF src/speech/$(DEPDIR)/libttsmimic_la-cst_track_io.Tpo -c -o src/speech/libttsmimic_la-cst_track_io.lo `test -f 'src/speech/cst_track_io.c' || echo '$(srcdir)/'`src/speech/cst_track_io.c
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) src/speech/$(DEPDIR)/libttsmimic_la-cst_track_io.Tpo src/speech/$(DEPDIR)/libttsmimic_la-cst_track_io.Plo
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='src/speech/cst_track_io.c' object='src/speech/libttsmimic_la-cst_track_io.lo' libtool=yes @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_la_CFLAGS) $(CFLAGS) -c -o src/speech/libmimic_la-cst_track_io.lo `test -f 'src/speech/cst_track_io.c' || echo '$(srcdir)/'`src/speech/cst_track_io.c
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_la_CFLAGS) $(CFLAGS) -c -o src/speech/libttsmimic_la-cst_track_io.lo `test -f 'src/speech/cst_track_io.c' || echo '$(srcdir)/'`src/speech/cst_track_io.c
 
-src/speech/libmimic_la-cst_wave.lo: src/speech/cst_wave.c
-@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_la_CFLAGS) $(CFLAGS) -MT src/speech/libmimic_la-cst_wave.lo -MD -MP -MF src/speech/$(DEPDIR)/libmimic_la-cst_wave.Tpo -c -o src/speech/libmimic_la-cst_wave.lo `test -f 'src/speech/cst_wave.c' || echo '$(srcdir)/'`src/speech/cst_wave.c
-@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) src/speech/$(DEPDIR)/libmimic_la-cst_wave.Tpo src/speech/$(DEPDIR)/libmimic_la-cst_wave.Plo
-@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='src/speech/cst_wave.c' object='src/speech/libmimic_la-cst_wave.lo' libtool=yes @AMDEPBACKSLASH@
+src/speech/libttsmimic_la-cst_wave.lo: src/speech/cst_wave.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_la_CFLAGS) $(CFLAGS) -MT src/speech/libttsmimic_la-cst_wave.lo -MD -MP -MF src/speech/$(DEPDIR)/libttsmimic_la-cst_wave.Tpo -c -o src/speech/libttsmimic_la-cst_wave.lo `test -f 'src/speech/cst_wave.c' || echo '$(srcdir)/'`src/speech/cst_wave.c
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) src/speech/$(DEPDIR)/libttsmimic_la-cst_wave.Tpo src/speech/$(DEPDIR)/libttsmimic_la-cst_wave.Plo
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='src/speech/cst_wave.c' object='src/speech/libttsmimic_la-cst_wave.lo' libtool=yes @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_la_CFLAGS) $(CFLAGS) -c -o src/speech/libmimic_la-cst_wave.lo `test -f 'src/speech/cst_wave.c' || echo '$(srcdir)/'`src/speech/cst_wave.c
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_la_CFLAGS) $(CFLAGS) -c -o src/speech/libttsmimic_la-cst_wave.lo `test -f 'src/speech/cst_wave.c' || echo '$(srcdir)/'`src/speech/cst_wave.c
 
-src/speech/libmimic_la-cst_wave_io.lo: src/speech/cst_wave_io.c
-@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_la_CFLAGS) $(CFLAGS) -MT src/speech/libmimic_la-cst_wave_io.lo -MD -MP -MF src/speech/$(DEPDIR)/libmimic_la-cst_wave_io.Tpo -c -o src/speech/libmimic_la-cst_wave_io.lo `test -f 'src/speech/cst_wave_io.c' || echo '$(srcdir)/'`src/speech/cst_wave_io.c
-@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) src/speech/$(DEPDIR)/libmimic_la-cst_wave_io.Tpo src/speech/$(DEPDIR)/libmimic_la-cst_wave_io.Plo
-@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='src/speech/cst_wave_io.c' object='src/speech/libmimic_la-cst_wave_io.lo' libtool=yes @AMDEPBACKSLASH@
+src/speech/libttsmimic_la-cst_wave_io.lo: src/speech/cst_wave_io.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_la_CFLAGS) $(CFLAGS) -MT src/speech/libttsmimic_la-cst_wave_io.lo -MD -MP -MF src/speech/$(DEPDIR)/libttsmimic_la-cst_wave_io.Tpo -c -o src/speech/libttsmimic_la-cst_wave_io.lo `test -f 'src/speech/cst_wave_io.c' || echo '$(srcdir)/'`src/speech/cst_wave_io.c
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) src/speech/$(DEPDIR)/libttsmimic_la-cst_wave_io.Tpo src/speech/$(DEPDIR)/libttsmimic_la-cst_wave_io.Plo
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='src/speech/cst_wave_io.c' object='src/speech/libttsmimic_la-cst_wave_io.lo' libtool=yes @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_la_CFLAGS) $(CFLAGS) -c -o src/speech/libmimic_la-cst_wave_io.lo `test -f 'src/speech/cst_wave_io.c' || echo '$(srcdir)/'`src/speech/cst_wave_io.c
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_la_CFLAGS) $(CFLAGS) -c -o src/speech/libttsmimic_la-cst_wave_io.lo `test -f 'src/speech/cst_wave_io.c' || echo '$(srcdir)/'`src/speech/cst_wave_io.c
 
-src/speech/libmimic_la-cst_wave_utils.lo: src/speech/cst_wave_utils.c
-@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_la_CFLAGS) $(CFLAGS) -MT src/speech/libmimic_la-cst_wave_utils.lo -MD -MP -MF src/speech/$(DEPDIR)/libmimic_la-cst_wave_utils.Tpo -c -o src/speech/libmimic_la-cst_wave_utils.lo `test -f 'src/speech/cst_wave_utils.c' || echo '$(srcdir)/'`src/speech/cst_wave_utils.c
-@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) src/speech/$(DEPDIR)/libmimic_la-cst_wave_utils.Tpo src/speech/$(DEPDIR)/libmimic_la-cst_wave_utils.Plo
-@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='src/speech/cst_wave_utils.c' object='src/speech/libmimic_la-cst_wave_utils.lo' libtool=yes @AMDEPBACKSLASH@
+src/speech/libttsmimic_la-cst_wave_utils.lo: src/speech/cst_wave_utils.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_la_CFLAGS) $(CFLAGS) -MT src/speech/libttsmimic_la-cst_wave_utils.lo -MD -MP -MF src/speech/$(DEPDIR)/libttsmimic_la-cst_wave_utils.Tpo -c -o src/speech/libttsmimic_la-cst_wave_utils.lo `test -f 'src/speech/cst_wave_utils.c' || echo '$(srcdir)/'`src/speech/cst_wave_utils.c
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) src/speech/$(DEPDIR)/libttsmimic_la-cst_wave_utils.Tpo src/speech/$(DEPDIR)/libttsmimic_la-cst_wave_utils.Plo
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='src/speech/cst_wave_utils.c' object='src/speech/libttsmimic_la-cst_wave_utils.lo' libtool=yes @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_la_CFLAGS) $(CFLAGS) -c -o src/speech/libmimic_la-cst_wave_utils.lo `test -f 'src/speech/cst_wave_utils.c' || echo '$(srcdir)/'`src/speech/cst_wave_utils.c
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_la_CFLAGS) $(CFLAGS) -c -o src/speech/libttsmimic_la-cst_wave_utils.lo `test -f 'src/speech/cst_wave_utils.c' || echo '$(srcdir)/'`src/speech/cst_wave_utils.c
 
-src/speech/libmimic_la-g721.lo: src/speech/g721.c
-@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_la_CFLAGS) $(CFLAGS) -MT src/speech/libmimic_la-g721.lo -MD -MP -MF src/speech/$(DEPDIR)/libmimic_la-g721.Tpo -c -o src/speech/libmimic_la-g721.lo `test -f 'src/speech/g721.c' || echo '$(srcdir)/'`src/speech/g721.c
-@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) src/speech/$(DEPDIR)/libmimic_la-g721.Tpo src/speech/$(DEPDIR)/libmimic_la-g721.Plo
-@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='src/speech/g721.c' object='src/speech/libmimic_la-g721.lo' libtool=yes @AMDEPBACKSLASH@
+src/speech/libttsmimic_la-g721.lo: src/speech/g721.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_la_CFLAGS) $(CFLAGS) -MT src/speech/libttsmimic_la-g721.lo -MD -MP -MF src/speech/$(DEPDIR)/libttsmimic_la-g721.Tpo -c -o src/speech/libttsmimic_la-g721.lo `test -f 'src/speech/g721.c' || echo '$(srcdir)/'`src/speech/g721.c
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) src/speech/$(DEPDIR)/libttsmimic_la-g721.Tpo src/speech/$(DEPDIR)/libttsmimic_la-g721.Plo
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='src/speech/g721.c' object='src/speech/libttsmimic_la-g721.lo' libtool=yes @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_la_CFLAGS) $(CFLAGS) -c -o src/speech/libmimic_la-g721.lo `test -f 'src/speech/g721.c' || echo '$(srcdir)/'`src/speech/g721.c
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_la_CFLAGS) $(CFLAGS) -c -o src/speech/libttsmimic_la-g721.lo `test -f 'src/speech/g721.c' || echo '$(srcdir)/'`src/speech/g721.c
 
-src/speech/libmimic_la-g723_24.lo: src/speech/g723_24.c
-@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_la_CFLAGS) $(CFLAGS) -MT src/speech/libmimic_la-g723_24.lo -MD -MP -MF src/speech/$(DEPDIR)/libmimic_la-g723_24.Tpo -c -o src/speech/libmimic_la-g723_24.lo `test -f 'src/speech/g723_24.c' || echo '$(srcdir)/'`src/speech/g723_24.c
-@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) src/speech/$(DEPDIR)/libmimic_la-g723_24.Tpo src/speech/$(DEPDIR)/libmimic_la-g723_24.Plo
-@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='src/speech/g723_24.c' object='src/speech/libmimic_la-g723_24.lo' libtool=yes @AMDEPBACKSLASH@
+src/speech/libttsmimic_la-g723_24.lo: src/speech/g723_24.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_la_CFLAGS) $(CFLAGS) -MT src/speech/libttsmimic_la-g723_24.lo -MD -MP -MF src/speech/$(DEPDIR)/libttsmimic_la-g723_24.Tpo -c -o src/speech/libttsmimic_la-g723_24.lo `test -f 'src/speech/g723_24.c' || echo '$(srcdir)/'`src/speech/g723_24.c
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) src/speech/$(DEPDIR)/libttsmimic_la-g723_24.Tpo src/speech/$(DEPDIR)/libttsmimic_la-g723_24.Plo
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='src/speech/g723_24.c' object='src/speech/libttsmimic_la-g723_24.lo' libtool=yes @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_la_CFLAGS) $(CFLAGS) -c -o src/speech/libmimic_la-g723_24.lo `test -f 'src/speech/g723_24.c' || echo '$(srcdir)/'`src/speech/g723_24.c
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_la_CFLAGS) $(CFLAGS) -c -o src/speech/libttsmimic_la-g723_24.lo `test -f 'src/speech/g723_24.c' || echo '$(srcdir)/'`src/speech/g723_24.c
 
-src/speech/libmimic_la-g723_40.lo: src/speech/g723_40.c
-@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_la_CFLAGS) $(CFLAGS) -MT src/speech/libmimic_la-g723_40.lo -MD -MP -MF src/speech/$(DEPDIR)/libmimic_la-g723_40.Tpo -c -o src/speech/libmimic_la-g723_40.lo `test -f 'src/speech/g723_40.c' || echo '$(srcdir)/'`src/speech/g723_40.c
-@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) src/speech/$(DEPDIR)/libmimic_la-g723_40.Tpo src/speech/$(DEPDIR)/libmimic_la-g723_40.Plo
-@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='src/speech/g723_40.c' object='src/speech/libmimic_la-g723_40.lo' libtool=yes @AMDEPBACKSLASH@
+src/speech/libttsmimic_la-g723_40.lo: src/speech/g723_40.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_la_CFLAGS) $(CFLAGS) -MT src/speech/libttsmimic_la-g723_40.lo -MD -MP -MF src/speech/$(DEPDIR)/libttsmimic_la-g723_40.Tpo -c -o src/speech/libttsmimic_la-g723_40.lo `test -f 'src/speech/g723_40.c' || echo '$(srcdir)/'`src/speech/g723_40.c
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) src/speech/$(DEPDIR)/libttsmimic_la-g723_40.Tpo src/speech/$(DEPDIR)/libttsmimic_la-g723_40.Plo
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='src/speech/g723_40.c' object='src/speech/libttsmimic_la-g723_40.lo' libtool=yes @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_la_CFLAGS) $(CFLAGS) -c -o src/speech/libmimic_la-g723_40.lo `test -f 'src/speech/g723_40.c' || echo '$(srcdir)/'`src/speech/g723_40.c
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_la_CFLAGS) $(CFLAGS) -c -o src/speech/libttsmimic_la-g723_40.lo `test -f 'src/speech/g723_40.c' || echo '$(srcdir)/'`src/speech/g723_40.c
 
-src/speech/libmimic_la-g72x.lo: src/speech/g72x.c
-@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_la_CFLAGS) $(CFLAGS) -MT src/speech/libmimic_la-g72x.lo -MD -MP -MF src/speech/$(DEPDIR)/libmimic_la-g72x.Tpo -c -o src/speech/libmimic_la-g72x.lo `test -f 'src/speech/g72x.c' || echo '$(srcdir)/'`src/speech/g72x.c
-@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) src/speech/$(DEPDIR)/libmimic_la-g72x.Tpo src/speech/$(DEPDIR)/libmimic_la-g72x.Plo
-@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='src/speech/g72x.c' object='src/speech/libmimic_la-g72x.lo' libtool=yes @AMDEPBACKSLASH@
+src/speech/libttsmimic_la-g72x.lo: src/speech/g72x.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_la_CFLAGS) $(CFLAGS) -MT src/speech/libttsmimic_la-g72x.lo -MD -MP -MF src/speech/$(DEPDIR)/libttsmimic_la-g72x.Tpo -c -o src/speech/libttsmimic_la-g72x.lo `test -f 'src/speech/g72x.c' || echo '$(srcdir)/'`src/speech/g72x.c
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) src/speech/$(DEPDIR)/libttsmimic_la-g72x.Tpo src/speech/$(DEPDIR)/libttsmimic_la-g72x.Plo
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='src/speech/g72x.c' object='src/speech/libttsmimic_la-g72x.lo' libtool=yes @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_la_CFLAGS) $(CFLAGS) -c -o src/speech/libmimic_la-g72x.lo `test -f 'src/speech/g72x.c' || echo '$(srcdir)/'`src/speech/g72x.c
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_la_CFLAGS) $(CFLAGS) -c -o src/speech/libttsmimic_la-g72x.lo `test -f 'src/speech/g72x.c' || echo '$(srcdir)/'`src/speech/g72x.c
 
-src/speech/libmimic_la-rateconv.lo: src/speech/rateconv.c
-@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_la_CFLAGS) $(CFLAGS) -MT src/speech/libmimic_la-rateconv.lo -MD -MP -MF src/speech/$(DEPDIR)/libmimic_la-rateconv.Tpo -c -o src/speech/libmimic_la-rateconv.lo `test -f 'src/speech/rateconv.c' || echo '$(srcdir)/'`src/speech/rateconv.c
-@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) src/speech/$(DEPDIR)/libmimic_la-rateconv.Tpo src/speech/$(DEPDIR)/libmimic_la-rateconv.Plo
-@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='src/speech/rateconv.c' object='src/speech/libmimic_la-rateconv.lo' libtool=yes @AMDEPBACKSLASH@
+src/speech/libttsmimic_la-rateconv.lo: src/speech/rateconv.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_la_CFLAGS) $(CFLAGS) -MT src/speech/libttsmimic_la-rateconv.lo -MD -MP -MF src/speech/$(DEPDIR)/libttsmimic_la-rateconv.Tpo -c -o src/speech/libttsmimic_la-rateconv.lo `test -f 'src/speech/rateconv.c' || echo '$(srcdir)/'`src/speech/rateconv.c
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) src/speech/$(DEPDIR)/libttsmimic_la-rateconv.Tpo src/speech/$(DEPDIR)/libttsmimic_la-rateconv.Plo
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='src/speech/rateconv.c' object='src/speech/libttsmimic_la-rateconv.lo' libtool=yes @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_la_CFLAGS) $(CFLAGS) -c -o src/speech/libmimic_la-rateconv.lo `test -f 'src/speech/rateconv.c' || echo '$(srcdir)/'`src/speech/rateconv.c
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_la_CFLAGS) $(CFLAGS) -c -o src/speech/libttsmimic_la-rateconv.lo `test -f 'src/speech/rateconv.c' || echo '$(srcdir)/'`src/speech/rateconv.c
 
-src/stats/libmimic_la-cst_cart.lo: src/stats/cst_cart.c
-@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_la_CFLAGS) $(CFLAGS) -MT src/stats/libmimic_la-cst_cart.lo -MD -MP -MF src/stats/$(DEPDIR)/libmimic_la-cst_cart.Tpo -c -o src/stats/libmimic_la-cst_cart.lo `test -f 'src/stats/cst_cart.c' || echo '$(srcdir)/'`src/stats/cst_cart.c
-@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) src/stats/$(DEPDIR)/libmimic_la-cst_cart.Tpo src/stats/$(DEPDIR)/libmimic_la-cst_cart.Plo
-@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='src/stats/cst_cart.c' object='src/stats/libmimic_la-cst_cart.lo' libtool=yes @AMDEPBACKSLASH@
+src/stats/libttsmimic_la-cst_cart.lo: src/stats/cst_cart.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_la_CFLAGS) $(CFLAGS) -MT src/stats/libttsmimic_la-cst_cart.lo -MD -MP -MF src/stats/$(DEPDIR)/libttsmimic_la-cst_cart.Tpo -c -o src/stats/libttsmimic_la-cst_cart.lo `test -f 'src/stats/cst_cart.c' || echo '$(srcdir)/'`src/stats/cst_cart.c
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) src/stats/$(DEPDIR)/libttsmimic_la-cst_cart.Tpo src/stats/$(DEPDIR)/libttsmimic_la-cst_cart.Plo
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='src/stats/cst_cart.c' object='src/stats/libttsmimic_la-cst_cart.lo' libtool=yes @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_la_CFLAGS) $(CFLAGS) -c -o src/stats/libmimic_la-cst_cart.lo `test -f 'src/stats/cst_cart.c' || echo '$(srcdir)/'`src/stats/cst_cart.c
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_la_CFLAGS) $(CFLAGS) -c -o src/stats/libttsmimic_la-cst_cart.lo `test -f 'src/stats/cst_cart.c' || echo '$(srcdir)/'`src/stats/cst_cart.c
 
-src/stats/libmimic_la-cst_ss.lo: src/stats/cst_ss.c
-@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_la_CFLAGS) $(CFLAGS) -MT src/stats/libmimic_la-cst_ss.lo -MD -MP -MF src/stats/$(DEPDIR)/libmimic_la-cst_ss.Tpo -c -o src/stats/libmimic_la-cst_ss.lo `test -f 'src/stats/cst_ss.c' || echo '$(srcdir)/'`src/stats/cst_ss.c
-@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) src/stats/$(DEPDIR)/libmimic_la-cst_ss.Tpo src/stats/$(DEPDIR)/libmimic_la-cst_ss.Plo
-@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='src/stats/cst_ss.c' object='src/stats/libmimic_la-cst_ss.lo' libtool=yes @AMDEPBACKSLASH@
+src/stats/libttsmimic_la-cst_ss.lo: src/stats/cst_ss.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_la_CFLAGS) $(CFLAGS) -MT src/stats/libttsmimic_la-cst_ss.lo -MD -MP -MF src/stats/$(DEPDIR)/libttsmimic_la-cst_ss.Tpo -c -o src/stats/libttsmimic_la-cst_ss.lo `test -f 'src/stats/cst_ss.c' || echo '$(srcdir)/'`src/stats/cst_ss.c
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) src/stats/$(DEPDIR)/libttsmimic_la-cst_ss.Tpo src/stats/$(DEPDIR)/libttsmimic_la-cst_ss.Plo
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='src/stats/cst_ss.c' object='src/stats/libttsmimic_la-cst_ss.lo' libtool=yes @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_la_CFLAGS) $(CFLAGS) -c -o src/stats/libmimic_la-cst_ss.lo `test -f 'src/stats/cst_ss.c' || echo '$(srcdir)/'`src/stats/cst_ss.c
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_la_CFLAGS) $(CFLAGS) -c -o src/stats/libttsmimic_la-cst_ss.lo `test -f 'src/stats/cst_ss.c' || echo '$(srcdir)/'`src/stats/cst_ss.c
 
-src/stats/libmimic_la-cst_viterbi.lo: src/stats/cst_viterbi.c
-@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_la_CFLAGS) $(CFLAGS) -MT src/stats/libmimic_la-cst_viterbi.lo -MD -MP -MF src/stats/$(DEPDIR)/libmimic_la-cst_viterbi.Tpo -c -o src/stats/libmimic_la-cst_viterbi.lo `test -f 'src/stats/cst_viterbi.c' || echo '$(srcdir)/'`src/stats/cst_viterbi.c
-@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) src/stats/$(DEPDIR)/libmimic_la-cst_viterbi.Tpo src/stats/$(DEPDIR)/libmimic_la-cst_viterbi.Plo
-@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='src/stats/cst_viterbi.c' object='src/stats/libmimic_la-cst_viterbi.lo' libtool=yes @AMDEPBACKSLASH@
+src/stats/libttsmimic_la-cst_viterbi.lo: src/stats/cst_viterbi.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_la_CFLAGS) $(CFLAGS) -MT src/stats/libttsmimic_la-cst_viterbi.lo -MD -MP -MF src/stats/$(DEPDIR)/libttsmimic_la-cst_viterbi.Tpo -c -o src/stats/libttsmimic_la-cst_viterbi.lo `test -f 'src/stats/cst_viterbi.c' || echo '$(srcdir)/'`src/stats/cst_viterbi.c
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) src/stats/$(DEPDIR)/libttsmimic_la-cst_viterbi.Tpo src/stats/$(DEPDIR)/libttsmimic_la-cst_viterbi.Plo
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='src/stats/cst_viterbi.c' object='src/stats/libttsmimic_la-cst_viterbi.lo' libtool=yes @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_la_CFLAGS) $(CFLAGS) -c -o src/stats/libmimic_la-cst_viterbi.lo `test -f 'src/stats/cst_viterbi.c' || echo '$(srcdir)/'`src/stats/cst_viterbi.c
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_la_CFLAGS) $(CFLAGS) -c -o src/stats/libttsmimic_la-cst_viterbi.lo `test -f 'src/stats/cst_viterbi.c' || echo '$(srcdir)/'`src/stats/cst_viterbi.c
 
-src/synth/libmimic_la-cst_ffeatures.lo: src/synth/cst_ffeatures.c
-@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_la_CFLAGS) $(CFLAGS) -MT src/synth/libmimic_la-cst_ffeatures.lo -MD -MP -MF src/synth/$(DEPDIR)/libmimic_la-cst_ffeatures.Tpo -c -o src/synth/libmimic_la-cst_ffeatures.lo `test -f 'src/synth/cst_ffeatures.c' || echo '$(srcdir)/'`src/synth/cst_ffeatures.c
-@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) src/synth/$(DEPDIR)/libmimic_la-cst_ffeatures.Tpo src/synth/$(DEPDIR)/libmimic_la-cst_ffeatures.Plo
-@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='src/synth/cst_ffeatures.c' object='src/synth/libmimic_la-cst_ffeatures.lo' libtool=yes @AMDEPBACKSLASH@
+src/synth/libttsmimic_la-cst_ffeatures.lo: src/synth/cst_ffeatures.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_la_CFLAGS) $(CFLAGS) -MT src/synth/libttsmimic_la-cst_ffeatures.lo -MD -MP -MF src/synth/$(DEPDIR)/libttsmimic_la-cst_ffeatures.Tpo -c -o src/synth/libttsmimic_la-cst_ffeatures.lo `test -f 'src/synth/cst_ffeatures.c' || echo '$(srcdir)/'`src/synth/cst_ffeatures.c
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) src/synth/$(DEPDIR)/libttsmimic_la-cst_ffeatures.Tpo src/synth/$(DEPDIR)/libttsmimic_la-cst_ffeatures.Plo
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='src/synth/cst_ffeatures.c' object='src/synth/libttsmimic_la-cst_ffeatures.lo' libtool=yes @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_la_CFLAGS) $(CFLAGS) -c -o src/synth/libmimic_la-cst_ffeatures.lo `test -f 'src/synth/cst_ffeatures.c' || echo '$(srcdir)/'`src/synth/cst_ffeatures.c
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_la_CFLAGS) $(CFLAGS) -c -o src/synth/libttsmimic_la-cst_ffeatures.lo `test -f 'src/synth/cst_ffeatures.c' || echo '$(srcdir)/'`src/synth/cst_ffeatures.c
 
-src/synth/libmimic_la-cst_phoneset.lo: src/synth/cst_phoneset.c
-@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_la_CFLAGS) $(CFLAGS) -MT src/synth/libmimic_la-cst_phoneset.lo -MD -MP -MF src/synth/$(DEPDIR)/libmimic_la-cst_phoneset.Tpo -c -o src/synth/libmimic_la-cst_phoneset.lo `test -f 'src/synth/cst_phoneset.c' || echo '$(srcdir)/'`src/synth/cst_phoneset.c
-@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) src/synth/$(DEPDIR)/libmimic_la-cst_phoneset.Tpo src/synth/$(DEPDIR)/libmimic_la-cst_phoneset.Plo
-@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='src/synth/cst_phoneset.c' object='src/synth/libmimic_la-cst_phoneset.lo' libtool=yes @AMDEPBACKSLASH@
+src/synth/libttsmimic_la-cst_phoneset.lo: src/synth/cst_phoneset.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_la_CFLAGS) $(CFLAGS) -MT src/synth/libttsmimic_la-cst_phoneset.lo -MD -MP -MF src/synth/$(DEPDIR)/libttsmimic_la-cst_phoneset.Tpo -c -o src/synth/libttsmimic_la-cst_phoneset.lo `test -f 'src/synth/cst_phoneset.c' || echo '$(srcdir)/'`src/synth/cst_phoneset.c
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) src/synth/$(DEPDIR)/libttsmimic_la-cst_phoneset.Tpo src/synth/$(DEPDIR)/libttsmimic_la-cst_phoneset.Plo
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='src/synth/cst_phoneset.c' object='src/synth/libttsmimic_la-cst_phoneset.lo' libtool=yes @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_la_CFLAGS) $(CFLAGS) -c -o src/synth/libmimic_la-cst_phoneset.lo `test -f 'src/synth/cst_phoneset.c' || echo '$(srcdir)/'`src/synth/cst_phoneset.c
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_la_CFLAGS) $(CFLAGS) -c -o src/synth/libttsmimic_la-cst_phoneset.lo `test -f 'src/synth/cst_phoneset.c' || echo '$(srcdir)/'`src/synth/cst_phoneset.c
 
-src/synth/libmimic_la-cst_ssml.lo: src/synth/cst_ssml.c
-@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_la_CFLAGS) $(CFLAGS) -MT src/synth/libmimic_la-cst_ssml.lo -MD -MP -MF src/synth/$(DEPDIR)/libmimic_la-cst_ssml.Tpo -c -o src/synth/libmimic_la-cst_ssml.lo `test -f 'src/synth/cst_ssml.c' || echo '$(srcdir)/'`src/synth/cst_ssml.c
-@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) src/synth/$(DEPDIR)/libmimic_la-cst_ssml.Tpo src/synth/$(DEPDIR)/libmimic_la-cst_ssml.Plo
-@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='src/synth/cst_ssml.c' object='src/synth/libmimic_la-cst_ssml.lo' libtool=yes @AMDEPBACKSLASH@
+src/synth/libttsmimic_la-cst_ssml.lo: src/synth/cst_ssml.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_la_CFLAGS) $(CFLAGS) -MT src/synth/libttsmimic_la-cst_ssml.lo -MD -MP -MF src/synth/$(DEPDIR)/libttsmimic_la-cst_ssml.Tpo -c -o src/synth/libttsmimic_la-cst_ssml.lo `test -f 'src/synth/cst_ssml.c' || echo '$(srcdir)/'`src/synth/cst_ssml.c
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) src/synth/$(DEPDIR)/libttsmimic_la-cst_ssml.Tpo src/synth/$(DEPDIR)/libttsmimic_la-cst_ssml.Plo
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='src/synth/cst_ssml.c' object='src/synth/libttsmimic_la-cst_ssml.lo' libtool=yes @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_la_CFLAGS) $(CFLAGS) -c -o src/synth/libmimic_la-cst_ssml.lo `test -f 'src/synth/cst_ssml.c' || echo '$(srcdir)/'`src/synth/cst_ssml.c
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_la_CFLAGS) $(CFLAGS) -c -o src/synth/libttsmimic_la-cst_ssml.lo `test -f 'src/synth/cst_ssml.c' || echo '$(srcdir)/'`src/synth/cst_ssml.c
 
-src/synth/libmimic_la-cst_synth.lo: src/synth/cst_synth.c
-@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_la_CFLAGS) $(CFLAGS) -MT src/synth/libmimic_la-cst_synth.lo -MD -MP -MF src/synth/$(DEPDIR)/libmimic_la-cst_synth.Tpo -c -o src/synth/libmimic_la-cst_synth.lo `test -f 'src/synth/cst_synth.c' || echo '$(srcdir)/'`src/synth/cst_synth.c
-@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) src/synth/$(DEPDIR)/libmimic_la-cst_synth.Tpo src/synth/$(DEPDIR)/libmimic_la-cst_synth.Plo
-@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='src/synth/cst_synth.c' object='src/synth/libmimic_la-cst_synth.lo' libtool=yes @AMDEPBACKSLASH@
+src/synth/libttsmimic_la-cst_synth.lo: src/synth/cst_synth.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_la_CFLAGS) $(CFLAGS) -MT src/synth/libttsmimic_la-cst_synth.lo -MD -MP -MF src/synth/$(DEPDIR)/libttsmimic_la-cst_synth.Tpo -c -o src/synth/libttsmimic_la-cst_synth.lo `test -f 'src/synth/cst_synth.c' || echo '$(srcdir)/'`src/synth/cst_synth.c
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) src/synth/$(DEPDIR)/libttsmimic_la-cst_synth.Tpo src/synth/$(DEPDIR)/libttsmimic_la-cst_synth.Plo
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='src/synth/cst_synth.c' object='src/synth/libttsmimic_la-cst_synth.lo' libtool=yes @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_la_CFLAGS) $(CFLAGS) -c -o src/synth/libmimic_la-cst_synth.lo `test -f 'src/synth/cst_synth.c' || echo '$(srcdir)/'`src/synth/cst_synth.c
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_la_CFLAGS) $(CFLAGS) -c -o src/synth/libttsmimic_la-cst_synth.lo `test -f 'src/synth/cst_synth.c' || echo '$(srcdir)/'`src/synth/cst_synth.c
 
-src/synth/libmimic_la-cst_utt_utils.lo: src/synth/cst_utt_utils.c
-@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_la_CFLAGS) $(CFLAGS) -MT src/synth/libmimic_la-cst_utt_utils.lo -MD -MP -MF src/synth/$(DEPDIR)/libmimic_la-cst_utt_utils.Tpo -c -o src/synth/libmimic_la-cst_utt_utils.lo `test -f 'src/synth/cst_utt_utils.c' || echo '$(srcdir)/'`src/synth/cst_utt_utils.c
-@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) src/synth/$(DEPDIR)/libmimic_la-cst_utt_utils.Tpo src/synth/$(DEPDIR)/libmimic_la-cst_utt_utils.Plo
-@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='src/synth/cst_utt_utils.c' object='src/synth/libmimic_la-cst_utt_utils.lo' libtool=yes @AMDEPBACKSLASH@
+src/synth/libttsmimic_la-cst_utt_utils.lo: src/synth/cst_utt_utils.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_la_CFLAGS) $(CFLAGS) -MT src/synth/libttsmimic_la-cst_utt_utils.lo -MD -MP -MF src/synth/$(DEPDIR)/libttsmimic_la-cst_utt_utils.Tpo -c -o src/synth/libttsmimic_la-cst_utt_utils.lo `test -f 'src/synth/cst_utt_utils.c' || echo '$(srcdir)/'`src/synth/cst_utt_utils.c
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) src/synth/$(DEPDIR)/libttsmimic_la-cst_utt_utils.Tpo src/synth/$(DEPDIR)/libttsmimic_la-cst_utt_utils.Plo
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='src/synth/cst_utt_utils.c' object='src/synth/libttsmimic_la-cst_utt_utils.lo' libtool=yes @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_la_CFLAGS) $(CFLAGS) -c -o src/synth/libmimic_la-cst_utt_utils.lo `test -f 'src/synth/cst_utt_utils.c' || echo '$(srcdir)/'`src/synth/cst_utt_utils.c
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_la_CFLAGS) $(CFLAGS) -c -o src/synth/libttsmimic_la-cst_utt_utils.lo `test -f 'src/synth/cst_utt_utils.c' || echo '$(srcdir)/'`src/synth/cst_utt_utils.c
 
-src/synth/libmimic_la-cst_voice.lo: src/synth/cst_voice.c
-@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_la_CFLAGS) $(CFLAGS) -MT src/synth/libmimic_la-cst_voice.lo -MD -MP -MF src/synth/$(DEPDIR)/libmimic_la-cst_voice.Tpo -c -o src/synth/libmimic_la-cst_voice.lo `test -f 'src/synth/cst_voice.c' || echo '$(srcdir)/'`src/synth/cst_voice.c
-@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) src/synth/$(DEPDIR)/libmimic_la-cst_voice.Tpo src/synth/$(DEPDIR)/libmimic_la-cst_voice.Plo
-@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='src/synth/cst_voice.c' object='src/synth/libmimic_la-cst_voice.lo' libtool=yes @AMDEPBACKSLASH@
+src/synth/libttsmimic_la-cst_voice.lo: src/synth/cst_voice.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_la_CFLAGS) $(CFLAGS) -MT src/synth/libttsmimic_la-cst_voice.lo -MD -MP -MF src/synth/$(DEPDIR)/libttsmimic_la-cst_voice.Tpo -c -o src/synth/libttsmimic_la-cst_voice.lo `test -f 'src/synth/cst_voice.c' || echo '$(srcdir)/'`src/synth/cst_voice.c
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) src/synth/$(DEPDIR)/libttsmimic_la-cst_voice.Tpo src/synth/$(DEPDIR)/libttsmimic_la-cst_voice.Plo
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='src/synth/cst_voice.c' object='src/synth/libttsmimic_la-cst_voice.lo' libtool=yes @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_la_CFLAGS) $(CFLAGS) -c -o src/synth/libmimic_la-cst_voice.lo `test -f 'src/synth/cst_voice.c' || echo '$(srcdir)/'`src/synth/cst_voice.c
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_la_CFLAGS) $(CFLAGS) -c -o src/synth/libttsmimic_la-cst_voice.lo `test -f 'src/synth/cst_voice.c' || echo '$(srcdir)/'`src/synth/cst_voice.c
 
-src/synth/libmimic_la-mimic.lo: src/synth/mimic.c
-@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_la_CFLAGS) $(CFLAGS) -MT src/synth/libmimic_la-mimic.lo -MD -MP -MF src/synth/$(DEPDIR)/libmimic_la-mimic.Tpo -c -o src/synth/libmimic_la-mimic.lo `test -f 'src/synth/mimic.c' || echo '$(srcdir)/'`src/synth/mimic.c
-@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) src/synth/$(DEPDIR)/libmimic_la-mimic.Tpo src/synth/$(DEPDIR)/libmimic_la-mimic.Plo
-@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='src/synth/mimic.c' object='src/synth/libmimic_la-mimic.lo' libtool=yes @AMDEPBACKSLASH@
+src/synth/libttsmimic_la-mimic.lo: src/synth/mimic.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_la_CFLAGS) $(CFLAGS) -MT src/synth/libttsmimic_la-mimic.lo -MD -MP -MF src/synth/$(DEPDIR)/libttsmimic_la-mimic.Tpo -c -o src/synth/libttsmimic_la-mimic.lo `test -f 'src/synth/mimic.c' || echo '$(srcdir)/'`src/synth/mimic.c
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) src/synth/$(DEPDIR)/libttsmimic_la-mimic.Tpo src/synth/$(DEPDIR)/libttsmimic_la-mimic.Plo
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='src/synth/mimic.c' object='src/synth/libttsmimic_la-mimic.lo' libtool=yes @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_la_CFLAGS) $(CFLAGS) -c -o src/synth/libmimic_la-mimic.lo `test -f 'src/synth/mimic.c' || echo '$(srcdir)/'`src/synth/mimic.c
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_la_CFLAGS) $(CFLAGS) -c -o src/synth/libttsmimic_la-mimic.lo `test -f 'src/synth/mimic.c' || echo '$(srcdir)/'`src/synth/mimic.c
 
-src/utils/libmimic_la-cst_alloc.lo: src/utils/cst_alloc.c
-@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_la_CFLAGS) $(CFLAGS) -MT src/utils/libmimic_la-cst_alloc.lo -MD -MP -MF src/utils/$(DEPDIR)/libmimic_la-cst_alloc.Tpo -c -o src/utils/libmimic_la-cst_alloc.lo `test -f 'src/utils/cst_alloc.c' || echo '$(srcdir)/'`src/utils/cst_alloc.c
-@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) src/utils/$(DEPDIR)/libmimic_la-cst_alloc.Tpo src/utils/$(DEPDIR)/libmimic_la-cst_alloc.Plo
-@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='src/utils/cst_alloc.c' object='src/utils/libmimic_la-cst_alloc.lo' libtool=yes @AMDEPBACKSLASH@
+src/utils/libttsmimic_la-cst_alloc.lo: src/utils/cst_alloc.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_la_CFLAGS) $(CFLAGS) -MT src/utils/libttsmimic_la-cst_alloc.lo -MD -MP -MF src/utils/$(DEPDIR)/libttsmimic_la-cst_alloc.Tpo -c -o src/utils/libttsmimic_la-cst_alloc.lo `test -f 'src/utils/cst_alloc.c' || echo '$(srcdir)/'`src/utils/cst_alloc.c
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) src/utils/$(DEPDIR)/libttsmimic_la-cst_alloc.Tpo src/utils/$(DEPDIR)/libttsmimic_la-cst_alloc.Plo
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='src/utils/cst_alloc.c' object='src/utils/libttsmimic_la-cst_alloc.lo' libtool=yes @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_la_CFLAGS) $(CFLAGS) -c -o src/utils/libmimic_la-cst_alloc.lo `test -f 'src/utils/cst_alloc.c' || echo '$(srcdir)/'`src/utils/cst_alloc.c
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_la_CFLAGS) $(CFLAGS) -c -o src/utils/libttsmimic_la-cst_alloc.lo `test -f 'src/utils/cst_alloc.c' || echo '$(srcdir)/'`src/utils/cst_alloc.c
 
-src/utils/libmimic_la-cst_args.lo: src/utils/cst_args.c
-@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_la_CFLAGS) $(CFLAGS) -MT src/utils/libmimic_la-cst_args.lo -MD -MP -MF src/utils/$(DEPDIR)/libmimic_la-cst_args.Tpo -c -o src/utils/libmimic_la-cst_args.lo `test -f 'src/utils/cst_args.c' || echo '$(srcdir)/'`src/utils/cst_args.c
-@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) src/utils/$(DEPDIR)/libmimic_la-cst_args.Tpo src/utils/$(DEPDIR)/libmimic_la-cst_args.Plo
-@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='src/utils/cst_args.c' object='src/utils/libmimic_la-cst_args.lo' libtool=yes @AMDEPBACKSLASH@
+src/utils/libttsmimic_la-cst_args.lo: src/utils/cst_args.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_la_CFLAGS) $(CFLAGS) -MT src/utils/libttsmimic_la-cst_args.lo -MD -MP -MF src/utils/$(DEPDIR)/libttsmimic_la-cst_args.Tpo -c -o src/utils/libttsmimic_la-cst_args.lo `test -f 'src/utils/cst_args.c' || echo '$(srcdir)/'`src/utils/cst_args.c
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) src/utils/$(DEPDIR)/libttsmimic_la-cst_args.Tpo src/utils/$(DEPDIR)/libttsmimic_la-cst_args.Plo
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='src/utils/cst_args.c' object='src/utils/libttsmimic_la-cst_args.lo' libtool=yes @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_la_CFLAGS) $(CFLAGS) -c -o src/utils/libmimic_la-cst_args.lo `test -f 'src/utils/cst_args.c' || echo '$(srcdir)/'`src/utils/cst_args.c
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_la_CFLAGS) $(CFLAGS) -c -o src/utils/libttsmimic_la-cst_args.lo `test -f 'src/utils/cst_args.c' || echo '$(srcdir)/'`src/utils/cst_args.c
 
-src/utils/libmimic_la-cst_endian.lo: src/utils/cst_endian.c
-@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_la_CFLAGS) $(CFLAGS) -MT src/utils/libmimic_la-cst_endian.lo -MD -MP -MF src/utils/$(DEPDIR)/libmimic_la-cst_endian.Tpo -c -o src/utils/libmimic_la-cst_endian.lo `test -f 'src/utils/cst_endian.c' || echo '$(srcdir)/'`src/utils/cst_endian.c
-@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) src/utils/$(DEPDIR)/libmimic_la-cst_endian.Tpo src/utils/$(DEPDIR)/libmimic_la-cst_endian.Plo
-@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='src/utils/cst_endian.c' object='src/utils/libmimic_la-cst_endian.lo' libtool=yes @AMDEPBACKSLASH@
+src/utils/libttsmimic_la-cst_endian.lo: src/utils/cst_endian.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_la_CFLAGS) $(CFLAGS) -MT src/utils/libttsmimic_la-cst_endian.lo -MD -MP -MF src/utils/$(DEPDIR)/libttsmimic_la-cst_endian.Tpo -c -o src/utils/libttsmimic_la-cst_endian.lo `test -f 'src/utils/cst_endian.c' || echo '$(srcdir)/'`src/utils/cst_endian.c
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) src/utils/$(DEPDIR)/libttsmimic_la-cst_endian.Tpo src/utils/$(DEPDIR)/libttsmimic_la-cst_endian.Plo
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='src/utils/cst_endian.c' object='src/utils/libttsmimic_la-cst_endian.lo' libtool=yes @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_la_CFLAGS) $(CFLAGS) -c -o src/utils/libmimic_la-cst_endian.lo `test -f 'src/utils/cst_endian.c' || echo '$(srcdir)/'`src/utils/cst_endian.c
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_la_CFLAGS) $(CFLAGS) -c -o src/utils/libttsmimic_la-cst_endian.lo `test -f 'src/utils/cst_endian.c' || echo '$(srcdir)/'`src/utils/cst_endian.c
 
-src/utils/libmimic_la-cst_error.lo: src/utils/cst_error.c
-@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_la_CFLAGS) $(CFLAGS) -MT src/utils/libmimic_la-cst_error.lo -MD -MP -MF src/utils/$(DEPDIR)/libmimic_la-cst_error.Tpo -c -o src/utils/libmimic_la-cst_error.lo `test -f 'src/utils/cst_error.c' || echo '$(srcdir)/'`src/utils/cst_error.c
-@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) src/utils/$(DEPDIR)/libmimic_la-cst_error.Tpo src/utils/$(DEPDIR)/libmimic_la-cst_error.Plo
-@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='src/utils/cst_error.c' object='src/utils/libmimic_la-cst_error.lo' libtool=yes @AMDEPBACKSLASH@
+src/utils/libttsmimic_la-cst_error.lo: src/utils/cst_error.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_la_CFLAGS) $(CFLAGS) -MT src/utils/libttsmimic_la-cst_error.lo -MD -MP -MF src/utils/$(DEPDIR)/libttsmimic_la-cst_error.Tpo -c -o src/utils/libttsmimic_la-cst_error.lo `test -f 'src/utils/cst_error.c' || echo '$(srcdir)/'`src/utils/cst_error.c
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) src/utils/$(DEPDIR)/libttsmimic_la-cst_error.Tpo src/utils/$(DEPDIR)/libttsmimic_la-cst_error.Plo
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='src/utils/cst_error.c' object='src/utils/libttsmimic_la-cst_error.lo' libtool=yes @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_la_CFLAGS) $(CFLAGS) -c -o src/utils/libmimic_la-cst_error.lo `test -f 'src/utils/cst_error.c' || echo '$(srcdir)/'`src/utils/cst_error.c
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_la_CFLAGS) $(CFLAGS) -c -o src/utils/libttsmimic_la-cst_error.lo `test -f 'src/utils/cst_error.c' || echo '$(srcdir)/'`src/utils/cst_error.c
 
-src/utils/libmimic_la-cst_features.lo: src/utils/cst_features.c
-@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_la_CFLAGS) $(CFLAGS) -MT src/utils/libmimic_la-cst_features.lo -MD -MP -MF src/utils/$(DEPDIR)/libmimic_la-cst_features.Tpo -c -o src/utils/libmimic_la-cst_features.lo `test -f 'src/utils/cst_features.c' || echo '$(srcdir)/'`src/utils/cst_features.c
-@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) src/utils/$(DEPDIR)/libmimic_la-cst_features.Tpo src/utils/$(DEPDIR)/libmimic_la-cst_features.Plo
-@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='src/utils/cst_features.c' object='src/utils/libmimic_la-cst_features.lo' libtool=yes @AMDEPBACKSLASH@
+src/utils/libttsmimic_la-cst_features.lo: src/utils/cst_features.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_la_CFLAGS) $(CFLAGS) -MT src/utils/libttsmimic_la-cst_features.lo -MD -MP -MF src/utils/$(DEPDIR)/libttsmimic_la-cst_features.Tpo -c -o src/utils/libttsmimic_la-cst_features.lo `test -f 'src/utils/cst_features.c' || echo '$(srcdir)/'`src/utils/cst_features.c
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) src/utils/$(DEPDIR)/libttsmimic_la-cst_features.Tpo src/utils/$(DEPDIR)/libttsmimic_la-cst_features.Plo
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='src/utils/cst_features.c' object='src/utils/libttsmimic_la-cst_features.lo' libtool=yes @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_la_CFLAGS) $(CFLAGS) -c -o src/utils/libmimic_la-cst_features.lo `test -f 'src/utils/cst_features.c' || echo '$(srcdir)/'`src/utils/cst_features.c
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_la_CFLAGS) $(CFLAGS) -c -o src/utils/libttsmimic_la-cst_features.lo `test -f 'src/utils/cst_features.c' || echo '$(srcdir)/'`src/utils/cst_features.c
 
-src/utils/libmimic_la-cst_file_stdio.lo: src/utils/cst_file_stdio.c
-@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_la_CFLAGS) $(CFLAGS) -MT src/utils/libmimic_la-cst_file_stdio.lo -MD -MP -MF src/utils/$(DEPDIR)/libmimic_la-cst_file_stdio.Tpo -c -o src/utils/libmimic_la-cst_file_stdio.lo `test -f 'src/utils/cst_file_stdio.c' || echo '$(srcdir)/'`src/utils/cst_file_stdio.c
-@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) src/utils/$(DEPDIR)/libmimic_la-cst_file_stdio.Tpo src/utils/$(DEPDIR)/libmimic_la-cst_file_stdio.Plo
-@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='src/utils/cst_file_stdio.c' object='src/utils/libmimic_la-cst_file_stdio.lo' libtool=yes @AMDEPBACKSLASH@
+src/utils/libttsmimic_la-cst_file_stdio.lo: src/utils/cst_file_stdio.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_la_CFLAGS) $(CFLAGS) -MT src/utils/libttsmimic_la-cst_file_stdio.lo -MD -MP -MF src/utils/$(DEPDIR)/libttsmimic_la-cst_file_stdio.Tpo -c -o src/utils/libttsmimic_la-cst_file_stdio.lo `test -f 'src/utils/cst_file_stdio.c' || echo '$(srcdir)/'`src/utils/cst_file_stdio.c
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) src/utils/$(DEPDIR)/libttsmimic_la-cst_file_stdio.Tpo src/utils/$(DEPDIR)/libttsmimic_la-cst_file_stdio.Plo
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='src/utils/cst_file_stdio.c' object='src/utils/libttsmimic_la-cst_file_stdio.lo' libtool=yes @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_la_CFLAGS) $(CFLAGS) -c -o src/utils/libmimic_la-cst_file_stdio.lo `test -f 'src/utils/cst_file_stdio.c' || echo '$(srcdir)/'`src/utils/cst_file_stdio.c
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_la_CFLAGS) $(CFLAGS) -c -o src/utils/libttsmimic_la-cst_file_stdio.lo `test -f 'src/utils/cst_file_stdio.c' || echo '$(srcdir)/'`src/utils/cst_file_stdio.c
 
-src/utils/libmimic_la-cst_mmap_none.lo: src/utils/cst_mmap_none.c
-@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_la_CFLAGS) $(CFLAGS) -MT src/utils/libmimic_la-cst_mmap_none.lo -MD -MP -MF src/utils/$(DEPDIR)/libmimic_la-cst_mmap_none.Tpo -c -o src/utils/libmimic_la-cst_mmap_none.lo `test -f 'src/utils/cst_mmap_none.c' || echo '$(srcdir)/'`src/utils/cst_mmap_none.c
-@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) src/utils/$(DEPDIR)/libmimic_la-cst_mmap_none.Tpo src/utils/$(DEPDIR)/libmimic_la-cst_mmap_none.Plo
-@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='src/utils/cst_mmap_none.c' object='src/utils/libmimic_la-cst_mmap_none.lo' libtool=yes @AMDEPBACKSLASH@
+src/utils/libttsmimic_la-cst_mmap_none.lo: src/utils/cst_mmap_none.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_la_CFLAGS) $(CFLAGS) -MT src/utils/libttsmimic_la-cst_mmap_none.lo -MD -MP -MF src/utils/$(DEPDIR)/libttsmimic_la-cst_mmap_none.Tpo -c -o src/utils/libttsmimic_la-cst_mmap_none.lo `test -f 'src/utils/cst_mmap_none.c' || echo '$(srcdir)/'`src/utils/cst_mmap_none.c
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) src/utils/$(DEPDIR)/libttsmimic_la-cst_mmap_none.Tpo src/utils/$(DEPDIR)/libttsmimic_la-cst_mmap_none.Plo
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='src/utils/cst_mmap_none.c' object='src/utils/libttsmimic_la-cst_mmap_none.lo' libtool=yes @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_la_CFLAGS) $(CFLAGS) -c -o src/utils/libmimic_la-cst_mmap_none.lo `test -f 'src/utils/cst_mmap_none.c' || echo '$(srcdir)/'`src/utils/cst_mmap_none.c
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_la_CFLAGS) $(CFLAGS) -c -o src/utils/libttsmimic_la-cst_mmap_none.lo `test -f 'src/utils/cst_mmap_none.c' || echo '$(srcdir)/'`src/utils/cst_mmap_none.c
 
-src/utils/libmimic_la-cst_mmap_posix.lo: src/utils/cst_mmap_posix.c
-@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_la_CFLAGS) $(CFLAGS) -MT src/utils/libmimic_la-cst_mmap_posix.lo -MD -MP -MF src/utils/$(DEPDIR)/libmimic_la-cst_mmap_posix.Tpo -c -o src/utils/libmimic_la-cst_mmap_posix.lo `test -f 'src/utils/cst_mmap_posix.c' || echo '$(srcdir)/'`src/utils/cst_mmap_posix.c
-@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) src/utils/$(DEPDIR)/libmimic_la-cst_mmap_posix.Tpo src/utils/$(DEPDIR)/libmimic_la-cst_mmap_posix.Plo
-@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='src/utils/cst_mmap_posix.c' object='src/utils/libmimic_la-cst_mmap_posix.lo' libtool=yes @AMDEPBACKSLASH@
+src/utils/libttsmimic_la-cst_mmap_posix.lo: src/utils/cst_mmap_posix.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_la_CFLAGS) $(CFLAGS) -MT src/utils/libttsmimic_la-cst_mmap_posix.lo -MD -MP -MF src/utils/$(DEPDIR)/libttsmimic_la-cst_mmap_posix.Tpo -c -o src/utils/libttsmimic_la-cst_mmap_posix.lo `test -f 'src/utils/cst_mmap_posix.c' || echo '$(srcdir)/'`src/utils/cst_mmap_posix.c
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) src/utils/$(DEPDIR)/libttsmimic_la-cst_mmap_posix.Tpo src/utils/$(DEPDIR)/libttsmimic_la-cst_mmap_posix.Plo
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='src/utils/cst_mmap_posix.c' object='src/utils/libttsmimic_la-cst_mmap_posix.lo' libtool=yes @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_la_CFLAGS) $(CFLAGS) -c -o src/utils/libmimic_la-cst_mmap_posix.lo `test -f 'src/utils/cst_mmap_posix.c' || echo '$(srcdir)/'`src/utils/cst_mmap_posix.c
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_la_CFLAGS) $(CFLAGS) -c -o src/utils/libttsmimic_la-cst_mmap_posix.lo `test -f 'src/utils/cst_mmap_posix.c' || echo '$(srcdir)/'`src/utils/cst_mmap_posix.c
 
-src/utils/libmimic_la-cst_mmap_win32.lo: src/utils/cst_mmap_win32.c
-@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_la_CFLAGS) $(CFLAGS) -MT src/utils/libmimic_la-cst_mmap_win32.lo -MD -MP -MF src/utils/$(DEPDIR)/libmimic_la-cst_mmap_win32.Tpo -c -o src/utils/libmimic_la-cst_mmap_win32.lo `test -f 'src/utils/cst_mmap_win32.c' || echo '$(srcdir)/'`src/utils/cst_mmap_win32.c
-@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) src/utils/$(DEPDIR)/libmimic_la-cst_mmap_win32.Tpo src/utils/$(DEPDIR)/libmimic_la-cst_mmap_win32.Plo
-@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='src/utils/cst_mmap_win32.c' object='src/utils/libmimic_la-cst_mmap_win32.lo' libtool=yes @AMDEPBACKSLASH@
+src/utils/libttsmimic_la-cst_mmap_win32.lo: src/utils/cst_mmap_win32.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_la_CFLAGS) $(CFLAGS) -MT src/utils/libttsmimic_la-cst_mmap_win32.lo -MD -MP -MF src/utils/$(DEPDIR)/libttsmimic_la-cst_mmap_win32.Tpo -c -o src/utils/libttsmimic_la-cst_mmap_win32.lo `test -f 'src/utils/cst_mmap_win32.c' || echo '$(srcdir)/'`src/utils/cst_mmap_win32.c
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) src/utils/$(DEPDIR)/libttsmimic_la-cst_mmap_win32.Tpo src/utils/$(DEPDIR)/libttsmimic_la-cst_mmap_win32.Plo
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='src/utils/cst_mmap_win32.c' object='src/utils/libttsmimic_la-cst_mmap_win32.lo' libtool=yes @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_la_CFLAGS) $(CFLAGS) -c -o src/utils/libmimic_la-cst_mmap_win32.lo `test -f 'src/utils/cst_mmap_win32.c' || echo '$(srcdir)/'`src/utils/cst_mmap_win32.c
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_la_CFLAGS) $(CFLAGS) -c -o src/utils/libttsmimic_la-cst_mmap_win32.lo `test -f 'src/utils/cst_mmap_win32.c' || echo '$(srcdir)/'`src/utils/cst_mmap_win32.c
 
-src/utils/libmimic_la-cst_socket.lo: src/utils/cst_socket.c
-@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_la_CFLAGS) $(CFLAGS) -MT src/utils/libmimic_la-cst_socket.lo -MD -MP -MF src/utils/$(DEPDIR)/libmimic_la-cst_socket.Tpo -c -o src/utils/libmimic_la-cst_socket.lo `test -f 'src/utils/cst_socket.c' || echo '$(srcdir)/'`src/utils/cst_socket.c
-@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) src/utils/$(DEPDIR)/libmimic_la-cst_socket.Tpo src/utils/$(DEPDIR)/libmimic_la-cst_socket.Plo
-@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='src/utils/cst_socket.c' object='src/utils/libmimic_la-cst_socket.lo' libtool=yes @AMDEPBACKSLASH@
+src/utils/libttsmimic_la-cst_socket.lo: src/utils/cst_socket.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_la_CFLAGS) $(CFLAGS) -MT src/utils/libttsmimic_la-cst_socket.lo -MD -MP -MF src/utils/$(DEPDIR)/libttsmimic_la-cst_socket.Tpo -c -o src/utils/libttsmimic_la-cst_socket.lo `test -f 'src/utils/cst_socket.c' || echo '$(srcdir)/'`src/utils/cst_socket.c
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) src/utils/$(DEPDIR)/libttsmimic_la-cst_socket.Tpo src/utils/$(DEPDIR)/libttsmimic_la-cst_socket.Plo
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='src/utils/cst_socket.c' object='src/utils/libttsmimic_la-cst_socket.lo' libtool=yes @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_la_CFLAGS) $(CFLAGS) -c -o src/utils/libmimic_la-cst_socket.lo `test -f 'src/utils/cst_socket.c' || echo '$(srcdir)/'`src/utils/cst_socket.c
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_la_CFLAGS) $(CFLAGS) -c -o src/utils/libttsmimic_la-cst_socket.lo `test -f 'src/utils/cst_socket.c' || echo '$(srcdir)/'`src/utils/cst_socket.c
 
-src/utils/libmimic_la-cst_string.lo: src/utils/cst_string.c
-@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_la_CFLAGS) $(CFLAGS) -MT src/utils/libmimic_la-cst_string.lo -MD -MP -MF src/utils/$(DEPDIR)/libmimic_la-cst_string.Tpo -c -o src/utils/libmimic_la-cst_string.lo `test -f 'src/utils/cst_string.c' || echo '$(srcdir)/'`src/utils/cst_string.c
-@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) src/utils/$(DEPDIR)/libmimic_la-cst_string.Tpo src/utils/$(DEPDIR)/libmimic_la-cst_string.Plo
-@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='src/utils/cst_string.c' object='src/utils/libmimic_la-cst_string.lo' libtool=yes @AMDEPBACKSLASH@
+src/utils/libttsmimic_la-cst_string.lo: src/utils/cst_string.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_la_CFLAGS) $(CFLAGS) -MT src/utils/libttsmimic_la-cst_string.lo -MD -MP -MF src/utils/$(DEPDIR)/libttsmimic_la-cst_string.Tpo -c -o src/utils/libttsmimic_la-cst_string.lo `test -f 'src/utils/cst_string.c' || echo '$(srcdir)/'`src/utils/cst_string.c
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) src/utils/$(DEPDIR)/libttsmimic_la-cst_string.Tpo src/utils/$(DEPDIR)/libttsmimic_la-cst_string.Plo
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='src/utils/cst_string.c' object='src/utils/libttsmimic_la-cst_string.lo' libtool=yes @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_la_CFLAGS) $(CFLAGS) -c -o src/utils/libmimic_la-cst_string.lo `test -f 'src/utils/cst_string.c' || echo '$(srcdir)/'`src/utils/cst_string.c
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_la_CFLAGS) $(CFLAGS) -c -o src/utils/libttsmimic_la-cst_string.lo `test -f 'src/utils/cst_string.c' || echo '$(srcdir)/'`src/utils/cst_string.c
 
-src/utils/libmimic_la-cst_tokenstream.lo: src/utils/cst_tokenstream.c
-@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_la_CFLAGS) $(CFLAGS) -MT src/utils/libmimic_la-cst_tokenstream.lo -MD -MP -MF src/utils/$(DEPDIR)/libmimic_la-cst_tokenstream.Tpo -c -o src/utils/libmimic_la-cst_tokenstream.lo `test -f 'src/utils/cst_tokenstream.c' || echo '$(srcdir)/'`src/utils/cst_tokenstream.c
-@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) src/utils/$(DEPDIR)/libmimic_la-cst_tokenstream.Tpo src/utils/$(DEPDIR)/libmimic_la-cst_tokenstream.Plo
-@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='src/utils/cst_tokenstream.c' object='src/utils/libmimic_la-cst_tokenstream.lo' libtool=yes @AMDEPBACKSLASH@
+src/utils/libttsmimic_la-cst_tokenstream.lo: src/utils/cst_tokenstream.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_la_CFLAGS) $(CFLAGS) -MT src/utils/libttsmimic_la-cst_tokenstream.lo -MD -MP -MF src/utils/$(DEPDIR)/libttsmimic_la-cst_tokenstream.Tpo -c -o src/utils/libttsmimic_la-cst_tokenstream.lo `test -f 'src/utils/cst_tokenstream.c' || echo '$(srcdir)/'`src/utils/cst_tokenstream.c
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) src/utils/$(DEPDIR)/libttsmimic_la-cst_tokenstream.Tpo src/utils/$(DEPDIR)/libttsmimic_la-cst_tokenstream.Plo
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='src/utils/cst_tokenstream.c' object='src/utils/libttsmimic_la-cst_tokenstream.lo' libtool=yes @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_la_CFLAGS) $(CFLAGS) -c -o src/utils/libmimic_la-cst_tokenstream.lo `test -f 'src/utils/cst_tokenstream.c' || echo '$(srcdir)/'`src/utils/cst_tokenstream.c
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_la_CFLAGS) $(CFLAGS) -c -o src/utils/libttsmimic_la-cst_tokenstream.lo `test -f 'src/utils/cst_tokenstream.c' || echo '$(srcdir)/'`src/utils/cst_tokenstream.c
 
-src/utils/libmimic_la-cst_url.lo: src/utils/cst_url.c
-@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_la_CFLAGS) $(CFLAGS) -MT src/utils/libmimic_la-cst_url.lo -MD -MP -MF src/utils/$(DEPDIR)/libmimic_la-cst_url.Tpo -c -o src/utils/libmimic_la-cst_url.lo `test -f 'src/utils/cst_url.c' || echo '$(srcdir)/'`src/utils/cst_url.c
-@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) src/utils/$(DEPDIR)/libmimic_la-cst_url.Tpo src/utils/$(DEPDIR)/libmimic_la-cst_url.Plo
-@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='src/utils/cst_url.c' object='src/utils/libmimic_la-cst_url.lo' libtool=yes @AMDEPBACKSLASH@
+src/utils/libttsmimic_la-cst_url.lo: src/utils/cst_url.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_la_CFLAGS) $(CFLAGS) -MT src/utils/libttsmimic_la-cst_url.lo -MD -MP -MF src/utils/$(DEPDIR)/libttsmimic_la-cst_url.Tpo -c -o src/utils/libttsmimic_la-cst_url.lo `test -f 'src/utils/cst_url.c' || echo '$(srcdir)/'`src/utils/cst_url.c
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) src/utils/$(DEPDIR)/libttsmimic_la-cst_url.Tpo src/utils/$(DEPDIR)/libttsmimic_la-cst_url.Plo
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='src/utils/cst_url.c' object='src/utils/libttsmimic_la-cst_url.lo' libtool=yes @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_la_CFLAGS) $(CFLAGS) -c -o src/utils/libmimic_la-cst_url.lo `test -f 'src/utils/cst_url.c' || echo '$(srcdir)/'`src/utils/cst_url.c
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_la_CFLAGS) $(CFLAGS) -c -o src/utils/libttsmimic_la-cst_url.lo `test -f 'src/utils/cst_url.c' || echo '$(srcdir)/'`src/utils/cst_url.c
 
-src/utils/libmimic_la-cst_val.lo: src/utils/cst_val.c
-@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_la_CFLAGS) $(CFLAGS) -MT src/utils/libmimic_la-cst_val.lo -MD -MP -MF src/utils/$(DEPDIR)/libmimic_la-cst_val.Tpo -c -o src/utils/libmimic_la-cst_val.lo `test -f 'src/utils/cst_val.c' || echo '$(srcdir)/'`src/utils/cst_val.c
-@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) src/utils/$(DEPDIR)/libmimic_la-cst_val.Tpo src/utils/$(DEPDIR)/libmimic_la-cst_val.Plo
-@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='src/utils/cst_val.c' object='src/utils/libmimic_la-cst_val.lo' libtool=yes @AMDEPBACKSLASH@
+src/utils/libttsmimic_la-cst_val.lo: src/utils/cst_val.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_la_CFLAGS) $(CFLAGS) -MT src/utils/libttsmimic_la-cst_val.lo -MD -MP -MF src/utils/$(DEPDIR)/libttsmimic_la-cst_val.Tpo -c -o src/utils/libttsmimic_la-cst_val.lo `test -f 'src/utils/cst_val.c' || echo '$(srcdir)/'`src/utils/cst_val.c
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) src/utils/$(DEPDIR)/libttsmimic_la-cst_val.Tpo src/utils/$(DEPDIR)/libttsmimic_la-cst_val.Plo
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='src/utils/cst_val.c' object='src/utils/libttsmimic_la-cst_val.lo' libtool=yes @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_la_CFLAGS) $(CFLAGS) -c -o src/utils/libmimic_la-cst_val.lo `test -f 'src/utils/cst_val.c' || echo '$(srcdir)/'`src/utils/cst_val.c
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_la_CFLAGS) $(CFLAGS) -c -o src/utils/libttsmimic_la-cst_val.lo `test -f 'src/utils/cst_val.c' || echo '$(srcdir)/'`src/utils/cst_val.c
 
-src/utils/libmimic_la-cst_val_const.lo: src/utils/cst_val_const.c
-@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_la_CFLAGS) $(CFLAGS) -MT src/utils/libmimic_la-cst_val_const.lo -MD -MP -MF src/utils/$(DEPDIR)/libmimic_la-cst_val_const.Tpo -c -o src/utils/libmimic_la-cst_val_const.lo `test -f 'src/utils/cst_val_const.c' || echo '$(srcdir)/'`src/utils/cst_val_const.c
-@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) src/utils/$(DEPDIR)/libmimic_la-cst_val_const.Tpo src/utils/$(DEPDIR)/libmimic_la-cst_val_const.Plo
-@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='src/utils/cst_val_const.c' object='src/utils/libmimic_la-cst_val_const.lo' libtool=yes @AMDEPBACKSLASH@
+src/utils/libttsmimic_la-cst_val_const.lo: src/utils/cst_val_const.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_la_CFLAGS) $(CFLAGS) -MT src/utils/libttsmimic_la-cst_val_const.lo -MD -MP -MF src/utils/$(DEPDIR)/libttsmimic_la-cst_val_const.Tpo -c -o src/utils/libttsmimic_la-cst_val_const.lo `test -f 'src/utils/cst_val_const.c' || echo '$(srcdir)/'`src/utils/cst_val_const.c
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) src/utils/$(DEPDIR)/libttsmimic_la-cst_val_const.Tpo src/utils/$(DEPDIR)/libttsmimic_la-cst_val_const.Plo
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='src/utils/cst_val_const.c' object='src/utils/libttsmimic_la-cst_val_const.lo' libtool=yes @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_la_CFLAGS) $(CFLAGS) -c -o src/utils/libmimic_la-cst_val_const.lo `test -f 'src/utils/cst_val_const.c' || echo '$(srcdir)/'`src/utils/cst_val_const.c
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_la_CFLAGS) $(CFLAGS) -c -o src/utils/libttsmimic_la-cst_val_const.lo `test -f 'src/utils/cst_val_const.c' || echo '$(srcdir)/'`src/utils/cst_val_const.c
 
-src/utils/libmimic_la-cst_val_user.lo: src/utils/cst_val_user.c
-@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_la_CFLAGS) $(CFLAGS) -MT src/utils/libmimic_la-cst_val_user.lo -MD -MP -MF src/utils/$(DEPDIR)/libmimic_la-cst_val_user.Tpo -c -o src/utils/libmimic_la-cst_val_user.lo `test -f 'src/utils/cst_val_user.c' || echo '$(srcdir)/'`src/utils/cst_val_user.c
-@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) src/utils/$(DEPDIR)/libmimic_la-cst_val_user.Tpo src/utils/$(DEPDIR)/libmimic_la-cst_val_user.Plo
-@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='src/utils/cst_val_user.c' object='src/utils/libmimic_la-cst_val_user.lo' libtool=yes @AMDEPBACKSLASH@
+src/utils/libttsmimic_la-cst_val_user.lo: src/utils/cst_val_user.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_la_CFLAGS) $(CFLAGS) -MT src/utils/libttsmimic_la-cst_val_user.lo -MD -MP -MF src/utils/$(DEPDIR)/libttsmimic_la-cst_val_user.Tpo -c -o src/utils/libttsmimic_la-cst_val_user.lo `test -f 'src/utils/cst_val_user.c' || echo '$(srcdir)/'`src/utils/cst_val_user.c
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) src/utils/$(DEPDIR)/libttsmimic_la-cst_val_user.Tpo src/utils/$(DEPDIR)/libttsmimic_la-cst_val_user.Plo
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='src/utils/cst_val_user.c' object='src/utils/libttsmimic_la-cst_val_user.lo' libtool=yes @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_la_CFLAGS) $(CFLAGS) -c -o src/utils/libmimic_la-cst_val_user.lo `test -f 'src/utils/cst_val_user.c' || echo '$(srcdir)/'`src/utils/cst_val_user.c
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_la_CFLAGS) $(CFLAGS) -c -o src/utils/libttsmimic_la-cst_val_user.lo `test -f 'src/utils/cst_val_user.c' || echo '$(srcdir)/'`src/utils/cst_val_user.c
 
-src/utils/libmimic_la-cst_wchar.lo: src/utils/cst_wchar.c
-@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_la_CFLAGS) $(CFLAGS) -MT src/utils/libmimic_la-cst_wchar.lo -MD -MP -MF src/utils/$(DEPDIR)/libmimic_la-cst_wchar.Tpo -c -o src/utils/libmimic_la-cst_wchar.lo `test -f 'src/utils/cst_wchar.c' || echo '$(srcdir)/'`src/utils/cst_wchar.c
-@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) src/utils/$(DEPDIR)/libmimic_la-cst_wchar.Tpo src/utils/$(DEPDIR)/libmimic_la-cst_wchar.Plo
-@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='src/utils/cst_wchar.c' object='src/utils/libmimic_la-cst_wchar.lo' libtool=yes @AMDEPBACKSLASH@
+src/utils/libttsmimic_la-cst_wchar.lo: src/utils/cst_wchar.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_la_CFLAGS) $(CFLAGS) -MT src/utils/libttsmimic_la-cst_wchar.lo -MD -MP -MF src/utils/$(DEPDIR)/libttsmimic_la-cst_wchar.Tpo -c -o src/utils/libttsmimic_la-cst_wchar.lo `test -f 'src/utils/cst_wchar.c' || echo '$(srcdir)/'`src/utils/cst_wchar.c
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) src/utils/$(DEPDIR)/libttsmimic_la-cst_wchar.Tpo src/utils/$(DEPDIR)/libttsmimic_la-cst_wchar.Plo
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='src/utils/cst_wchar.c' object='src/utils/libttsmimic_la-cst_wchar.lo' libtool=yes @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_la_CFLAGS) $(CFLAGS) -c -o src/utils/libmimic_la-cst_wchar.lo `test -f 'src/utils/cst_wchar.c' || echo '$(srcdir)/'`src/utils/cst_wchar.c
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_la_CFLAGS) $(CFLAGS) -c -o src/utils/libttsmimic_la-cst_wchar.lo `test -f 'src/utils/cst_wchar.c' || echo '$(srcdir)/'`src/utils/cst_wchar.c
 
-src/wavesynth/libmimic_la-cst_clunits.lo: src/wavesynth/cst_clunits.c
-@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_la_CFLAGS) $(CFLAGS) -MT src/wavesynth/libmimic_la-cst_clunits.lo -MD -MP -MF src/wavesynth/$(DEPDIR)/libmimic_la-cst_clunits.Tpo -c -o src/wavesynth/libmimic_la-cst_clunits.lo `test -f 'src/wavesynth/cst_clunits.c' || echo '$(srcdir)/'`src/wavesynth/cst_clunits.c
-@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) src/wavesynth/$(DEPDIR)/libmimic_la-cst_clunits.Tpo src/wavesynth/$(DEPDIR)/libmimic_la-cst_clunits.Plo
-@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='src/wavesynth/cst_clunits.c' object='src/wavesynth/libmimic_la-cst_clunits.lo' libtool=yes @AMDEPBACKSLASH@
+src/wavesynth/libttsmimic_la-cst_clunits.lo: src/wavesynth/cst_clunits.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_la_CFLAGS) $(CFLAGS) -MT src/wavesynth/libttsmimic_la-cst_clunits.lo -MD -MP -MF src/wavesynth/$(DEPDIR)/libttsmimic_la-cst_clunits.Tpo -c -o src/wavesynth/libttsmimic_la-cst_clunits.lo `test -f 'src/wavesynth/cst_clunits.c' || echo '$(srcdir)/'`src/wavesynth/cst_clunits.c
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) src/wavesynth/$(DEPDIR)/libttsmimic_la-cst_clunits.Tpo src/wavesynth/$(DEPDIR)/libttsmimic_la-cst_clunits.Plo
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='src/wavesynth/cst_clunits.c' object='src/wavesynth/libttsmimic_la-cst_clunits.lo' libtool=yes @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_la_CFLAGS) $(CFLAGS) -c -o src/wavesynth/libmimic_la-cst_clunits.lo `test -f 'src/wavesynth/cst_clunits.c' || echo '$(srcdir)/'`src/wavesynth/cst_clunits.c
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_la_CFLAGS) $(CFLAGS) -c -o src/wavesynth/libttsmimic_la-cst_clunits.lo `test -f 'src/wavesynth/cst_clunits.c' || echo '$(srcdir)/'`src/wavesynth/cst_clunits.c
 
-src/wavesynth/libmimic_la-cst_diphone.lo: src/wavesynth/cst_diphone.c
-@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_la_CFLAGS) $(CFLAGS) -MT src/wavesynth/libmimic_la-cst_diphone.lo -MD -MP -MF src/wavesynth/$(DEPDIR)/libmimic_la-cst_diphone.Tpo -c -o src/wavesynth/libmimic_la-cst_diphone.lo `test -f 'src/wavesynth/cst_diphone.c' || echo '$(srcdir)/'`src/wavesynth/cst_diphone.c
-@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) src/wavesynth/$(DEPDIR)/libmimic_la-cst_diphone.Tpo src/wavesynth/$(DEPDIR)/libmimic_la-cst_diphone.Plo
-@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='src/wavesynth/cst_diphone.c' object='src/wavesynth/libmimic_la-cst_diphone.lo' libtool=yes @AMDEPBACKSLASH@
+src/wavesynth/libttsmimic_la-cst_diphone.lo: src/wavesynth/cst_diphone.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_la_CFLAGS) $(CFLAGS) -MT src/wavesynth/libttsmimic_la-cst_diphone.lo -MD -MP -MF src/wavesynth/$(DEPDIR)/libttsmimic_la-cst_diphone.Tpo -c -o src/wavesynth/libttsmimic_la-cst_diphone.lo `test -f 'src/wavesynth/cst_diphone.c' || echo '$(srcdir)/'`src/wavesynth/cst_diphone.c
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) src/wavesynth/$(DEPDIR)/libttsmimic_la-cst_diphone.Tpo src/wavesynth/$(DEPDIR)/libttsmimic_la-cst_diphone.Plo
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='src/wavesynth/cst_diphone.c' object='src/wavesynth/libttsmimic_la-cst_diphone.lo' libtool=yes @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_la_CFLAGS) $(CFLAGS) -c -o src/wavesynth/libmimic_la-cst_diphone.lo `test -f 'src/wavesynth/cst_diphone.c' || echo '$(srcdir)/'`src/wavesynth/cst_diphone.c
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_la_CFLAGS) $(CFLAGS) -c -o src/wavesynth/libttsmimic_la-cst_diphone.lo `test -f 'src/wavesynth/cst_diphone.c' || echo '$(srcdir)/'`src/wavesynth/cst_diphone.c
 
-src/wavesynth/libmimic_la-cst_reflpc.lo: src/wavesynth/cst_reflpc.c
-@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_la_CFLAGS) $(CFLAGS) -MT src/wavesynth/libmimic_la-cst_reflpc.lo -MD -MP -MF src/wavesynth/$(DEPDIR)/libmimic_la-cst_reflpc.Tpo -c -o src/wavesynth/libmimic_la-cst_reflpc.lo `test -f 'src/wavesynth/cst_reflpc.c' || echo '$(srcdir)/'`src/wavesynth/cst_reflpc.c
-@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) src/wavesynth/$(DEPDIR)/libmimic_la-cst_reflpc.Tpo src/wavesynth/$(DEPDIR)/libmimic_la-cst_reflpc.Plo
-@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='src/wavesynth/cst_reflpc.c' object='src/wavesynth/libmimic_la-cst_reflpc.lo' libtool=yes @AMDEPBACKSLASH@
+src/wavesynth/libttsmimic_la-cst_reflpc.lo: src/wavesynth/cst_reflpc.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_la_CFLAGS) $(CFLAGS) -MT src/wavesynth/libttsmimic_la-cst_reflpc.lo -MD -MP -MF src/wavesynth/$(DEPDIR)/libttsmimic_la-cst_reflpc.Tpo -c -o src/wavesynth/libttsmimic_la-cst_reflpc.lo `test -f 'src/wavesynth/cst_reflpc.c' || echo '$(srcdir)/'`src/wavesynth/cst_reflpc.c
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) src/wavesynth/$(DEPDIR)/libttsmimic_la-cst_reflpc.Tpo src/wavesynth/$(DEPDIR)/libttsmimic_la-cst_reflpc.Plo
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='src/wavesynth/cst_reflpc.c' object='src/wavesynth/libttsmimic_la-cst_reflpc.lo' libtool=yes @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_la_CFLAGS) $(CFLAGS) -c -o src/wavesynth/libmimic_la-cst_reflpc.lo `test -f 'src/wavesynth/cst_reflpc.c' || echo '$(srcdir)/'`src/wavesynth/cst_reflpc.c
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_la_CFLAGS) $(CFLAGS) -c -o src/wavesynth/libttsmimic_la-cst_reflpc.lo `test -f 'src/wavesynth/cst_reflpc.c' || echo '$(srcdir)/'`src/wavesynth/cst_reflpc.c
 
-src/wavesynth/libmimic_la-cst_sigpr.lo: src/wavesynth/cst_sigpr.c
-@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_la_CFLAGS) $(CFLAGS) -MT src/wavesynth/libmimic_la-cst_sigpr.lo -MD -MP -MF src/wavesynth/$(DEPDIR)/libmimic_la-cst_sigpr.Tpo -c -o src/wavesynth/libmimic_la-cst_sigpr.lo `test -f 'src/wavesynth/cst_sigpr.c' || echo '$(srcdir)/'`src/wavesynth/cst_sigpr.c
-@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) src/wavesynth/$(DEPDIR)/libmimic_la-cst_sigpr.Tpo src/wavesynth/$(DEPDIR)/libmimic_la-cst_sigpr.Plo
-@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='src/wavesynth/cst_sigpr.c' object='src/wavesynth/libmimic_la-cst_sigpr.lo' libtool=yes @AMDEPBACKSLASH@
+src/wavesynth/libttsmimic_la-cst_sigpr.lo: src/wavesynth/cst_sigpr.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_la_CFLAGS) $(CFLAGS) -MT src/wavesynth/libttsmimic_la-cst_sigpr.lo -MD -MP -MF src/wavesynth/$(DEPDIR)/libttsmimic_la-cst_sigpr.Tpo -c -o src/wavesynth/libttsmimic_la-cst_sigpr.lo `test -f 'src/wavesynth/cst_sigpr.c' || echo '$(srcdir)/'`src/wavesynth/cst_sigpr.c
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) src/wavesynth/$(DEPDIR)/libttsmimic_la-cst_sigpr.Tpo src/wavesynth/$(DEPDIR)/libttsmimic_la-cst_sigpr.Plo
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='src/wavesynth/cst_sigpr.c' object='src/wavesynth/libttsmimic_la-cst_sigpr.lo' libtool=yes @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_la_CFLAGS) $(CFLAGS) -c -o src/wavesynth/libmimic_la-cst_sigpr.lo `test -f 'src/wavesynth/cst_sigpr.c' || echo '$(srcdir)/'`src/wavesynth/cst_sigpr.c
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_la_CFLAGS) $(CFLAGS) -c -o src/wavesynth/libttsmimic_la-cst_sigpr.lo `test -f 'src/wavesynth/cst_sigpr.c' || echo '$(srcdir)/'`src/wavesynth/cst_sigpr.c
 
-src/wavesynth/libmimic_la-cst_sts.lo: src/wavesynth/cst_sts.c
-@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_la_CFLAGS) $(CFLAGS) -MT src/wavesynth/libmimic_la-cst_sts.lo -MD -MP -MF src/wavesynth/$(DEPDIR)/libmimic_la-cst_sts.Tpo -c -o src/wavesynth/libmimic_la-cst_sts.lo `test -f 'src/wavesynth/cst_sts.c' || echo '$(srcdir)/'`src/wavesynth/cst_sts.c
-@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) src/wavesynth/$(DEPDIR)/libmimic_la-cst_sts.Tpo src/wavesynth/$(DEPDIR)/libmimic_la-cst_sts.Plo
-@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='src/wavesynth/cst_sts.c' object='src/wavesynth/libmimic_la-cst_sts.lo' libtool=yes @AMDEPBACKSLASH@
+src/wavesynth/libttsmimic_la-cst_sts.lo: src/wavesynth/cst_sts.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_la_CFLAGS) $(CFLAGS) -MT src/wavesynth/libttsmimic_la-cst_sts.lo -MD -MP -MF src/wavesynth/$(DEPDIR)/libttsmimic_la-cst_sts.Tpo -c -o src/wavesynth/libttsmimic_la-cst_sts.lo `test -f 'src/wavesynth/cst_sts.c' || echo '$(srcdir)/'`src/wavesynth/cst_sts.c
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) src/wavesynth/$(DEPDIR)/libttsmimic_la-cst_sts.Tpo src/wavesynth/$(DEPDIR)/libttsmimic_la-cst_sts.Plo
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='src/wavesynth/cst_sts.c' object='src/wavesynth/libttsmimic_la-cst_sts.lo' libtool=yes @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_la_CFLAGS) $(CFLAGS) -c -o src/wavesynth/libmimic_la-cst_sts.lo `test -f 'src/wavesynth/cst_sts.c' || echo '$(srcdir)/'`src/wavesynth/cst_sts.c
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_la_CFLAGS) $(CFLAGS) -c -o src/wavesynth/libttsmimic_la-cst_sts.lo `test -f 'src/wavesynth/cst_sts.c' || echo '$(srcdir)/'`src/wavesynth/cst_sts.c
 
-src/wavesynth/libmimic_la-cst_units.lo: src/wavesynth/cst_units.c
-@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_la_CFLAGS) $(CFLAGS) -MT src/wavesynth/libmimic_la-cst_units.lo -MD -MP -MF src/wavesynth/$(DEPDIR)/libmimic_la-cst_units.Tpo -c -o src/wavesynth/libmimic_la-cst_units.lo `test -f 'src/wavesynth/cst_units.c' || echo '$(srcdir)/'`src/wavesynth/cst_units.c
-@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) src/wavesynth/$(DEPDIR)/libmimic_la-cst_units.Tpo src/wavesynth/$(DEPDIR)/libmimic_la-cst_units.Plo
-@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='src/wavesynth/cst_units.c' object='src/wavesynth/libmimic_la-cst_units.lo' libtool=yes @AMDEPBACKSLASH@
+src/wavesynth/libttsmimic_la-cst_units.lo: src/wavesynth/cst_units.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_la_CFLAGS) $(CFLAGS) -MT src/wavesynth/libttsmimic_la-cst_units.lo -MD -MP -MF src/wavesynth/$(DEPDIR)/libttsmimic_la-cst_units.Tpo -c -o src/wavesynth/libttsmimic_la-cst_units.lo `test -f 'src/wavesynth/cst_units.c' || echo '$(srcdir)/'`src/wavesynth/cst_units.c
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) src/wavesynth/$(DEPDIR)/libttsmimic_la-cst_units.Tpo src/wavesynth/$(DEPDIR)/libttsmimic_la-cst_units.Plo
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='src/wavesynth/cst_units.c' object='src/wavesynth/libttsmimic_la-cst_units.lo' libtool=yes @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_la_CFLAGS) $(CFLAGS) -c -o src/wavesynth/libmimic_la-cst_units.lo `test -f 'src/wavesynth/cst_units.c' || echo '$(srcdir)/'`src/wavesynth/cst_units.c
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_la_CFLAGS) $(CFLAGS) -c -o src/wavesynth/libttsmimic_la-cst_units.lo `test -f 'src/wavesynth/cst_units.c' || echo '$(srcdir)/'`src/wavesynth/cst_units.c
 
-lang/cmu_time_awb/libmimic_lang_cmu_time_awb_la-cmu_time_awb.lo: lang/cmu_time_awb/cmu_time_awb.c
-@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_lang_cmu_time_awb_la_CFLAGS) $(CFLAGS) -MT lang/cmu_time_awb/libmimic_lang_cmu_time_awb_la-cmu_time_awb.lo -MD -MP -MF lang/cmu_time_awb/$(DEPDIR)/libmimic_lang_cmu_time_awb_la-cmu_time_awb.Tpo -c -o lang/cmu_time_awb/libmimic_lang_cmu_time_awb_la-cmu_time_awb.lo `test -f 'lang/cmu_time_awb/cmu_time_awb.c' || echo '$(srcdir)/'`lang/cmu_time_awb/cmu_time_awb.c
-@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) lang/cmu_time_awb/$(DEPDIR)/libmimic_lang_cmu_time_awb_la-cmu_time_awb.Tpo lang/cmu_time_awb/$(DEPDIR)/libmimic_lang_cmu_time_awb_la-cmu_time_awb.Plo
-@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='lang/cmu_time_awb/cmu_time_awb.c' object='lang/cmu_time_awb/libmimic_lang_cmu_time_awb_la-cmu_time_awb.lo' libtool=yes @AMDEPBACKSLASH@
+lang/cmu_time_awb/libttsmimic_lang_cmu_time_awb_la-cmu_time_awb.lo: lang/cmu_time_awb/cmu_time_awb.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_lang_cmu_time_awb_la_CFLAGS) $(CFLAGS) -MT lang/cmu_time_awb/libttsmimic_lang_cmu_time_awb_la-cmu_time_awb.lo -MD -MP -MF lang/cmu_time_awb/$(DEPDIR)/libttsmimic_lang_cmu_time_awb_la-cmu_time_awb.Tpo -c -o lang/cmu_time_awb/libttsmimic_lang_cmu_time_awb_la-cmu_time_awb.lo `test -f 'lang/cmu_time_awb/cmu_time_awb.c' || echo '$(srcdir)/'`lang/cmu_time_awb/cmu_time_awb.c
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) lang/cmu_time_awb/$(DEPDIR)/libttsmimic_lang_cmu_time_awb_la-cmu_time_awb.Tpo lang/cmu_time_awb/$(DEPDIR)/libttsmimic_lang_cmu_time_awb_la-cmu_time_awb.Plo
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='lang/cmu_time_awb/cmu_time_awb.c' object='lang/cmu_time_awb/libttsmimic_lang_cmu_time_awb_la-cmu_time_awb.lo' libtool=yes @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_lang_cmu_time_awb_la_CFLAGS) $(CFLAGS) -c -o lang/cmu_time_awb/libmimic_lang_cmu_time_awb_la-cmu_time_awb.lo `test -f 'lang/cmu_time_awb/cmu_time_awb.c' || echo '$(srcdir)/'`lang/cmu_time_awb/cmu_time_awb.c
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_lang_cmu_time_awb_la_CFLAGS) $(CFLAGS) -c -o lang/cmu_time_awb/libttsmimic_lang_cmu_time_awb_la-cmu_time_awb.lo `test -f 'lang/cmu_time_awb/cmu_time_awb.c' || echo '$(srcdir)/'`lang/cmu_time_awb/cmu_time_awb.c
 
-lang/cmu_time_awb/libmimic_lang_cmu_time_awb_la-cmu_time_awb_cart.lo: lang/cmu_time_awb/cmu_time_awb_cart.c
-@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_lang_cmu_time_awb_la_CFLAGS) $(CFLAGS) -MT lang/cmu_time_awb/libmimic_lang_cmu_time_awb_la-cmu_time_awb_cart.lo -MD -MP -MF lang/cmu_time_awb/$(DEPDIR)/libmimic_lang_cmu_time_awb_la-cmu_time_awb_cart.Tpo -c -o lang/cmu_time_awb/libmimic_lang_cmu_time_awb_la-cmu_time_awb_cart.lo `test -f 'lang/cmu_time_awb/cmu_time_awb_cart.c' || echo '$(srcdir)/'`lang/cmu_time_awb/cmu_time_awb_cart.c
-@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) lang/cmu_time_awb/$(DEPDIR)/libmimic_lang_cmu_time_awb_la-cmu_time_awb_cart.Tpo lang/cmu_time_awb/$(DEPDIR)/libmimic_lang_cmu_time_awb_la-cmu_time_awb_cart.Plo
-@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='lang/cmu_time_awb/cmu_time_awb_cart.c' object='lang/cmu_time_awb/libmimic_lang_cmu_time_awb_la-cmu_time_awb_cart.lo' libtool=yes @AMDEPBACKSLASH@
+lang/cmu_time_awb/libttsmimic_lang_cmu_time_awb_la-cmu_time_awb_cart.lo: lang/cmu_time_awb/cmu_time_awb_cart.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_lang_cmu_time_awb_la_CFLAGS) $(CFLAGS) -MT lang/cmu_time_awb/libttsmimic_lang_cmu_time_awb_la-cmu_time_awb_cart.lo -MD -MP -MF lang/cmu_time_awb/$(DEPDIR)/libttsmimic_lang_cmu_time_awb_la-cmu_time_awb_cart.Tpo -c -o lang/cmu_time_awb/libttsmimic_lang_cmu_time_awb_la-cmu_time_awb_cart.lo `test -f 'lang/cmu_time_awb/cmu_time_awb_cart.c' || echo '$(srcdir)/'`lang/cmu_time_awb/cmu_time_awb_cart.c
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) lang/cmu_time_awb/$(DEPDIR)/libttsmimic_lang_cmu_time_awb_la-cmu_time_awb_cart.Tpo lang/cmu_time_awb/$(DEPDIR)/libttsmimic_lang_cmu_time_awb_la-cmu_time_awb_cart.Plo
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='lang/cmu_time_awb/cmu_time_awb_cart.c' object='lang/cmu_time_awb/libttsmimic_lang_cmu_time_awb_la-cmu_time_awb_cart.lo' libtool=yes @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_lang_cmu_time_awb_la_CFLAGS) $(CFLAGS) -c -o lang/cmu_time_awb/libmimic_lang_cmu_time_awb_la-cmu_time_awb_cart.lo `test -f 'lang/cmu_time_awb/cmu_time_awb_cart.c' || echo '$(srcdir)/'`lang/cmu_time_awb/cmu_time_awb_cart.c
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_lang_cmu_time_awb_la_CFLAGS) $(CFLAGS) -c -o lang/cmu_time_awb/libttsmimic_lang_cmu_time_awb_la-cmu_time_awb_cart.lo `test -f 'lang/cmu_time_awb/cmu_time_awb_cart.c' || echo '$(srcdir)/'`lang/cmu_time_awb/cmu_time_awb_cart.c
 
-lang/cmu_time_awb/libmimic_lang_cmu_time_awb_la-cmu_time_awb_clunits.lo: lang/cmu_time_awb/cmu_time_awb_clunits.c
-@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_lang_cmu_time_awb_la_CFLAGS) $(CFLAGS) -MT lang/cmu_time_awb/libmimic_lang_cmu_time_awb_la-cmu_time_awb_clunits.lo -MD -MP -MF lang/cmu_time_awb/$(DEPDIR)/libmimic_lang_cmu_time_awb_la-cmu_time_awb_clunits.Tpo -c -o lang/cmu_time_awb/libmimic_lang_cmu_time_awb_la-cmu_time_awb_clunits.lo `test -f 'lang/cmu_time_awb/cmu_time_awb_clunits.c' || echo '$(srcdir)/'`lang/cmu_time_awb/cmu_time_awb_clunits.c
-@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) lang/cmu_time_awb/$(DEPDIR)/libmimic_lang_cmu_time_awb_la-cmu_time_awb_clunits.Tpo lang/cmu_time_awb/$(DEPDIR)/libmimic_lang_cmu_time_awb_la-cmu_time_awb_clunits.Plo
-@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='lang/cmu_time_awb/cmu_time_awb_clunits.c' object='lang/cmu_time_awb/libmimic_lang_cmu_time_awb_la-cmu_time_awb_clunits.lo' libtool=yes @AMDEPBACKSLASH@
+lang/cmu_time_awb/libttsmimic_lang_cmu_time_awb_la-cmu_time_awb_clunits.lo: lang/cmu_time_awb/cmu_time_awb_clunits.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_lang_cmu_time_awb_la_CFLAGS) $(CFLAGS) -MT lang/cmu_time_awb/libttsmimic_lang_cmu_time_awb_la-cmu_time_awb_clunits.lo -MD -MP -MF lang/cmu_time_awb/$(DEPDIR)/libttsmimic_lang_cmu_time_awb_la-cmu_time_awb_clunits.Tpo -c -o lang/cmu_time_awb/libttsmimic_lang_cmu_time_awb_la-cmu_time_awb_clunits.lo `test -f 'lang/cmu_time_awb/cmu_time_awb_clunits.c' || echo '$(srcdir)/'`lang/cmu_time_awb/cmu_time_awb_clunits.c
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) lang/cmu_time_awb/$(DEPDIR)/libttsmimic_lang_cmu_time_awb_la-cmu_time_awb_clunits.Tpo lang/cmu_time_awb/$(DEPDIR)/libttsmimic_lang_cmu_time_awb_la-cmu_time_awb_clunits.Plo
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='lang/cmu_time_awb/cmu_time_awb_clunits.c' object='lang/cmu_time_awb/libttsmimic_lang_cmu_time_awb_la-cmu_time_awb_clunits.lo' libtool=yes @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_lang_cmu_time_awb_la_CFLAGS) $(CFLAGS) -c -o lang/cmu_time_awb/libmimic_lang_cmu_time_awb_la-cmu_time_awb_clunits.lo `test -f 'lang/cmu_time_awb/cmu_time_awb_clunits.c' || echo '$(srcdir)/'`lang/cmu_time_awb/cmu_time_awb_clunits.c
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_lang_cmu_time_awb_la_CFLAGS) $(CFLAGS) -c -o lang/cmu_time_awb/libttsmimic_lang_cmu_time_awb_la-cmu_time_awb_clunits.lo `test -f 'lang/cmu_time_awb/cmu_time_awb_clunits.c' || echo '$(srcdir)/'`lang/cmu_time_awb/cmu_time_awb_clunits.c
 
-lang/cmu_time_awb/libmimic_lang_cmu_time_awb_la-cmu_time_awb_lex_entry.lo: lang/cmu_time_awb/cmu_time_awb_lex_entry.c
-@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_lang_cmu_time_awb_la_CFLAGS) $(CFLAGS) -MT lang/cmu_time_awb/libmimic_lang_cmu_time_awb_la-cmu_time_awb_lex_entry.lo -MD -MP -MF lang/cmu_time_awb/$(DEPDIR)/libmimic_lang_cmu_time_awb_la-cmu_time_awb_lex_entry.Tpo -c -o lang/cmu_time_awb/libmimic_lang_cmu_time_awb_la-cmu_time_awb_lex_entry.lo `test -f 'lang/cmu_time_awb/cmu_time_awb_lex_entry.c' || echo '$(srcdir)/'`lang/cmu_time_awb/cmu_time_awb_lex_entry.c
-@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) lang/cmu_time_awb/$(DEPDIR)/libmimic_lang_cmu_time_awb_la-cmu_time_awb_lex_entry.Tpo lang/cmu_time_awb/$(DEPDIR)/libmimic_lang_cmu_time_awb_la-cmu_time_awb_lex_entry.Plo
-@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='lang/cmu_time_awb/cmu_time_awb_lex_entry.c' object='lang/cmu_time_awb/libmimic_lang_cmu_time_awb_la-cmu_time_awb_lex_entry.lo' libtool=yes @AMDEPBACKSLASH@
+lang/cmu_time_awb/libttsmimic_lang_cmu_time_awb_la-cmu_time_awb_lex_entry.lo: lang/cmu_time_awb/cmu_time_awb_lex_entry.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_lang_cmu_time_awb_la_CFLAGS) $(CFLAGS) -MT lang/cmu_time_awb/libttsmimic_lang_cmu_time_awb_la-cmu_time_awb_lex_entry.lo -MD -MP -MF lang/cmu_time_awb/$(DEPDIR)/libttsmimic_lang_cmu_time_awb_la-cmu_time_awb_lex_entry.Tpo -c -o lang/cmu_time_awb/libttsmimic_lang_cmu_time_awb_la-cmu_time_awb_lex_entry.lo `test -f 'lang/cmu_time_awb/cmu_time_awb_lex_entry.c' || echo '$(srcdir)/'`lang/cmu_time_awb/cmu_time_awb_lex_entry.c
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) lang/cmu_time_awb/$(DEPDIR)/libttsmimic_lang_cmu_time_awb_la-cmu_time_awb_lex_entry.Tpo lang/cmu_time_awb/$(DEPDIR)/libttsmimic_lang_cmu_time_awb_la-cmu_time_awb_lex_entry.Plo
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='lang/cmu_time_awb/cmu_time_awb_lex_entry.c' object='lang/cmu_time_awb/libttsmimic_lang_cmu_time_awb_la-cmu_time_awb_lex_entry.lo' libtool=yes @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_lang_cmu_time_awb_la_CFLAGS) $(CFLAGS) -c -o lang/cmu_time_awb/libmimic_lang_cmu_time_awb_la-cmu_time_awb_lex_entry.lo `test -f 'lang/cmu_time_awb/cmu_time_awb_lex_entry.c' || echo '$(srcdir)/'`lang/cmu_time_awb/cmu_time_awb_lex_entry.c
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_lang_cmu_time_awb_la_CFLAGS) $(CFLAGS) -c -o lang/cmu_time_awb/libttsmimic_lang_cmu_time_awb_la-cmu_time_awb_lex_entry.lo `test -f 'lang/cmu_time_awb/cmu_time_awb_lex_entry.c' || echo '$(srcdir)/'`lang/cmu_time_awb/cmu_time_awb_lex_entry.c
 
-lang/cmu_time_awb/libmimic_lang_cmu_time_awb_la-cmu_time_awb_lpc.lo: lang/cmu_time_awb/cmu_time_awb_lpc.c
-@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_lang_cmu_time_awb_la_CFLAGS) $(CFLAGS) -MT lang/cmu_time_awb/libmimic_lang_cmu_time_awb_la-cmu_time_awb_lpc.lo -MD -MP -MF lang/cmu_time_awb/$(DEPDIR)/libmimic_lang_cmu_time_awb_la-cmu_time_awb_lpc.Tpo -c -o lang/cmu_time_awb/libmimic_lang_cmu_time_awb_la-cmu_time_awb_lpc.lo `test -f 'lang/cmu_time_awb/cmu_time_awb_lpc.c' || echo '$(srcdir)/'`lang/cmu_time_awb/cmu_time_awb_lpc.c
-@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) lang/cmu_time_awb/$(DEPDIR)/libmimic_lang_cmu_time_awb_la-cmu_time_awb_lpc.Tpo lang/cmu_time_awb/$(DEPDIR)/libmimic_lang_cmu_time_awb_la-cmu_time_awb_lpc.Plo
-@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='lang/cmu_time_awb/cmu_time_awb_lpc.c' object='lang/cmu_time_awb/libmimic_lang_cmu_time_awb_la-cmu_time_awb_lpc.lo' libtool=yes @AMDEPBACKSLASH@
+lang/cmu_time_awb/libttsmimic_lang_cmu_time_awb_la-cmu_time_awb_lpc.lo: lang/cmu_time_awb/cmu_time_awb_lpc.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_lang_cmu_time_awb_la_CFLAGS) $(CFLAGS) -MT lang/cmu_time_awb/libttsmimic_lang_cmu_time_awb_la-cmu_time_awb_lpc.lo -MD -MP -MF lang/cmu_time_awb/$(DEPDIR)/libttsmimic_lang_cmu_time_awb_la-cmu_time_awb_lpc.Tpo -c -o lang/cmu_time_awb/libttsmimic_lang_cmu_time_awb_la-cmu_time_awb_lpc.lo `test -f 'lang/cmu_time_awb/cmu_time_awb_lpc.c' || echo '$(srcdir)/'`lang/cmu_time_awb/cmu_time_awb_lpc.c
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) lang/cmu_time_awb/$(DEPDIR)/libttsmimic_lang_cmu_time_awb_la-cmu_time_awb_lpc.Tpo lang/cmu_time_awb/$(DEPDIR)/libttsmimic_lang_cmu_time_awb_la-cmu_time_awb_lpc.Plo
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='lang/cmu_time_awb/cmu_time_awb_lpc.c' object='lang/cmu_time_awb/libttsmimic_lang_cmu_time_awb_la-cmu_time_awb_lpc.lo' libtool=yes @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_lang_cmu_time_awb_la_CFLAGS) $(CFLAGS) -c -o lang/cmu_time_awb/libmimic_lang_cmu_time_awb_la-cmu_time_awb_lpc.lo `test -f 'lang/cmu_time_awb/cmu_time_awb_lpc.c' || echo '$(srcdir)/'`lang/cmu_time_awb/cmu_time_awb_lpc.c
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_lang_cmu_time_awb_la_CFLAGS) $(CFLAGS) -c -o lang/cmu_time_awb/libttsmimic_lang_cmu_time_awb_la-cmu_time_awb_lpc.lo `test -f 'lang/cmu_time_awb/cmu_time_awb_lpc.c' || echo '$(srcdir)/'`lang/cmu_time_awb/cmu_time_awb_lpc.c
 
-lang/cmu_time_awb/libmimic_lang_cmu_time_awb_la-cmu_time_awb_mcep.lo: lang/cmu_time_awb/cmu_time_awb_mcep.c
-@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_lang_cmu_time_awb_la_CFLAGS) $(CFLAGS) -MT lang/cmu_time_awb/libmimic_lang_cmu_time_awb_la-cmu_time_awb_mcep.lo -MD -MP -MF lang/cmu_time_awb/$(DEPDIR)/libmimic_lang_cmu_time_awb_la-cmu_time_awb_mcep.Tpo -c -o lang/cmu_time_awb/libmimic_lang_cmu_time_awb_la-cmu_time_awb_mcep.lo `test -f 'lang/cmu_time_awb/cmu_time_awb_mcep.c' || echo '$(srcdir)/'`lang/cmu_time_awb/cmu_time_awb_mcep.c
-@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) lang/cmu_time_awb/$(DEPDIR)/libmimic_lang_cmu_time_awb_la-cmu_time_awb_mcep.Tpo lang/cmu_time_awb/$(DEPDIR)/libmimic_lang_cmu_time_awb_la-cmu_time_awb_mcep.Plo
-@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='lang/cmu_time_awb/cmu_time_awb_mcep.c' object='lang/cmu_time_awb/libmimic_lang_cmu_time_awb_la-cmu_time_awb_mcep.lo' libtool=yes @AMDEPBACKSLASH@
+lang/cmu_time_awb/libttsmimic_lang_cmu_time_awb_la-cmu_time_awb_mcep.lo: lang/cmu_time_awb/cmu_time_awb_mcep.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_lang_cmu_time_awb_la_CFLAGS) $(CFLAGS) -MT lang/cmu_time_awb/libttsmimic_lang_cmu_time_awb_la-cmu_time_awb_mcep.lo -MD -MP -MF lang/cmu_time_awb/$(DEPDIR)/libttsmimic_lang_cmu_time_awb_la-cmu_time_awb_mcep.Tpo -c -o lang/cmu_time_awb/libttsmimic_lang_cmu_time_awb_la-cmu_time_awb_mcep.lo `test -f 'lang/cmu_time_awb/cmu_time_awb_mcep.c' || echo '$(srcdir)/'`lang/cmu_time_awb/cmu_time_awb_mcep.c
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) lang/cmu_time_awb/$(DEPDIR)/libttsmimic_lang_cmu_time_awb_la-cmu_time_awb_mcep.Tpo lang/cmu_time_awb/$(DEPDIR)/libttsmimic_lang_cmu_time_awb_la-cmu_time_awb_mcep.Plo
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='lang/cmu_time_awb/cmu_time_awb_mcep.c' object='lang/cmu_time_awb/libttsmimic_lang_cmu_time_awb_la-cmu_time_awb_mcep.lo' libtool=yes @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_lang_cmu_time_awb_la_CFLAGS) $(CFLAGS) -c -o lang/cmu_time_awb/libmimic_lang_cmu_time_awb_la-cmu_time_awb_mcep.lo `test -f 'lang/cmu_time_awb/cmu_time_awb_mcep.c' || echo '$(srcdir)/'`lang/cmu_time_awb/cmu_time_awb_mcep.c
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_lang_cmu_time_awb_la_CFLAGS) $(CFLAGS) -c -o lang/cmu_time_awb/libttsmimic_lang_cmu_time_awb_la-cmu_time_awb_mcep.lo `test -f 'lang/cmu_time_awb/cmu_time_awb_mcep.c' || echo '$(srcdir)/'`lang/cmu_time_awb/cmu_time_awb_mcep.c
 
-lang/cmu_us_awb/libmimic_lang_cmu_us_awb_la-cmu_us_awb.lo: lang/cmu_us_awb/cmu_us_awb.c
-@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_lang_cmu_us_awb_la_CFLAGS) $(CFLAGS) -MT lang/cmu_us_awb/libmimic_lang_cmu_us_awb_la-cmu_us_awb.lo -MD -MP -MF lang/cmu_us_awb/$(DEPDIR)/libmimic_lang_cmu_us_awb_la-cmu_us_awb.Tpo -c -o lang/cmu_us_awb/libmimic_lang_cmu_us_awb_la-cmu_us_awb.lo `test -f 'lang/cmu_us_awb/cmu_us_awb.c' || echo '$(srcdir)/'`lang/cmu_us_awb/cmu_us_awb.c
-@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) lang/cmu_us_awb/$(DEPDIR)/libmimic_lang_cmu_us_awb_la-cmu_us_awb.Tpo lang/cmu_us_awb/$(DEPDIR)/libmimic_lang_cmu_us_awb_la-cmu_us_awb.Plo
-@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='lang/cmu_us_awb/cmu_us_awb.c' object='lang/cmu_us_awb/libmimic_lang_cmu_us_awb_la-cmu_us_awb.lo' libtool=yes @AMDEPBACKSLASH@
+lang/cmu_us_awb/libttsmimic_lang_cmu_us_awb_la-cmu_us_awb.lo: lang/cmu_us_awb/cmu_us_awb.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_lang_cmu_us_awb_la_CFLAGS) $(CFLAGS) -MT lang/cmu_us_awb/libttsmimic_lang_cmu_us_awb_la-cmu_us_awb.lo -MD -MP -MF lang/cmu_us_awb/$(DEPDIR)/libttsmimic_lang_cmu_us_awb_la-cmu_us_awb.Tpo -c -o lang/cmu_us_awb/libttsmimic_lang_cmu_us_awb_la-cmu_us_awb.lo `test -f 'lang/cmu_us_awb/cmu_us_awb.c' || echo '$(srcdir)/'`lang/cmu_us_awb/cmu_us_awb.c
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) lang/cmu_us_awb/$(DEPDIR)/libttsmimic_lang_cmu_us_awb_la-cmu_us_awb.Tpo lang/cmu_us_awb/$(DEPDIR)/libttsmimic_lang_cmu_us_awb_la-cmu_us_awb.Plo
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='lang/cmu_us_awb/cmu_us_awb.c' object='lang/cmu_us_awb/libttsmimic_lang_cmu_us_awb_la-cmu_us_awb.lo' libtool=yes @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_lang_cmu_us_awb_la_CFLAGS) $(CFLAGS) -c -o lang/cmu_us_awb/libmimic_lang_cmu_us_awb_la-cmu_us_awb.lo `test -f 'lang/cmu_us_awb/cmu_us_awb.c' || echo '$(srcdir)/'`lang/cmu_us_awb/cmu_us_awb.c
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_lang_cmu_us_awb_la_CFLAGS) $(CFLAGS) -c -o lang/cmu_us_awb/libttsmimic_lang_cmu_us_awb_la-cmu_us_awb.lo `test -f 'lang/cmu_us_awb/cmu_us_awb.c' || echo '$(srcdir)/'`lang/cmu_us_awb/cmu_us_awb.c
 
-lang/cmu_us_awb/libmimic_lang_cmu_us_awb_la-cmu_us_awb_cg.lo: lang/cmu_us_awb/cmu_us_awb_cg.c
-@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_lang_cmu_us_awb_la_CFLAGS) $(CFLAGS) -MT lang/cmu_us_awb/libmimic_lang_cmu_us_awb_la-cmu_us_awb_cg.lo -MD -MP -MF lang/cmu_us_awb/$(DEPDIR)/libmimic_lang_cmu_us_awb_la-cmu_us_awb_cg.Tpo -c -o lang/cmu_us_awb/libmimic_lang_cmu_us_awb_la-cmu_us_awb_cg.lo `test -f 'lang/cmu_us_awb/cmu_us_awb_cg.c' || echo '$(srcdir)/'`lang/cmu_us_awb/cmu_us_awb_cg.c
-@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) lang/cmu_us_awb/$(DEPDIR)/libmimic_lang_cmu_us_awb_la-cmu_us_awb_cg.Tpo lang/cmu_us_awb/$(DEPDIR)/libmimic_lang_cmu_us_awb_la-cmu_us_awb_cg.Plo
-@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='lang/cmu_us_awb/cmu_us_awb_cg.c' object='lang/cmu_us_awb/libmimic_lang_cmu_us_awb_la-cmu_us_awb_cg.lo' libtool=yes @AMDEPBACKSLASH@
+lang/cmu_us_awb/libttsmimic_lang_cmu_us_awb_la-cmu_us_awb_cg.lo: lang/cmu_us_awb/cmu_us_awb_cg.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_lang_cmu_us_awb_la_CFLAGS) $(CFLAGS) -MT lang/cmu_us_awb/libttsmimic_lang_cmu_us_awb_la-cmu_us_awb_cg.lo -MD -MP -MF lang/cmu_us_awb/$(DEPDIR)/libttsmimic_lang_cmu_us_awb_la-cmu_us_awb_cg.Tpo -c -o lang/cmu_us_awb/libttsmimic_lang_cmu_us_awb_la-cmu_us_awb_cg.lo `test -f 'lang/cmu_us_awb/cmu_us_awb_cg.c' || echo '$(srcdir)/'`lang/cmu_us_awb/cmu_us_awb_cg.c
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) lang/cmu_us_awb/$(DEPDIR)/libttsmimic_lang_cmu_us_awb_la-cmu_us_awb_cg.Tpo lang/cmu_us_awb/$(DEPDIR)/libttsmimic_lang_cmu_us_awb_la-cmu_us_awb_cg.Plo
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='lang/cmu_us_awb/cmu_us_awb_cg.c' object='lang/cmu_us_awb/libttsmimic_lang_cmu_us_awb_la-cmu_us_awb_cg.lo' libtool=yes @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_lang_cmu_us_awb_la_CFLAGS) $(CFLAGS) -c -o lang/cmu_us_awb/libmimic_lang_cmu_us_awb_la-cmu_us_awb_cg.lo `test -f 'lang/cmu_us_awb/cmu_us_awb_cg.c' || echo '$(srcdir)/'`lang/cmu_us_awb/cmu_us_awb_cg.c
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_lang_cmu_us_awb_la_CFLAGS) $(CFLAGS) -c -o lang/cmu_us_awb/libttsmimic_lang_cmu_us_awb_la-cmu_us_awb_cg.lo `test -f 'lang/cmu_us_awb/cmu_us_awb_cg.c' || echo '$(srcdir)/'`lang/cmu_us_awb/cmu_us_awb_cg.c
 
-lang/cmu_us_awb/libmimic_lang_cmu_us_awb_la-cmu_us_awb_cg_durmodel.lo: lang/cmu_us_awb/cmu_us_awb_cg_durmodel.c
-@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_lang_cmu_us_awb_la_CFLAGS) $(CFLAGS) -MT lang/cmu_us_awb/libmimic_lang_cmu_us_awb_la-cmu_us_awb_cg_durmodel.lo -MD -MP -MF lang/cmu_us_awb/$(DEPDIR)/libmimic_lang_cmu_us_awb_la-cmu_us_awb_cg_durmodel.Tpo -c -o lang/cmu_us_awb/libmimic_lang_cmu_us_awb_la-cmu_us_awb_cg_durmodel.lo `test -f 'lang/cmu_us_awb/cmu_us_awb_cg_durmodel.c' || echo '$(srcdir)/'`lang/cmu_us_awb/cmu_us_awb_cg_durmodel.c
-@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) lang/cmu_us_awb/$(DEPDIR)/libmimic_lang_cmu_us_awb_la-cmu_us_awb_cg_durmodel.Tpo lang/cmu_us_awb/$(DEPDIR)/libmimic_lang_cmu_us_awb_la-cmu_us_awb_cg_durmodel.Plo
-@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='lang/cmu_us_awb/cmu_us_awb_cg_durmodel.c' object='lang/cmu_us_awb/libmimic_lang_cmu_us_awb_la-cmu_us_awb_cg_durmodel.lo' libtool=yes @AMDEPBACKSLASH@
+lang/cmu_us_awb/libttsmimic_lang_cmu_us_awb_la-cmu_us_awb_cg_durmodel.lo: lang/cmu_us_awb/cmu_us_awb_cg_durmodel.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_lang_cmu_us_awb_la_CFLAGS) $(CFLAGS) -MT lang/cmu_us_awb/libttsmimic_lang_cmu_us_awb_la-cmu_us_awb_cg_durmodel.lo -MD -MP -MF lang/cmu_us_awb/$(DEPDIR)/libttsmimic_lang_cmu_us_awb_la-cmu_us_awb_cg_durmodel.Tpo -c -o lang/cmu_us_awb/libttsmimic_lang_cmu_us_awb_la-cmu_us_awb_cg_durmodel.lo `test -f 'lang/cmu_us_awb/cmu_us_awb_cg_durmodel.c' || echo '$(srcdir)/'`lang/cmu_us_awb/cmu_us_awb_cg_durmodel.c
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) lang/cmu_us_awb/$(DEPDIR)/libttsmimic_lang_cmu_us_awb_la-cmu_us_awb_cg_durmodel.Tpo lang/cmu_us_awb/$(DEPDIR)/libttsmimic_lang_cmu_us_awb_la-cmu_us_awb_cg_durmodel.Plo
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='lang/cmu_us_awb/cmu_us_awb_cg_durmodel.c' object='lang/cmu_us_awb/libttsmimic_lang_cmu_us_awb_la-cmu_us_awb_cg_durmodel.lo' libtool=yes @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_lang_cmu_us_awb_la_CFLAGS) $(CFLAGS) -c -o lang/cmu_us_awb/libmimic_lang_cmu_us_awb_la-cmu_us_awb_cg_durmodel.lo `test -f 'lang/cmu_us_awb/cmu_us_awb_cg_durmodel.c' || echo '$(srcdir)/'`lang/cmu_us_awb/cmu_us_awb_cg_durmodel.c
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_lang_cmu_us_awb_la_CFLAGS) $(CFLAGS) -c -o lang/cmu_us_awb/libttsmimic_lang_cmu_us_awb_la-cmu_us_awb_cg_durmodel.lo `test -f 'lang/cmu_us_awb/cmu_us_awb_cg_durmodel.c' || echo '$(srcdir)/'`lang/cmu_us_awb/cmu_us_awb_cg_durmodel.c
 
-lang/cmu_us_awb/libmimic_lang_cmu_us_awb_la-cmu_us_awb_cg_f0_trees.lo: lang/cmu_us_awb/cmu_us_awb_cg_f0_trees.c
-@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_lang_cmu_us_awb_la_CFLAGS) $(CFLAGS) -MT lang/cmu_us_awb/libmimic_lang_cmu_us_awb_la-cmu_us_awb_cg_f0_trees.lo -MD -MP -MF lang/cmu_us_awb/$(DEPDIR)/libmimic_lang_cmu_us_awb_la-cmu_us_awb_cg_f0_trees.Tpo -c -o lang/cmu_us_awb/libmimic_lang_cmu_us_awb_la-cmu_us_awb_cg_f0_trees.lo `test -f 'lang/cmu_us_awb/cmu_us_awb_cg_f0_trees.c' || echo '$(srcdir)/'`lang/cmu_us_awb/cmu_us_awb_cg_f0_trees.c
-@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) lang/cmu_us_awb/$(DEPDIR)/libmimic_lang_cmu_us_awb_la-cmu_us_awb_cg_f0_trees.Tpo lang/cmu_us_awb/$(DEPDIR)/libmimic_lang_cmu_us_awb_la-cmu_us_awb_cg_f0_trees.Plo
-@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='lang/cmu_us_awb/cmu_us_awb_cg_f0_trees.c' object='lang/cmu_us_awb/libmimic_lang_cmu_us_awb_la-cmu_us_awb_cg_f0_trees.lo' libtool=yes @AMDEPBACKSLASH@
+lang/cmu_us_awb/libttsmimic_lang_cmu_us_awb_la-cmu_us_awb_cg_f0_trees.lo: lang/cmu_us_awb/cmu_us_awb_cg_f0_trees.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_lang_cmu_us_awb_la_CFLAGS) $(CFLAGS) -MT lang/cmu_us_awb/libttsmimic_lang_cmu_us_awb_la-cmu_us_awb_cg_f0_trees.lo -MD -MP -MF lang/cmu_us_awb/$(DEPDIR)/libttsmimic_lang_cmu_us_awb_la-cmu_us_awb_cg_f0_trees.Tpo -c -o lang/cmu_us_awb/libttsmimic_lang_cmu_us_awb_la-cmu_us_awb_cg_f0_trees.lo `test -f 'lang/cmu_us_awb/cmu_us_awb_cg_f0_trees.c' || echo '$(srcdir)/'`lang/cmu_us_awb/cmu_us_awb_cg_f0_trees.c
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) lang/cmu_us_awb/$(DEPDIR)/libttsmimic_lang_cmu_us_awb_la-cmu_us_awb_cg_f0_trees.Tpo lang/cmu_us_awb/$(DEPDIR)/libttsmimic_lang_cmu_us_awb_la-cmu_us_awb_cg_f0_trees.Plo
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='lang/cmu_us_awb/cmu_us_awb_cg_f0_trees.c' object='lang/cmu_us_awb/libttsmimic_lang_cmu_us_awb_la-cmu_us_awb_cg_f0_trees.lo' libtool=yes @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_lang_cmu_us_awb_la_CFLAGS) $(CFLAGS) -c -o lang/cmu_us_awb/libmimic_lang_cmu_us_awb_la-cmu_us_awb_cg_f0_trees.lo `test -f 'lang/cmu_us_awb/cmu_us_awb_cg_f0_trees.c' || echo '$(srcdir)/'`lang/cmu_us_awb/cmu_us_awb_cg_f0_trees.c
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_lang_cmu_us_awb_la_CFLAGS) $(CFLAGS) -c -o lang/cmu_us_awb/libttsmimic_lang_cmu_us_awb_la-cmu_us_awb_cg_f0_trees.lo `test -f 'lang/cmu_us_awb/cmu_us_awb_cg_f0_trees.c' || echo '$(srcdir)/'`lang/cmu_us_awb/cmu_us_awb_cg_f0_trees.c
 
-lang/cmu_us_awb/libmimic_lang_cmu_us_awb_la-cmu_us_awb_cg_phonestate.lo: lang/cmu_us_awb/cmu_us_awb_cg_phonestate.c
-@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_lang_cmu_us_awb_la_CFLAGS) $(CFLAGS) -MT lang/cmu_us_awb/libmimic_lang_cmu_us_awb_la-cmu_us_awb_cg_phonestate.lo -MD -MP -MF lang/cmu_us_awb/$(DEPDIR)/libmimic_lang_cmu_us_awb_la-cmu_us_awb_cg_phonestate.Tpo -c -o lang/cmu_us_awb/libmimic_lang_cmu_us_awb_la-cmu_us_awb_cg_phonestate.lo `test -f 'lang/cmu_us_awb/cmu_us_awb_cg_phonestate.c' || echo '$(srcdir)/'`lang/cmu_us_awb/cmu_us_awb_cg_phonestate.c
-@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) lang/cmu_us_awb/$(DEPDIR)/libmimic_lang_cmu_us_awb_la-cmu_us_awb_cg_phonestate.Tpo lang/cmu_us_awb/$(DEPDIR)/libmimic_lang_cmu_us_awb_la-cmu_us_awb_cg_phonestate.Plo
-@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='lang/cmu_us_awb/cmu_us_awb_cg_phonestate.c' object='lang/cmu_us_awb/libmimic_lang_cmu_us_awb_la-cmu_us_awb_cg_phonestate.lo' libtool=yes @AMDEPBACKSLASH@
+lang/cmu_us_awb/libttsmimic_lang_cmu_us_awb_la-cmu_us_awb_cg_phonestate.lo: lang/cmu_us_awb/cmu_us_awb_cg_phonestate.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_lang_cmu_us_awb_la_CFLAGS) $(CFLAGS) -MT lang/cmu_us_awb/libttsmimic_lang_cmu_us_awb_la-cmu_us_awb_cg_phonestate.lo -MD -MP -MF lang/cmu_us_awb/$(DEPDIR)/libttsmimic_lang_cmu_us_awb_la-cmu_us_awb_cg_phonestate.Tpo -c -o lang/cmu_us_awb/libttsmimic_lang_cmu_us_awb_la-cmu_us_awb_cg_phonestate.lo `test -f 'lang/cmu_us_awb/cmu_us_awb_cg_phonestate.c' || echo '$(srcdir)/'`lang/cmu_us_awb/cmu_us_awb_cg_phonestate.c
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) lang/cmu_us_awb/$(DEPDIR)/libttsmimic_lang_cmu_us_awb_la-cmu_us_awb_cg_phonestate.Tpo lang/cmu_us_awb/$(DEPDIR)/libttsmimic_lang_cmu_us_awb_la-cmu_us_awb_cg_phonestate.Plo
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='lang/cmu_us_awb/cmu_us_awb_cg_phonestate.c' object='lang/cmu_us_awb/libttsmimic_lang_cmu_us_awb_la-cmu_us_awb_cg_phonestate.lo' libtool=yes @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_lang_cmu_us_awb_la_CFLAGS) $(CFLAGS) -c -o lang/cmu_us_awb/libmimic_lang_cmu_us_awb_la-cmu_us_awb_cg_phonestate.lo `test -f 'lang/cmu_us_awb/cmu_us_awb_cg_phonestate.c' || echo '$(srcdir)/'`lang/cmu_us_awb/cmu_us_awb_cg_phonestate.c
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_lang_cmu_us_awb_la_CFLAGS) $(CFLAGS) -c -o lang/cmu_us_awb/libttsmimic_lang_cmu_us_awb_la-cmu_us_awb_cg_phonestate.lo `test -f 'lang/cmu_us_awb/cmu_us_awb_cg_phonestate.c' || echo '$(srcdir)/'`lang/cmu_us_awb/cmu_us_awb_cg_phonestate.c
 
-lang/cmu_us_awb/libmimic_lang_cmu_us_awb_la-cmu_us_awb_cg_single_mcep_trees.lo: lang/cmu_us_awb/cmu_us_awb_cg_single_mcep_trees.c
-@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_lang_cmu_us_awb_la_CFLAGS) $(CFLAGS) -MT lang/cmu_us_awb/libmimic_lang_cmu_us_awb_la-cmu_us_awb_cg_single_mcep_trees.lo -MD -MP -MF lang/cmu_us_awb/$(DEPDIR)/libmimic_lang_cmu_us_awb_la-cmu_us_awb_cg_single_mcep_trees.Tpo -c -o lang/cmu_us_awb/libmimic_lang_cmu_us_awb_la-cmu_us_awb_cg_single_mcep_trees.lo `test -f 'lang/cmu_us_awb/cmu_us_awb_cg_single_mcep_trees.c' || echo '$(srcdir)/'`lang/cmu_us_awb/cmu_us_awb_cg_single_mcep_trees.c
-@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) lang/cmu_us_awb/$(DEPDIR)/libmimic_lang_cmu_us_awb_la-cmu_us_awb_cg_single_mcep_trees.Tpo lang/cmu_us_awb/$(DEPDIR)/libmimic_lang_cmu_us_awb_la-cmu_us_awb_cg_single_mcep_trees.Plo
-@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='lang/cmu_us_awb/cmu_us_awb_cg_single_mcep_trees.c' object='lang/cmu_us_awb/libmimic_lang_cmu_us_awb_la-cmu_us_awb_cg_single_mcep_trees.lo' libtool=yes @AMDEPBACKSLASH@
+lang/cmu_us_awb/libttsmimic_lang_cmu_us_awb_la-cmu_us_awb_cg_single_mcep_trees.lo: lang/cmu_us_awb/cmu_us_awb_cg_single_mcep_trees.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_lang_cmu_us_awb_la_CFLAGS) $(CFLAGS) -MT lang/cmu_us_awb/libttsmimic_lang_cmu_us_awb_la-cmu_us_awb_cg_single_mcep_trees.lo -MD -MP -MF lang/cmu_us_awb/$(DEPDIR)/libttsmimic_lang_cmu_us_awb_la-cmu_us_awb_cg_single_mcep_trees.Tpo -c -o lang/cmu_us_awb/libttsmimic_lang_cmu_us_awb_la-cmu_us_awb_cg_single_mcep_trees.lo `test -f 'lang/cmu_us_awb/cmu_us_awb_cg_single_mcep_trees.c' || echo '$(srcdir)/'`lang/cmu_us_awb/cmu_us_awb_cg_single_mcep_trees.c
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) lang/cmu_us_awb/$(DEPDIR)/libttsmimic_lang_cmu_us_awb_la-cmu_us_awb_cg_single_mcep_trees.Tpo lang/cmu_us_awb/$(DEPDIR)/libttsmimic_lang_cmu_us_awb_la-cmu_us_awb_cg_single_mcep_trees.Plo
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='lang/cmu_us_awb/cmu_us_awb_cg_single_mcep_trees.c' object='lang/cmu_us_awb/libttsmimic_lang_cmu_us_awb_la-cmu_us_awb_cg_single_mcep_trees.lo' libtool=yes @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_lang_cmu_us_awb_la_CFLAGS) $(CFLAGS) -c -o lang/cmu_us_awb/libmimic_lang_cmu_us_awb_la-cmu_us_awb_cg_single_mcep_trees.lo `test -f 'lang/cmu_us_awb/cmu_us_awb_cg_single_mcep_trees.c' || echo '$(srcdir)/'`lang/cmu_us_awb/cmu_us_awb_cg_single_mcep_trees.c
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_lang_cmu_us_awb_la_CFLAGS) $(CFLAGS) -c -o lang/cmu_us_awb/libttsmimic_lang_cmu_us_awb_la-cmu_us_awb_cg_single_mcep_trees.lo `test -f 'lang/cmu_us_awb/cmu_us_awb_cg_single_mcep_trees.c' || echo '$(srcdir)/'`lang/cmu_us_awb/cmu_us_awb_cg_single_mcep_trees.c
 
-lang/cmu_us_awb/libmimic_lang_cmu_us_awb_la-cmu_us_awb_cg_single_params.lo: lang/cmu_us_awb/cmu_us_awb_cg_single_params.c
-@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_lang_cmu_us_awb_la_CFLAGS) $(CFLAGS) -MT lang/cmu_us_awb/libmimic_lang_cmu_us_awb_la-cmu_us_awb_cg_single_params.lo -MD -MP -MF lang/cmu_us_awb/$(DEPDIR)/libmimic_lang_cmu_us_awb_la-cmu_us_awb_cg_single_params.Tpo -c -o lang/cmu_us_awb/libmimic_lang_cmu_us_awb_la-cmu_us_awb_cg_single_params.lo `test -f 'lang/cmu_us_awb/cmu_us_awb_cg_single_params.c' || echo '$(srcdir)/'`lang/cmu_us_awb/cmu_us_awb_cg_single_params.c
-@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) lang/cmu_us_awb/$(DEPDIR)/libmimic_lang_cmu_us_awb_la-cmu_us_awb_cg_single_params.Tpo lang/cmu_us_awb/$(DEPDIR)/libmimic_lang_cmu_us_awb_la-cmu_us_awb_cg_single_params.Plo
-@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='lang/cmu_us_awb/cmu_us_awb_cg_single_params.c' object='lang/cmu_us_awb/libmimic_lang_cmu_us_awb_la-cmu_us_awb_cg_single_params.lo' libtool=yes @AMDEPBACKSLASH@
+lang/cmu_us_awb/libttsmimic_lang_cmu_us_awb_la-cmu_us_awb_cg_single_params.lo: lang/cmu_us_awb/cmu_us_awb_cg_single_params.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_lang_cmu_us_awb_la_CFLAGS) $(CFLAGS) -MT lang/cmu_us_awb/libttsmimic_lang_cmu_us_awb_la-cmu_us_awb_cg_single_params.lo -MD -MP -MF lang/cmu_us_awb/$(DEPDIR)/libttsmimic_lang_cmu_us_awb_la-cmu_us_awb_cg_single_params.Tpo -c -o lang/cmu_us_awb/libttsmimic_lang_cmu_us_awb_la-cmu_us_awb_cg_single_params.lo `test -f 'lang/cmu_us_awb/cmu_us_awb_cg_single_params.c' || echo '$(srcdir)/'`lang/cmu_us_awb/cmu_us_awb_cg_single_params.c
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) lang/cmu_us_awb/$(DEPDIR)/libttsmimic_lang_cmu_us_awb_la-cmu_us_awb_cg_single_params.Tpo lang/cmu_us_awb/$(DEPDIR)/libttsmimic_lang_cmu_us_awb_la-cmu_us_awb_cg_single_params.Plo
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='lang/cmu_us_awb/cmu_us_awb_cg_single_params.c' object='lang/cmu_us_awb/libttsmimic_lang_cmu_us_awb_la-cmu_us_awb_cg_single_params.lo' libtool=yes @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_lang_cmu_us_awb_la_CFLAGS) $(CFLAGS) -c -o lang/cmu_us_awb/libmimic_lang_cmu_us_awb_la-cmu_us_awb_cg_single_params.lo `test -f 'lang/cmu_us_awb/cmu_us_awb_cg_single_params.c' || echo '$(srcdir)/'`lang/cmu_us_awb/cmu_us_awb_cg_single_params.c
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_lang_cmu_us_awb_la_CFLAGS) $(CFLAGS) -c -o lang/cmu_us_awb/libttsmimic_lang_cmu_us_awb_la-cmu_us_awb_cg_single_params.lo `test -f 'lang/cmu_us_awb/cmu_us_awb_cg_single_params.c' || echo '$(srcdir)/'`lang/cmu_us_awb/cmu_us_awb_cg_single_params.c
 
-lang/cmu_us_awb/libmimic_lang_cmu_us_awb_la-cmu_us_awb_spamf0_accent.lo: lang/cmu_us_awb/cmu_us_awb_spamf0_accent.c
-@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_lang_cmu_us_awb_la_CFLAGS) $(CFLAGS) -MT lang/cmu_us_awb/libmimic_lang_cmu_us_awb_la-cmu_us_awb_spamf0_accent.lo -MD -MP -MF lang/cmu_us_awb/$(DEPDIR)/libmimic_lang_cmu_us_awb_la-cmu_us_awb_spamf0_accent.Tpo -c -o lang/cmu_us_awb/libmimic_lang_cmu_us_awb_la-cmu_us_awb_spamf0_accent.lo `test -f 'lang/cmu_us_awb/cmu_us_awb_spamf0_accent.c' || echo '$(srcdir)/'`lang/cmu_us_awb/cmu_us_awb_spamf0_accent.c
-@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) lang/cmu_us_awb/$(DEPDIR)/libmimic_lang_cmu_us_awb_la-cmu_us_awb_spamf0_accent.Tpo lang/cmu_us_awb/$(DEPDIR)/libmimic_lang_cmu_us_awb_la-cmu_us_awb_spamf0_accent.Plo
-@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='lang/cmu_us_awb/cmu_us_awb_spamf0_accent.c' object='lang/cmu_us_awb/libmimic_lang_cmu_us_awb_la-cmu_us_awb_spamf0_accent.lo' libtool=yes @AMDEPBACKSLASH@
+lang/cmu_us_awb/libttsmimic_lang_cmu_us_awb_la-cmu_us_awb_spamf0_accent.lo: lang/cmu_us_awb/cmu_us_awb_spamf0_accent.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_lang_cmu_us_awb_la_CFLAGS) $(CFLAGS) -MT lang/cmu_us_awb/libttsmimic_lang_cmu_us_awb_la-cmu_us_awb_spamf0_accent.lo -MD -MP -MF lang/cmu_us_awb/$(DEPDIR)/libttsmimic_lang_cmu_us_awb_la-cmu_us_awb_spamf0_accent.Tpo -c -o lang/cmu_us_awb/libttsmimic_lang_cmu_us_awb_la-cmu_us_awb_spamf0_accent.lo `test -f 'lang/cmu_us_awb/cmu_us_awb_spamf0_accent.c' || echo '$(srcdir)/'`lang/cmu_us_awb/cmu_us_awb_spamf0_accent.c
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) lang/cmu_us_awb/$(DEPDIR)/libttsmimic_lang_cmu_us_awb_la-cmu_us_awb_spamf0_accent.Tpo lang/cmu_us_awb/$(DEPDIR)/libttsmimic_lang_cmu_us_awb_la-cmu_us_awb_spamf0_accent.Plo
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='lang/cmu_us_awb/cmu_us_awb_spamf0_accent.c' object='lang/cmu_us_awb/libttsmimic_lang_cmu_us_awb_la-cmu_us_awb_spamf0_accent.lo' libtool=yes @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_lang_cmu_us_awb_la_CFLAGS) $(CFLAGS) -c -o lang/cmu_us_awb/libmimic_lang_cmu_us_awb_la-cmu_us_awb_spamf0_accent.lo `test -f 'lang/cmu_us_awb/cmu_us_awb_spamf0_accent.c' || echo '$(srcdir)/'`lang/cmu_us_awb/cmu_us_awb_spamf0_accent.c
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_lang_cmu_us_awb_la_CFLAGS) $(CFLAGS) -c -o lang/cmu_us_awb/libttsmimic_lang_cmu_us_awb_la-cmu_us_awb_spamf0_accent.lo `test -f 'lang/cmu_us_awb/cmu_us_awb_spamf0_accent.c' || echo '$(srcdir)/'`lang/cmu_us_awb/cmu_us_awb_spamf0_accent.c
 
-lang/cmu_us_awb/libmimic_lang_cmu_us_awb_la-cmu_us_awb_spamf0_accent_params.lo: lang/cmu_us_awb/cmu_us_awb_spamf0_accent_params.c
-@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_lang_cmu_us_awb_la_CFLAGS) $(CFLAGS) -MT lang/cmu_us_awb/libmimic_lang_cmu_us_awb_la-cmu_us_awb_spamf0_accent_params.lo -MD -MP -MF lang/cmu_us_awb/$(DEPDIR)/libmimic_lang_cmu_us_awb_la-cmu_us_awb_spamf0_accent_params.Tpo -c -o lang/cmu_us_awb/libmimic_lang_cmu_us_awb_la-cmu_us_awb_spamf0_accent_params.lo `test -f 'lang/cmu_us_awb/cmu_us_awb_spamf0_accent_params.c' || echo '$(srcdir)/'`lang/cmu_us_awb/cmu_us_awb_spamf0_accent_params.c
-@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) lang/cmu_us_awb/$(DEPDIR)/libmimic_lang_cmu_us_awb_la-cmu_us_awb_spamf0_accent_params.Tpo lang/cmu_us_awb/$(DEPDIR)/libmimic_lang_cmu_us_awb_la-cmu_us_awb_spamf0_accent_params.Plo
-@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='lang/cmu_us_awb/cmu_us_awb_spamf0_accent_params.c' object='lang/cmu_us_awb/libmimic_lang_cmu_us_awb_la-cmu_us_awb_spamf0_accent_params.lo' libtool=yes @AMDEPBACKSLASH@
+lang/cmu_us_awb/libttsmimic_lang_cmu_us_awb_la-cmu_us_awb_spamf0_accent_params.lo: lang/cmu_us_awb/cmu_us_awb_spamf0_accent_params.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_lang_cmu_us_awb_la_CFLAGS) $(CFLAGS) -MT lang/cmu_us_awb/libttsmimic_lang_cmu_us_awb_la-cmu_us_awb_spamf0_accent_params.lo -MD -MP -MF lang/cmu_us_awb/$(DEPDIR)/libttsmimic_lang_cmu_us_awb_la-cmu_us_awb_spamf0_accent_params.Tpo -c -o lang/cmu_us_awb/libttsmimic_lang_cmu_us_awb_la-cmu_us_awb_spamf0_accent_params.lo `test -f 'lang/cmu_us_awb/cmu_us_awb_spamf0_accent_params.c' || echo '$(srcdir)/'`lang/cmu_us_awb/cmu_us_awb_spamf0_accent_params.c
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) lang/cmu_us_awb/$(DEPDIR)/libttsmimic_lang_cmu_us_awb_la-cmu_us_awb_spamf0_accent_params.Tpo lang/cmu_us_awb/$(DEPDIR)/libttsmimic_lang_cmu_us_awb_la-cmu_us_awb_spamf0_accent_params.Plo
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='lang/cmu_us_awb/cmu_us_awb_spamf0_accent_params.c' object='lang/cmu_us_awb/libttsmimic_lang_cmu_us_awb_la-cmu_us_awb_spamf0_accent_params.lo' libtool=yes @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_lang_cmu_us_awb_la_CFLAGS) $(CFLAGS) -c -o lang/cmu_us_awb/libmimic_lang_cmu_us_awb_la-cmu_us_awb_spamf0_accent_params.lo `test -f 'lang/cmu_us_awb/cmu_us_awb_spamf0_accent_params.c' || echo '$(srcdir)/'`lang/cmu_us_awb/cmu_us_awb_spamf0_accent_params.c
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_lang_cmu_us_awb_la_CFLAGS) $(CFLAGS) -c -o lang/cmu_us_awb/libttsmimic_lang_cmu_us_awb_la-cmu_us_awb_spamf0_accent_params.lo `test -f 'lang/cmu_us_awb/cmu_us_awb_spamf0_accent_params.c' || echo '$(srcdir)/'`lang/cmu_us_awb/cmu_us_awb_spamf0_accent_params.c
 
-lang/cmu_us_awb/libmimic_lang_cmu_us_awb_la-cmu_us_awb_spamf0_phrase.lo: lang/cmu_us_awb/cmu_us_awb_spamf0_phrase.c
-@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_lang_cmu_us_awb_la_CFLAGS) $(CFLAGS) -MT lang/cmu_us_awb/libmimic_lang_cmu_us_awb_la-cmu_us_awb_spamf0_phrase.lo -MD -MP -MF lang/cmu_us_awb/$(DEPDIR)/libmimic_lang_cmu_us_awb_la-cmu_us_awb_spamf0_phrase.Tpo -c -o lang/cmu_us_awb/libmimic_lang_cmu_us_awb_la-cmu_us_awb_spamf0_phrase.lo `test -f 'lang/cmu_us_awb/cmu_us_awb_spamf0_phrase.c' || echo '$(srcdir)/'`lang/cmu_us_awb/cmu_us_awb_spamf0_phrase.c
-@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) lang/cmu_us_awb/$(DEPDIR)/libmimic_lang_cmu_us_awb_la-cmu_us_awb_spamf0_phrase.Tpo lang/cmu_us_awb/$(DEPDIR)/libmimic_lang_cmu_us_awb_la-cmu_us_awb_spamf0_phrase.Plo
-@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='lang/cmu_us_awb/cmu_us_awb_spamf0_phrase.c' object='lang/cmu_us_awb/libmimic_lang_cmu_us_awb_la-cmu_us_awb_spamf0_phrase.lo' libtool=yes @AMDEPBACKSLASH@
+lang/cmu_us_awb/libttsmimic_lang_cmu_us_awb_la-cmu_us_awb_spamf0_phrase.lo: lang/cmu_us_awb/cmu_us_awb_spamf0_phrase.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_lang_cmu_us_awb_la_CFLAGS) $(CFLAGS) -MT lang/cmu_us_awb/libttsmimic_lang_cmu_us_awb_la-cmu_us_awb_spamf0_phrase.lo -MD -MP -MF lang/cmu_us_awb/$(DEPDIR)/libttsmimic_lang_cmu_us_awb_la-cmu_us_awb_spamf0_phrase.Tpo -c -o lang/cmu_us_awb/libttsmimic_lang_cmu_us_awb_la-cmu_us_awb_spamf0_phrase.lo `test -f 'lang/cmu_us_awb/cmu_us_awb_spamf0_phrase.c' || echo '$(srcdir)/'`lang/cmu_us_awb/cmu_us_awb_spamf0_phrase.c
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) lang/cmu_us_awb/$(DEPDIR)/libttsmimic_lang_cmu_us_awb_la-cmu_us_awb_spamf0_phrase.Tpo lang/cmu_us_awb/$(DEPDIR)/libttsmimic_lang_cmu_us_awb_la-cmu_us_awb_spamf0_phrase.Plo
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='lang/cmu_us_awb/cmu_us_awb_spamf0_phrase.c' object='lang/cmu_us_awb/libttsmimic_lang_cmu_us_awb_la-cmu_us_awb_spamf0_phrase.lo' libtool=yes @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_lang_cmu_us_awb_la_CFLAGS) $(CFLAGS) -c -o lang/cmu_us_awb/libmimic_lang_cmu_us_awb_la-cmu_us_awb_spamf0_phrase.lo `test -f 'lang/cmu_us_awb/cmu_us_awb_spamf0_phrase.c' || echo '$(srcdir)/'`lang/cmu_us_awb/cmu_us_awb_spamf0_phrase.c
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_lang_cmu_us_awb_la_CFLAGS) $(CFLAGS) -c -o lang/cmu_us_awb/libttsmimic_lang_cmu_us_awb_la-cmu_us_awb_spamf0_phrase.lo `test -f 'lang/cmu_us_awb/cmu_us_awb_spamf0_phrase.c' || echo '$(srcdir)/'`lang/cmu_us_awb/cmu_us_awb_spamf0_phrase.c
 
-lang/cmu_us_kal/libmimic_lang_cmu_us_kal_la-cmu_us_kal.lo: lang/cmu_us_kal/cmu_us_kal.c
-@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_lang_cmu_us_kal_la_CFLAGS) $(CFLAGS) -MT lang/cmu_us_kal/libmimic_lang_cmu_us_kal_la-cmu_us_kal.lo -MD -MP -MF lang/cmu_us_kal/$(DEPDIR)/libmimic_lang_cmu_us_kal_la-cmu_us_kal.Tpo -c -o lang/cmu_us_kal/libmimic_lang_cmu_us_kal_la-cmu_us_kal.lo `test -f 'lang/cmu_us_kal/cmu_us_kal.c' || echo '$(srcdir)/'`lang/cmu_us_kal/cmu_us_kal.c
-@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) lang/cmu_us_kal/$(DEPDIR)/libmimic_lang_cmu_us_kal_la-cmu_us_kal.Tpo lang/cmu_us_kal/$(DEPDIR)/libmimic_lang_cmu_us_kal_la-cmu_us_kal.Plo
-@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='lang/cmu_us_kal/cmu_us_kal.c' object='lang/cmu_us_kal/libmimic_lang_cmu_us_kal_la-cmu_us_kal.lo' libtool=yes @AMDEPBACKSLASH@
+lang/cmu_us_kal/libttsmimic_lang_cmu_us_kal_la-cmu_us_kal.lo: lang/cmu_us_kal/cmu_us_kal.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_lang_cmu_us_kal_la_CFLAGS) $(CFLAGS) -MT lang/cmu_us_kal/libttsmimic_lang_cmu_us_kal_la-cmu_us_kal.lo -MD -MP -MF lang/cmu_us_kal/$(DEPDIR)/libttsmimic_lang_cmu_us_kal_la-cmu_us_kal.Tpo -c -o lang/cmu_us_kal/libttsmimic_lang_cmu_us_kal_la-cmu_us_kal.lo `test -f 'lang/cmu_us_kal/cmu_us_kal.c' || echo '$(srcdir)/'`lang/cmu_us_kal/cmu_us_kal.c
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) lang/cmu_us_kal/$(DEPDIR)/libttsmimic_lang_cmu_us_kal_la-cmu_us_kal.Tpo lang/cmu_us_kal/$(DEPDIR)/libttsmimic_lang_cmu_us_kal_la-cmu_us_kal.Plo
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='lang/cmu_us_kal/cmu_us_kal.c' object='lang/cmu_us_kal/libttsmimic_lang_cmu_us_kal_la-cmu_us_kal.lo' libtool=yes @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_lang_cmu_us_kal_la_CFLAGS) $(CFLAGS) -c -o lang/cmu_us_kal/libmimic_lang_cmu_us_kal_la-cmu_us_kal.lo `test -f 'lang/cmu_us_kal/cmu_us_kal.c' || echo '$(srcdir)/'`lang/cmu_us_kal/cmu_us_kal.c
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_lang_cmu_us_kal_la_CFLAGS) $(CFLAGS) -c -o lang/cmu_us_kal/libttsmimic_lang_cmu_us_kal_la-cmu_us_kal.lo `test -f 'lang/cmu_us_kal/cmu_us_kal.c' || echo '$(srcdir)/'`lang/cmu_us_kal/cmu_us_kal.c
 
-lang/cmu_us_kal/libmimic_lang_cmu_us_kal_la-cmu_us_kal_diphone.lo: lang/cmu_us_kal/cmu_us_kal_diphone.c
-@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_lang_cmu_us_kal_la_CFLAGS) $(CFLAGS) -MT lang/cmu_us_kal/libmimic_lang_cmu_us_kal_la-cmu_us_kal_diphone.lo -MD -MP -MF lang/cmu_us_kal/$(DEPDIR)/libmimic_lang_cmu_us_kal_la-cmu_us_kal_diphone.Tpo -c -o lang/cmu_us_kal/libmimic_lang_cmu_us_kal_la-cmu_us_kal_diphone.lo `test -f 'lang/cmu_us_kal/cmu_us_kal_diphone.c' || echo '$(srcdir)/'`lang/cmu_us_kal/cmu_us_kal_diphone.c
-@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) lang/cmu_us_kal/$(DEPDIR)/libmimic_lang_cmu_us_kal_la-cmu_us_kal_diphone.Tpo lang/cmu_us_kal/$(DEPDIR)/libmimic_lang_cmu_us_kal_la-cmu_us_kal_diphone.Plo
-@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='lang/cmu_us_kal/cmu_us_kal_diphone.c' object='lang/cmu_us_kal/libmimic_lang_cmu_us_kal_la-cmu_us_kal_diphone.lo' libtool=yes @AMDEPBACKSLASH@
+lang/cmu_us_kal/libttsmimic_lang_cmu_us_kal_la-cmu_us_kal_diphone.lo: lang/cmu_us_kal/cmu_us_kal_diphone.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_lang_cmu_us_kal_la_CFLAGS) $(CFLAGS) -MT lang/cmu_us_kal/libttsmimic_lang_cmu_us_kal_la-cmu_us_kal_diphone.lo -MD -MP -MF lang/cmu_us_kal/$(DEPDIR)/libttsmimic_lang_cmu_us_kal_la-cmu_us_kal_diphone.Tpo -c -o lang/cmu_us_kal/libttsmimic_lang_cmu_us_kal_la-cmu_us_kal_diphone.lo `test -f 'lang/cmu_us_kal/cmu_us_kal_diphone.c' || echo '$(srcdir)/'`lang/cmu_us_kal/cmu_us_kal_diphone.c
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) lang/cmu_us_kal/$(DEPDIR)/libttsmimic_lang_cmu_us_kal_la-cmu_us_kal_diphone.Tpo lang/cmu_us_kal/$(DEPDIR)/libttsmimic_lang_cmu_us_kal_la-cmu_us_kal_diphone.Plo
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='lang/cmu_us_kal/cmu_us_kal_diphone.c' object='lang/cmu_us_kal/libttsmimic_lang_cmu_us_kal_la-cmu_us_kal_diphone.lo' libtool=yes @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_lang_cmu_us_kal_la_CFLAGS) $(CFLAGS) -c -o lang/cmu_us_kal/libmimic_lang_cmu_us_kal_la-cmu_us_kal_diphone.lo `test -f 'lang/cmu_us_kal/cmu_us_kal_diphone.c' || echo '$(srcdir)/'`lang/cmu_us_kal/cmu_us_kal_diphone.c
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_lang_cmu_us_kal_la_CFLAGS) $(CFLAGS) -c -o lang/cmu_us_kal/libttsmimic_lang_cmu_us_kal_la-cmu_us_kal_diphone.lo `test -f 'lang/cmu_us_kal/cmu_us_kal_diphone.c' || echo '$(srcdir)/'`lang/cmu_us_kal/cmu_us_kal_diphone.c
 
-lang/cmu_us_kal/libmimic_lang_cmu_us_kal_la-cmu_us_kal_lpc.lo: lang/cmu_us_kal/cmu_us_kal_lpc.c
-@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_lang_cmu_us_kal_la_CFLAGS) $(CFLAGS) -MT lang/cmu_us_kal/libmimic_lang_cmu_us_kal_la-cmu_us_kal_lpc.lo -MD -MP -MF lang/cmu_us_kal/$(DEPDIR)/libmimic_lang_cmu_us_kal_la-cmu_us_kal_lpc.Tpo -c -o lang/cmu_us_kal/libmimic_lang_cmu_us_kal_la-cmu_us_kal_lpc.lo `test -f 'lang/cmu_us_kal/cmu_us_kal_lpc.c' || echo '$(srcdir)/'`lang/cmu_us_kal/cmu_us_kal_lpc.c
-@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) lang/cmu_us_kal/$(DEPDIR)/libmimic_lang_cmu_us_kal_la-cmu_us_kal_lpc.Tpo lang/cmu_us_kal/$(DEPDIR)/libmimic_lang_cmu_us_kal_la-cmu_us_kal_lpc.Plo
-@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='lang/cmu_us_kal/cmu_us_kal_lpc.c' object='lang/cmu_us_kal/libmimic_lang_cmu_us_kal_la-cmu_us_kal_lpc.lo' libtool=yes @AMDEPBACKSLASH@
+lang/cmu_us_kal/libttsmimic_lang_cmu_us_kal_la-cmu_us_kal_lpc.lo: lang/cmu_us_kal/cmu_us_kal_lpc.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_lang_cmu_us_kal_la_CFLAGS) $(CFLAGS) -MT lang/cmu_us_kal/libttsmimic_lang_cmu_us_kal_la-cmu_us_kal_lpc.lo -MD -MP -MF lang/cmu_us_kal/$(DEPDIR)/libttsmimic_lang_cmu_us_kal_la-cmu_us_kal_lpc.Tpo -c -o lang/cmu_us_kal/libttsmimic_lang_cmu_us_kal_la-cmu_us_kal_lpc.lo `test -f 'lang/cmu_us_kal/cmu_us_kal_lpc.c' || echo '$(srcdir)/'`lang/cmu_us_kal/cmu_us_kal_lpc.c
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) lang/cmu_us_kal/$(DEPDIR)/libttsmimic_lang_cmu_us_kal_la-cmu_us_kal_lpc.Tpo lang/cmu_us_kal/$(DEPDIR)/libttsmimic_lang_cmu_us_kal_la-cmu_us_kal_lpc.Plo
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='lang/cmu_us_kal/cmu_us_kal_lpc.c' object='lang/cmu_us_kal/libttsmimic_lang_cmu_us_kal_la-cmu_us_kal_lpc.lo' libtool=yes @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_lang_cmu_us_kal_la_CFLAGS) $(CFLAGS) -c -o lang/cmu_us_kal/libmimic_lang_cmu_us_kal_la-cmu_us_kal_lpc.lo `test -f 'lang/cmu_us_kal/cmu_us_kal_lpc.c' || echo '$(srcdir)/'`lang/cmu_us_kal/cmu_us_kal_lpc.c
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_lang_cmu_us_kal_la_CFLAGS) $(CFLAGS) -c -o lang/cmu_us_kal/libttsmimic_lang_cmu_us_kal_la-cmu_us_kal_lpc.lo `test -f 'lang/cmu_us_kal/cmu_us_kal_lpc.c' || echo '$(srcdir)/'`lang/cmu_us_kal/cmu_us_kal_lpc.c
 
-lang/cmu_us_kal/libmimic_lang_cmu_us_kal_la-cmu_us_kal_res.lo: lang/cmu_us_kal/cmu_us_kal_res.c
-@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_lang_cmu_us_kal_la_CFLAGS) $(CFLAGS) -MT lang/cmu_us_kal/libmimic_lang_cmu_us_kal_la-cmu_us_kal_res.lo -MD -MP -MF lang/cmu_us_kal/$(DEPDIR)/libmimic_lang_cmu_us_kal_la-cmu_us_kal_res.Tpo -c -o lang/cmu_us_kal/libmimic_lang_cmu_us_kal_la-cmu_us_kal_res.lo `test -f 'lang/cmu_us_kal/cmu_us_kal_res.c' || echo '$(srcdir)/'`lang/cmu_us_kal/cmu_us_kal_res.c
-@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) lang/cmu_us_kal/$(DEPDIR)/libmimic_lang_cmu_us_kal_la-cmu_us_kal_res.Tpo lang/cmu_us_kal/$(DEPDIR)/libmimic_lang_cmu_us_kal_la-cmu_us_kal_res.Plo
-@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='lang/cmu_us_kal/cmu_us_kal_res.c' object='lang/cmu_us_kal/libmimic_lang_cmu_us_kal_la-cmu_us_kal_res.lo' libtool=yes @AMDEPBACKSLASH@
+lang/cmu_us_kal/libttsmimic_lang_cmu_us_kal_la-cmu_us_kal_res.lo: lang/cmu_us_kal/cmu_us_kal_res.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_lang_cmu_us_kal_la_CFLAGS) $(CFLAGS) -MT lang/cmu_us_kal/libttsmimic_lang_cmu_us_kal_la-cmu_us_kal_res.lo -MD -MP -MF lang/cmu_us_kal/$(DEPDIR)/libttsmimic_lang_cmu_us_kal_la-cmu_us_kal_res.Tpo -c -o lang/cmu_us_kal/libttsmimic_lang_cmu_us_kal_la-cmu_us_kal_res.lo `test -f 'lang/cmu_us_kal/cmu_us_kal_res.c' || echo '$(srcdir)/'`lang/cmu_us_kal/cmu_us_kal_res.c
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) lang/cmu_us_kal/$(DEPDIR)/libttsmimic_lang_cmu_us_kal_la-cmu_us_kal_res.Tpo lang/cmu_us_kal/$(DEPDIR)/libttsmimic_lang_cmu_us_kal_la-cmu_us_kal_res.Plo
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='lang/cmu_us_kal/cmu_us_kal_res.c' object='lang/cmu_us_kal/libttsmimic_lang_cmu_us_kal_la-cmu_us_kal_res.lo' libtool=yes @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_lang_cmu_us_kal_la_CFLAGS) $(CFLAGS) -c -o lang/cmu_us_kal/libmimic_lang_cmu_us_kal_la-cmu_us_kal_res.lo `test -f 'lang/cmu_us_kal/cmu_us_kal_res.c' || echo '$(srcdir)/'`lang/cmu_us_kal/cmu_us_kal_res.c
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_lang_cmu_us_kal_la_CFLAGS) $(CFLAGS) -c -o lang/cmu_us_kal/libttsmimic_lang_cmu_us_kal_la-cmu_us_kal_res.lo `test -f 'lang/cmu_us_kal/cmu_us_kal_res.c' || echo '$(srcdir)/'`lang/cmu_us_kal/cmu_us_kal_res.c
 
-lang/cmu_us_kal/libmimic_lang_cmu_us_kal_la-cmu_us_kal_residx.lo: lang/cmu_us_kal/cmu_us_kal_residx.c
-@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_lang_cmu_us_kal_la_CFLAGS) $(CFLAGS) -MT lang/cmu_us_kal/libmimic_lang_cmu_us_kal_la-cmu_us_kal_residx.lo -MD -MP -MF lang/cmu_us_kal/$(DEPDIR)/libmimic_lang_cmu_us_kal_la-cmu_us_kal_residx.Tpo -c -o lang/cmu_us_kal/libmimic_lang_cmu_us_kal_la-cmu_us_kal_residx.lo `test -f 'lang/cmu_us_kal/cmu_us_kal_residx.c' || echo '$(srcdir)/'`lang/cmu_us_kal/cmu_us_kal_residx.c
-@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) lang/cmu_us_kal/$(DEPDIR)/libmimic_lang_cmu_us_kal_la-cmu_us_kal_residx.Tpo lang/cmu_us_kal/$(DEPDIR)/libmimic_lang_cmu_us_kal_la-cmu_us_kal_residx.Plo
-@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='lang/cmu_us_kal/cmu_us_kal_residx.c' object='lang/cmu_us_kal/libmimic_lang_cmu_us_kal_la-cmu_us_kal_residx.lo' libtool=yes @AMDEPBACKSLASH@
+lang/cmu_us_kal/libttsmimic_lang_cmu_us_kal_la-cmu_us_kal_residx.lo: lang/cmu_us_kal/cmu_us_kal_residx.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_lang_cmu_us_kal_la_CFLAGS) $(CFLAGS) -MT lang/cmu_us_kal/libttsmimic_lang_cmu_us_kal_la-cmu_us_kal_residx.lo -MD -MP -MF lang/cmu_us_kal/$(DEPDIR)/libttsmimic_lang_cmu_us_kal_la-cmu_us_kal_residx.Tpo -c -o lang/cmu_us_kal/libttsmimic_lang_cmu_us_kal_la-cmu_us_kal_residx.lo `test -f 'lang/cmu_us_kal/cmu_us_kal_residx.c' || echo '$(srcdir)/'`lang/cmu_us_kal/cmu_us_kal_residx.c
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) lang/cmu_us_kal/$(DEPDIR)/libttsmimic_lang_cmu_us_kal_la-cmu_us_kal_residx.Tpo lang/cmu_us_kal/$(DEPDIR)/libttsmimic_lang_cmu_us_kal_la-cmu_us_kal_residx.Plo
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='lang/cmu_us_kal/cmu_us_kal_residx.c' object='lang/cmu_us_kal/libttsmimic_lang_cmu_us_kal_la-cmu_us_kal_residx.lo' libtool=yes @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_lang_cmu_us_kal_la_CFLAGS) $(CFLAGS) -c -o lang/cmu_us_kal/libmimic_lang_cmu_us_kal_la-cmu_us_kal_residx.lo `test -f 'lang/cmu_us_kal/cmu_us_kal_residx.c' || echo '$(srcdir)/'`lang/cmu_us_kal/cmu_us_kal_residx.c
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_lang_cmu_us_kal_la_CFLAGS) $(CFLAGS) -c -o lang/cmu_us_kal/libttsmimic_lang_cmu_us_kal_la-cmu_us_kal_residx.lo `test -f 'lang/cmu_us_kal/cmu_us_kal_residx.c' || echo '$(srcdir)/'`lang/cmu_us_kal/cmu_us_kal_residx.c
 
-lang/cmu_us_kal/libmimic_lang_cmu_us_kal_la-cmu_us_kal_ressize.lo: lang/cmu_us_kal/cmu_us_kal_ressize.c
-@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_lang_cmu_us_kal_la_CFLAGS) $(CFLAGS) -MT lang/cmu_us_kal/libmimic_lang_cmu_us_kal_la-cmu_us_kal_ressize.lo -MD -MP -MF lang/cmu_us_kal/$(DEPDIR)/libmimic_lang_cmu_us_kal_la-cmu_us_kal_ressize.Tpo -c -o lang/cmu_us_kal/libmimic_lang_cmu_us_kal_la-cmu_us_kal_ressize.lo `test -f 'lang/cmu_us_kal/cmu_us_kal_ressize.c' || echo '$(srcdir)/'`lang/cmu_us_kal/cmu_us_kal_ressize.c
-@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) lang/cmu_us_kal/$(DEPDIR)/libmimic_lang_cmu_us_kal_la-cmu_us_kal_ressize.Tpo lang/cmu_us_kal/$(DEPDIR)/libmimic_lang_cmu_us_kal_la-cmu_us_kal_ressize.Plo
-@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='lang/cmu_us_kal/cmu_us_kal_ressize.c' object='lang/cmu_us_kal/libmimic_lang_cmu_us_kal_la-cmu_us_kal_ressize.lo' libtool=yes @AMDEPBACKSLASH@
+lang/cmu_us_kal/libttsmimic_lang_cmu_us_kal_la-cmu_us_kal_ressize.lo: lang/cmu_us_kal/cmu_us_kal_ressize.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_lang_cmu_us_kal_la_CFLAGS) $(CFLAGS) -MT lang/cmu_us_kal/libttsmimic_lang_cmu_us_kal_la-cmu_us_kal_ressize.lo -MD -MP -MF lang/cmu_us_kal/$(DEPDIR)/libttsmimic_lang_cmu_us_kal_la-cmu_us_kal_ressize.Tpo -c -o lang/cmu_us_kal/libttsmimic_lang_cmu_us_kal_la-cmu_us_kal_ressize.lo `test -f 'lang/cmu_us_kal/cmu_us_kal_ressize.c' || echo '$(srcdir)/'`lang/cmu_us_kal/cmu_us_kal_ressize.c
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) lang/cmu_us_kal/$(DEPDIR)/libttsmimic_lang_cmu_us_kal_la-cmu_us_kal_ressize.Tpo lang/cmu_us_kal/$(DEPDIR)/libttsmimic_lang_cmu_us_kal_la-cmu_us_kal_ressize.Plo
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='lang/cmu_us_kal/cmu_us_kal_ressize.c' object='lang/cmu_us_kal/libttsmimic_lang_cmu_us_kal_la-cmu_us_kal_ressize.lo' libtool=yes @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_lang_cmu_us_kal_la_CFLAGS) $(CFLAGS) -c -o lang/cmu_us_kal/libmimic_lang_cmu_us_kal_la-cmu_us_kal_ressize.lo `test -f 'lang/cmu_us_kal/cmu_us_kal_ressize.c' || echo '$(srcdir)/'`lang/cmu_us_kal/cmu_us_kal_ressize.c
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_lang_cmu_us_kal_la_CFLAGS) $(CFLAGS) -c -o lang/cmu_us_kal/libttsmimic_lang_cmu_us_kal_la-cmu_us_kal_ressize.lo `test -f 'lang/cmu_us_kal/cmu_us_kal_ressize.c' || echo '$(srcdir)/'`lang/cmu_us_kal/cmu_us_kal_ressize.c
 
-lang/cmu_us_kal16/libmimic_lang_cmu_us_kal16_la-cmu_us_kal16.lo: lang/cmu_us_kal16/cmu_us_kal16.c
-@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_lang_cmu_us_kal16_la_CFLAGS) $(CFLAGS) -MT lang/cmu_us_kal16/libmimic_lang_cmu_us_kal16_la-cmu_us_kal16.lo -MD -MP -MF lang/cmu_us_kal16/$(DEPDIR)/libmimic_lang_cmu_us_kal16_la-cmu_us_kal16.Tpo -c -o lang/cmu_us_kal16/libmimic_lang_cmu_us_kal16_la-cmu_us_kal16.lo `test -f 'lang/cmu_us_kal16/cmu_us_kal16.c' || echo '$(srcdir)/'`lang/cmu_us_kal16/cmu_us_kal16.c
-@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) lang/cmu_us_kal16/$(DEPDIR)/libmimic_lang_cmu_us_kal16_la-cmu_us_kal16.Tpo lang/cmu_us_kal16/$(DEPDIR)/libmimic_lang_cmu_us_kal16_la-cmu_us_kal16.Plo
-@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='lang/cmu_us_kal16/cmu_us_kal16.c' object='lang/cmu_us_kal16/libmimic_lang_cmu_us_kal16_la-cmu_us_kal16.lo' libtool=yes @AMDEPBACKSLASH@
+lang/cmu_us_kal16/libttsmimic_lang_cmu_us_kal16_la-cmu_us_kal16.lo: lang/cmu_us_kal16/cmu_us_kal16.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_lang_cmu_us_kal16_la_CFLAGS) $(CFLAGS) -MT lang/cmu_us_kal16/libttsmimic_lang_cmu_us_kal16_la-cmu_us_kal16.lo -MD -MP -MF lang/cmu_us_kal16/$(DEPDIR)/libttsmimic_lang_cmu_us_kal16_la-cmu_us_kal16.Tpo -c -o lang/cmu_us_kal16/libttsmimic_lang_cmu_us_kal16_la-cmu_us_kal16.lo `test -f 'lang/cmu_us_kal16/cmu_us_kal16.c' || echo '$(srcdir)/'`lang/cmu_us_kal16/cmu_us_kal16.c
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) lang/cmu_us_kal16/$(DEPDIR)/libttsmimic_lang_cmu_us_kal16_la-cmu_us_kal16.Tpo lang/cmu_us_kal16/$(DEPDIR)/libttsmimic_lang_cmu_us_kal16_la-cmu_us_kal16.Plo
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='lang/cmu_us_kal16/cmu_us_kal16.c' object='lang/cmu_us_kal16/libttsmimic_lang_cmu_us_kal16_la-cmu_us_kal16.lo' libtool=yes @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_lang_cmu_us_kal16_la_CFLAGS) $(CFLAGS) -c -o lang/cmu_us_kal16/libmimic_lang_cmu_us_kal16_la-cmu_us_kal16.lo `test -f 'lang/cmu_us_kal16/cmu_us_kal16.c' || echo '$(srcdir)/'`lang/cmu_us_kal16/cmu_us_kal16.c
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_lang_cmu_us_kal16_la_CFLAGS) $(CFLAGS) -c -o lang/cmu_us_kal16/libttsmimic_lang_cmu_us_kal16_la-cmu_us_kal16.lo `test -f 'lang/cmu_us_kal16/cmu_us_kal16.c' || echo '$(srcdir)/'`lang/cmu_us_kal16/cmu_us_kal16.c
 
-lang/cmu_us_kal16/libmimic_lang_cmu_us_kal16_la-cmu_us_kal16_diphone.lo: lang/cmu_us_kal16/cmu_us_kal16_diphone.c
-@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_lang_cmu_us_kal16_la_CFLAGS) $(CFLAGS) -MT lang/cmu_us_kal16/libmimic_lang_cmu_us_kal16_la-cmu_us_kal16_diphone.lo -MD -MP -MF lang/cmu_us_kal16/$(DEPDIR)/libmimic_lang_cmu_us_kal16_la-cmu_us_kal16_diphone.Tpo -c -o lang/cmu_us_kal16/libmimic_lang_cmu_us_kal16_la-cmu_us_kal16_diphone.lo `test -f 'lang/cmu_us_kal16/cmu_us_kal16_diphone.c' || echo '$(srcdir)/'`lang/cmu_us_kal16/cmu_us_kal16_diphone.c
-@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) lang/cmu_us_kal16/$(DEPDIR)/libmimic_lang_cmu_us_kal16_la-cmu_us_kal16_diphone.Tpo lang/cmu_us_kal16/$(DEPDIR)/libmimic_lang_cmu_us_kal16_la-cmu_us_kal16_diphone.Plo
-@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='lang/cmu_us_kal16/cmu_us_kal16_diphone.c' object='lang/cmu_us_kal16/libmimic_lang_cmu_us_kal16_la-cmu_us_kal16_diphone.lo' libtool=yes @AMDEPBACKSLASH@
+lang/cmu_us_kal16/libttsmimic_lang_cmu_us_kal16_la-cmu_us_kal16_diphone.lo: lang/cmu_us_kal16/cmu_us_kal16_diphone.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_lang_cmu_us_kal16_la_CFLAGS) $(CFLAGS) -MT lang/cmu_us_kal16/libttsmimic_lang_cmu_us_kal16_la-cmu_us_kal16_diphone.lo -MD -MP -MF lang/cmu_us_kal16/$(DEPDIR)/libttsmimic_lang_cmu_us_kal16_la-cmu_us_kal16_diphone.Tpo -c -o lang/cmu_us_kal16/libttsmimic_lang_cmu_us_kal16_la-cmu_us_kal16_diphone.lo `test -f 'lang/cmu_us_kal16/cmu_us_kal16_diphone.c' || echo '$(srcdir)/'`lang/cmu_us_kal16/cmu_us_kal16_diphone.c
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) lang/cmu_us_kal16/$(DEPDIR)/libttsmimic_lang_cmu_us_kal16_la-cmu_us_kal16_diphone.Tpo lang/cmu_us_kal16/$(DEPDIR)/libttsmimic_lang_cmu_us_kal16_la-cmu_us_kal16_diphone.Plo
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='lang/cmu_us_kal16/cmu_us_kal16_diphone.c' object='lang/cmu_us_kal16/libttsmimic_lang_cmu_us_kal16_la-cmu_us_kal16_diphone.lo' libtool=yes @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_lang_cmu_us_kal16_la_CFLAGS) $(CFLAGS) -c -o lang/cmu_us_kal16/libmimic_lang_cmu_us_kal16_la-cmu_us_kal16_diphone.lo `test -f 'lang/cmu_us_kal16/cmu_us_kal16_diphone.c' || echo '$(srcdir)/'`lang/cmu_us_kal16/cmu_us_kal16_diphone.c
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_lang_cmu_us_kal16_la_CFLAGS) $(CFLAGS) -c -o lang/cmu_us_kal16/libttsmimic_lang_cmu_us_kal16_la-cmu_us_kal16_diphone.lo `test -f 'lang/cmu_us_kal16/cmu_us_kal16_diphone.c' || echo '$(srcdir)/'`lang/cmu_us_kal16/cmu_us_kal16_diphone.c
 
-lang/cmu_us_kal16/libmimic_lang_cmu_us_kal16_la-cmu_us_kal16_lpc.lo: lang/cmu_us_kal16/cmu_us_kal16_lpc.c
-@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_lang_cmu_us_kal16_la_CFLAGS) $(CFLAGS) -MT lang/cmu_us_kal16/libmimic_lang_cmu_us_kal16_la-cmu_us_kal16_lpc.lo -MD -MP -MF lang/cmu_us_kal16/$(DEPDIR)/libmimic_lang_cmu_us_kal16_la-cmu_us_kal16_lpc.Tpo -c -o lang/cmu_us_kal16/libmimic_lang_cmu_us_kal16_la-cmu_us_kal16_lpc.lo `test -f 'lang/cmu_us_kal16/cmu_us_kal16_lpc.c' || echo '$(srcdir)/'`lang/cmu_us_kal16/cmu_us_kal16_lpc.c
-@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) lang/cmu_us_kal16/$(DEPDIR)/libmimic_lang_cmu_us_kal16_la-cmu_us_kal16_lpc.Tpo lang/cmu_us_kal16/$(DEPDIR)/libmimic_lang_cmu_us_kal16_la-cmu_us_kal16_lpc.Plo
-@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='lang/cmu_us_kal16/cmu_us_kal16_lpc.c' object='lang/cmu_us_kal16/libmimic_lang_cmu_us_kal16_la-cmu_us_kal16_lpc.lo' libtool=yes @AMDEPBACKSLASH@
+lang/cmu_us_kal16/libttsmimic_lang_cmu_us_kal16_la-cmu_us_kal16_lpc.lo: lang/cmu_us_kal16/cmu_us_kal16_lpc.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_lang_cmu_us_kal16_la_CFLAGS) $(CFLAGS) -MT lang/cmu_us_kal16/libttsmimic_lang_cmu_us_kal16_la-cmu_us_kal16_lpc.lo -MD -MP -MF lang/cmu_us_kal16/$(DEPDIR)/libttsmimic_lang_cmu_us_kal16_la-cmu_us_kal16_lpc.Tpo -c -o lang/cmu_us_kal16/libttsmimic_lang_cmu_us_kal16_la-cmu_us_kal16_lpc.lo `test -f 'lang/cmu_us_kal16/cmu_us_kal16_lpc.c' || echo '$(srcdir)/'`lang/cmu_us_kal16/cmu_us_kal16_lpc.c
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) lang/cmu_us_kal16/$(DEPDIR)/libttsmimic_lang_cmu_us_kal16_la-cmu_us_kal16_lpc.Tpo lang/cmu_us_kal16/$(DEPDIR)/libttsmimic_lang_cmu_us_kal16_la-cmu_us_kal16_lpc.Plo
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='lang/cmu_us_kal16/cmu_us_kal16_lpc.c' object='lang/cmu_us_kal16/libttsmimic_lang_cmu_us_kal16_la-cmu_us_kal16_lpc.lo' libtool=yes @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_lang_cmu_us_kal16_la_CFLAGS) $(CFLAGS) -c -o lang/cmu_us_kal16/libmimic_lang_cmu_us_kal16_la-cmu_us_kal16_lpc.lo `test -f 'lang/cmu_us_kal16/cmu_us_kal16_lpc.c' || echo '$(srcdir)/'`lang/cmu_us_kal16/cmu_us_kal16_lpc.c
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_lang_cmu_us_kal16_la_CFLAGS) $(CFLAGS) -c -o lang/cmu_us_kal16/libttsmimic_lang_cmu_us_kal16_la-cmu_us_kal16_lpc.lo `test -f 'lang/cmu_us_kal16/cmu_us_kal16_lpc.c' || echo '$(srcdir)/'`lang/cmu_us_kal16/cmu_us_kal16_lpc.c
 
-lang/cmu_us_kal16/libmimic_lang_cmu_us_kal16_la-cmu_us_kal16_res.lo: lang/cmu_us_kal16/cmu_us_kal16_res.c
-@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_lang_cmu_us_kal16_la_CFLAGS) $(CFLAGS) -MT lang/cmu_us_kal16/libmimic_lang_cmu_us_kal16_la-cmu_us_kal16_res.lo -MD -MP -MF lang/cmu_us_kal16/$(DEPDIR)/libmimic_lang_cmu_us_kal16_la-cmu_us_kal16_res.Tpo -c -o lang/cmu_us_kal16/libmimic_lang_cmu_us_kal16_la-cmu_us_kal16_res.lo `test -f 'lang/cmu_us_kal16/cmu_us_kal16_res.c' || echo '$(srcdir)/'`lang/cmu_us_kal16/cmu_us_kal16_res.c
-@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) lang/cmu_us_kal16/$(DEPDIR)/libmimic_lang_cmu_us_kal16_la-cmu_us_kal16_res.Tpo lang/cmu_us_kal16/$(DEPDIR)/libmimic_lang_cmu_us_kal16_la-cmu_us_kal16_res.Plo
-@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='lang/cmu_us_kal16/cmu_us_kal16_res.c' object='lang/cmu_us_kal16/libmimic_lang_cmu_us_kal16_la-cmu_us_kal16_res.lo' libtool=yes @AMDEPBACKSLASH@
+lang/cmu_us_kal16/libttsmimic_lang_cmu_us_kal16_la-cmu_us_kal16_res.lo: lang/cmu_us_kal16/cmu_us_kal16_res.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_lang_cmu_us_kal16_la_CFLAGS) $(CFLAGS) -MT lang/cmu_us_kal16/libttsmimic_lang_cmu_us_kal16_la-cmu_us_kal16_res.lo -MD -MP -MF lang/cmu_us_kal16/$(DEPDIR)/libttsmimic_lang_cmu_us_kal16_la-cmu_us_kal16_res.Tpo -c -o lang/cmu_us_kal16/libttsmimic_lang_cmu_us_kal16_la-cmu_us_kal16_res.lo `test -f 'lang/cmu_us_kal16/cmu_us_kal16_res.c' || echo '$(srcdir)/'`lang/cmu_us_kal16/cmu_us_kal16_res.c
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) lang/cmu_us_kal16/$(DEPDIR)/libttsmimic_lang_cmu_us_kal16_la-cmu_us_kal16_res.Tpo lang/cmu_us_kal16/$(DEPDIR)/libttsmimic_lang_cmu_us_kal16_la-cmu_us_kal16_res.Plo
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='lang/cmu_us_kal16/cmu_us_kal16_res.c' object='lang/cmu_us_kal16/libttsmimic_lang_cmu_us_kal16_la-cmu_us_kal16_res.lo' libtool=yes @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_lang_cmu_us_kal16_la_CFLAGS) $(CFLAGS) -c -o lang/cmu_us_kal16/libmimic_lang_cmu_us_kal16_la-cmu_us_kal16_res.lo `test -f 'lang/cmu_us_kal16/cmu_us_kal16_res.c' || echo '$(srcdir)/'`lang/cmu_us_kal16/cmu_us_kal16_res.c
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_lang_cmu_us_kal16_la_CFLAGS) $(CFLAGS) -c -o lang/cmu_us_kal16/libttsmimic_lang_cmu_us_kal16_la-cmu_us_kal16_res.lo `test -f 'lang/cmu_us_kal16/cmu_us_kal16_res.c' || echo '$(srcdir)/'`lang/cmu_us_kal16/cmu_us_kal16_res.c
 
-lang/cmu_us_kal16/libmimic_lang_cmu_us_kal16_la-cmu_us_kal16_residx.lo: lang/cmu_us_kal16/cmu_us_kal16_residx.c
-@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_lang_cmu_us_kal16_la_CFLAGS) $(CFLAGS) -MT lang/cmu_us_kal16/libmimic_lang_cmu_us_kal16_la-cmu_us_kal16_residx.lo -MD -MP -MF lang/cmu_us_kal16/$(DEPDIR)/libmimic_lang_cmu_us_kal16_la-cmu_us_kal16_residx.Tpo -c -o lang/cmu_us_kal16/libmimic_lang_cmu_us_kal16_la-cmu_us_kal16_residx.lo `test -f 'lang/cmu_us_kal16/cmu_us_kal16_residx.c' || echo '$(srcdir)/'`lang/cmu_us_kal16/cmu_us_kal16_residx.c
-@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) lang/cmu_us_kal16/$(DEPDIR)/libmimic_lang_cmu_us_kal16_la-cmu_us_kal16_residx.Tpo lang/cmu_us_kal16/$(DEPDIR)/libmimic_lang_cmu_us_kal16_la-cmu_us_kal16_residx.Plo
-@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='lang/cmu_us_kal16/cmu_us_kal16_residx.c' object='lang/cmu_us_kal16/libmimic_lang_cmu_us_kal16_la-cmu_us_kal16_residx.lo' libtool=yes @AMDEPBACKSLASH@
+lang/cmu_us_kal16/libttsmimic_lang_cmu_us_kal16_la-cmu_us_kal16_residx.lo: lang/cmu_us_kal16/cmu_us_kal16_residx.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_lang_cmu_us_kal16_la_CFLAGS) $(CFLAGS) -MT lang/cmu_us_kal16/libttsmimic_lang_cmu_us_kal16_la-cmu_us_kal16_residx.lo -MD -MP -MF lang/cmu_us_kal16/$(DEPDIR)/libttsmimic_lang_cmu_us_kal16_la-cmu_us_kal16_residx.Tpo -c -o lang/cmu_us_kal16/libttsmimic_lang_cmu_us_kal16_la-cmu_us_kal16_residx.lo `test -f 'lang/cmu_us_kal16/cmu_us_kal16_residx.c' || echo '$(srcdir)/'`lang/cmu_us_kal16/cmu_us_kal16_residx.c
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) lang/cmu_us_kal16/$(DEPDIR)/libttsmimic_lang_cmu_us_kal16_la-cmu_us_kal16_residx.Tpo lang/cmu_us_kal16/$(DEPDIR)/libttsmimic_lang_cmu_us_kal16_la-cmu_us_kal16_residx.Plo
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='lang/cmu_us_kal16/cmu_us_kal16_residx.c' object='lang/cmu_us_kal16/libttsmimic_lang_cmu_us_kal16_la-cmu_us_kal16_residx.lo' libtool=yes @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_lang_cmu_us_kal16_la_CFLAGS) $(CFLAGS) -c -o lang/cmu_us_kal16/libmimic_lang_cmu_us_kal16_la-cmu_us_kal16_residx.lo `test -f 'lang/cmu_us_kal16/cmu_us_kal16_residx.c' || echo '$(srcdir)/'`lang/cmu_us_kal16/cmu_us_kal16_residx.c
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_lang_cmu_us_kal16_la_CFLAGS) $(CFLAGS) -c -o lang/cmu_us_kal16/libttsmimic_lang_cmu_us_kal16_la-cmu_us_kal16_residx.lo `test -f 'lang/cmu_us_kal16/cmu_us_kal16_residx.c' || echo '$(srcdir)/'`lang/cmu_us_kal16/cmu_us_kal16_residx.c
 
-lang/cmu_us_rms/libmimic_lang_cmu_us_rms_la-cmu_us_rms.lo: lang/cmu_us_rms/cmu_us_rms.c
-@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_lang_cmu_us_rms_la_CFLAGS) $(CFLAGS) -MT lang/cmu_us_rms/libmimic_lang_cmu_us_rms_la-cmu_us_rms.lo -MD -MP -MF lang/cmu_us_rms/$(DEPDIR)/libmimic_lang_cmu_us_rms_la-cmu_us_rms.Tpo -c -o lang/cmu_us_rms/libmimic_lang_cmu_us_rms_la-cmu_us_rms.lo `test -f 'lang/cmu_us_rms/cmu_us_rms.c' || echo '$(srcdir)/'`lang/cmu_us_rms/cmu_us_rms.c
-@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) lang/cmu_us_rms/$(DEPDIR)/libmimic_lang_cmu_us_rms_la-cmu_us_rms.Tpo lang/cmu_us_rms/$(DEPDIR)/libmimic_lang_cmu_us_rms_la-cmu_us_rms.Plo
-@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='lang/cmu_us_rms/cmu_us_rms.c' object='lang/cmu_us_rms/libmimic_lang_cmu_us_rms_la-cmu_us_rms.lo' libtool=yes @AMDEPBACKSLASH@
+lang/cmu_us_rms/libttsmimic_lang_cmu_us_rms_la-cmu_us_rms.lo: lang/cmu_us_rms/cmu_us_rms.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_lang_cmu_us_rms_la_CFLAGS) $(CFLAGS) -MT lang/cmu_us_rms/libttsmimic_lang_cmu_us_rms_la-cmu_us_rms.lo -MD -MP -MF lang/cmu_us_rms/$(DEPDIR)/libttsmimic_lang_cmu_us_rms_la-cmu_us_rms.Tpo -c -o lang/cmu_us_rms/libttsmimic_lang_cmu_us_rms_la-cmu_us_rms.lo `test -f 'lang/cmu_us_rms/cmu_us_rms.c' || echo '$(srcdir)/'`lang/cmu_us_rms/cmu_us_rms.c
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) lang/cmu_us_rms/$(DEPDIR)/libttsmimic_lang_cmu_us_rms_la-cmu_us_rms.Tpo lang/cmu_us_rms/$(DEPDIR)/libttsmimic_lang_cmu_us_rms_la-cmu_us_rms.Plo
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='lang/cmu_us_rms/cmu_us_rms.c' object='lang/cmu_us_rms/libttsmimic_lang_cmu_us_rms_la-cmu_us_rms.lo' libtool=yes @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_lang_cmu_us_rms_la_CFLAGS) $(CFLAGS) -c -o lang/cmu_us_rms/libmimic_lang_cmu_us_rms_la-cmu_us_rms.lo `test -f 'lang/cmu_us_rms/cmu_us_rms.c' || echo '$(srcdir)/'`lang/cmu_us_rms/cmu_us_rms.c
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_lang_cmu_us_rms_la_CFLAGS) $(CFLAGS) -c -o lang/cmu_us_rms/libttsmimic_lang_cmu_us_rms_la-cmu_us_rms.lo `test -f 'lang/cmu_us_rms/cmu_us_rms.c' || echo '$(srcdir)/'`lang/cmu_us_rms/cmu_us_rms.c
 
-lang/cmu_us_rms/libmimic_lang_cmu_us_rms_la-cmu_us_rms_cg.lo: lang/cmu_us_rms/cmu_us_rms_cg.c
-@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_lang_cmu_us_rms_la_CFLAGS) $(CFLAGS) -MT lang/cmu_us_rms/libmimic_lang_cmu_us_rms_la-cmu_us_rms_cg.lo -MD -MP -MF lang/cmu_us_rms/$(DEPDIR)/libmimic_lang_cmu_us_rms_la-cmu_us_rms_cg.Tpo -c -o lang/cmu_us_rms/libmimic_lang_cmu_us_rms_la-cmu_us_rms_cg.lo `test -f 'lang/cmu_us_rms/cmu_us_rms_cg.c' || echo '$(srcdir)/'`lang/cmu_us_rms/cmu_us_rms_cg.c
-@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) lang/cmu_us_rms/$(DEPDIR)/libmimic_lang_cmu_us_rms_la-cmu_us_rms_cg.Tpo lang/cmu_us_rms/$(DEPDIR)/libmimic_lang_cmu_us_rms_la-cmu_us_rms_cg.Plo
-@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='lang/cmu_us_rms/cmu_us_rms_cg.c' object='lang/cmu_us_rms/libmimic_lang_cmu_us_rms_la-cmu_us_rms_cg.lo' libtool=yes @AMDEPBACKSLASH@
+lang/cmu_us_rms/libttsmimic_lang_cmu_us_rms_la-cmu_us_rms_cg.lo: lang/cmu_us_rms/cmu_us_rms_cg.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_lang_cmu_us_rms_la_CFLAGS) $(CFLAGS) -MT lang/cmu_us_rms/libttsmimic_lang_cmu_us_rms_la-cmu_us_rms_cg.lo -MD -MP -MF lang/cmu_us_rms/$(DEPDIR)/libttsmimic_lang_cmu_us_rms_la-cmu_us_rms_cg.Tpo -c -o lang/cmu_us_rms/libttsmimic_lang_cmu_us_rms_la-cmu_us_rms_cg.lo `test -f 'lang/cmu_us_rms/cmu_us_rms_cg.c' || echo '$(srcdir)/'`lang/cmu_us_rms/cmu_us_rms_cg.c
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) lang/cmu_us_rms/$(DEPDIR)/libttsmimic_lang_cmu_us_rms_la-cmu_us_rms_cg.Tpo lang/cmu_us_rms/$(DEPDIR)/libttsmimic_lang_cmu_us_rms_la-cmu_us_rms_cg.Plo
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='lang/cmu_us_rms/cmu_us_rms_cg.c' object='lang/cmu_us_rms/libttsmimic_lang_cmu_us_rms_la-cmu_us_rms_cg.lo' libtool=yes @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_lang_cmu_us_rms_la_CFLAGS) $(CFLAGS) -c -o lang/cmu_us_rms/libmimic_lang_cmu_us_rms_la-cmu_us_rms_cg.lo `test -f 'lang/cmu_us_rms/cmu_us_rms_cg.c' || echo '$(srcdir)/'`lang/cmu_us_rms/cmu_us_rms_cg.c
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_lang_cmu_us_rms_la_CFLAGS) $(CFLAGS) -c -o lang/cmu_us_rms/libttsmimic_lang_cmu_us_rms_la-cmu_us_rms_cg.lo `test -f 'lang/cmu_us_rms/cmu_us_rms_cg.c' || echo '$(srcdir)/'`lang/cmu_us_rms/cmu_us_rms_cg.c
 
-lang/cmu_us_rms/libmimic_lang_cmu_us_rms_la-cmu_us_rms_cg_durmodel.lo: lang/cmu_us_rms/cmu_us_rms_cg_durmodel.c
-@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_lang_cmu_us_rms_la_CFLAGS) $(CFLAGS) -MT lang/cmu_us_rms/libmimic_lang_cmu_us_rms_la-cmu_us_rms_cg_durmodel.lo -MD -MP -MF lang/cmu_us_rms/$(DEPDIR)/libmimic_lang_cmu_us_rms_la-cmu_us_rms_cg_durmodel.Tpo -c -o lang/cmu_us_rms/libmimic_lang_cmu_us_rms_la-cmu_us_rms_cg_durmodel.lo `test -f 'lang/cmu_us_rms/cmu_us_rms_cg_durmodel.c' || echo '$(srcdir)/'`lang/cmu_us_rms/cmu_us_rms_cg_durmodel.c
-@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) lang/cmu_us_rms/$(DEPDIR)/libmimic_lang_cmu_us_rms_la-cmu_us_rms_cg_durmodel.Tpo lang/cmu_us_rms/$(DEPDIR)/libmimic_lang_cmu_us_rms_la-cmu_us_rms_cg_durmodel.Plo
-@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='lang/cmu_us_rms/cmu_us_rms_cg_durmodel.c' object='lang/cmu_us_rms/libmimic_lang_cmu_us_rms_la-cmu_us_rms_cg_durmodel.lo' libtool=yes @AMDEPBACKSLASH@
+lang/cmu_us_rms/libttsmimic_lang_cmu_us_rms_la-cmu_us_rms_cg_durmodel.lo: lang/cmu_us_rms/cmu_us_rms_cg_durmodel.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_lang_cmu_us_rms_la_CFLAGS) $(CFLAGS) -MT lang/cmu_us_rms/libttsmimic_lang_cmu_us_rms_la-cmu_us_rms_cg_durmodel.lo -MD -MP -MF lang/cmu_us_rms/$(DEPDIR)/libttsmimic_lang_cmu_us_rms_la-cmu_us_rms_cg_durmodel.Tpo -c -o lang/cmu_us_rms/libttsmimic_lang_cmu_us_rms_la-cmu_us_rms_cg_durmodel.lo `test -f 'lang/cmu_us_rms/cmu_us_rms_cg_durmodel.c' || echo '$(srcdir)/'`lang/cmu_us_rms/cmu_us_rms_cg_durmodel.c
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) lang/cmu_us_rms/$(DEPDIR)/libttsmimic_lang_cmu_us_rms_la-cmu_us_rms_cg_durmodel.Tpo lang/cmu_us_rms/$(DEPDIR)/libttsmimic_lang_cmu_us_rms_la-cmu_us_rms_cg_durmodel.Plo
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='lang/cmu_us_rms/cmu_us_rms_cg_durmodel.c' object='lang/cmu_us_rms/libttsmimic_lang_cmu_us_rms_la-cmu_us_rms_cg_durmodel.lo' libtool=yes @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_lang_cmu_us_rms_la_CFLAGS) $(CFLAGS) -c -o lang/cmu_us_rms/libmimic_lang_cmu_us_rms_la-cmu_us_rms_cg_durmodel.lo `test -f 'lang/cmu_us_rms/cmu_us_rms_cg_durmodel.c' || echo '$(srcdir)/'`lang/cmu_us_rms/cmu_us_rms_cg_durmodel.c
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_lang_cmu_us_rms_la_CFLAGS) $(CFLAGS) -c -o lang/cmu_us_rms/libttsmimic_lang_cmu_us_rms_la-cmu_us_rms_cg_durmodel.lo `test -f 'lang/cmu_us_rms/cmu_us_rms_cg_durmodel.c' || echo '$(srcdir)/'`lang/cmu_us_rms/cmu_us_rms_cg_durmodel.c
 
-lang/cmu_us_rms/libmimic_lang_cmu_us_rms_la-cmu_us_rms_cg_f0_trees.lo: lang/cmu_us_rms/cmu_us_rms_cg_f0_trees.c
-@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_lang_cmu_us_rms_la_CFLAGS) $(CFLAGS) -MT lang/cmu_us_rms/libmimic_lang_cmu_us_rms_la-cmu_us_rms_cg_f0_trees.lo -MD -MP -MF lang/cmu_us_rms/$(DEPDIR)/libmimic_lang_cmu_us_rms_la-cmu_us_rms_cg_f0_trees.Tpo -c -o lang/cmu_us_rms/libmimic_lang_cmu_us_rms_la-cmu_us_rms_cg_f0_trees.lo `test -f 'lang/cmu_us_rms/cmu_us_rms_cg_f0_trees.c' || echo '$(srcdir)/'`lang/cmu_us_rms/cmu_us_rms_cg_f0_trees.c
-@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) lang/cmu_us_rms/$(DEPDIR)/libmimic_lang_cmu_us_rms_la-cmu_us_rms_cg_f0_trees.Tpo lang/cmu_us_rms/$(DEPDIR)/libmimic_lang_cmu_us_rms_la-cmu_us_rms_cg_f0_trees.Plo
-@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='lang/cmu_us_rms/cmu_us_rms_cg_f0_trees.c' object='lang/cmu_us_rms/libmimic_lang_cmu_us_rms_la-cmu_us_rms_cg_f0_trees.lo' libtool=yes @AMDEPBACKSLASH@
+lang/cmu_us_rms/libttsmimic_lang_cmu_us_rms_la-cmu_us_rms_cg_f0_trees.lo: lang/cmu_us_rms/cmu_us_rms_cg_f0_trees.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_lang_cmu_us_rms_la_CFLAGS) $(CFLAGS) -MT lang/cmu_us_rms/libttsmimic_lang_cmu_us_rms_la-cmu_us_rms_cg_f0_trees.lo -MD -MP -MF lang/cmu_us_rms/$(DEPDIR)/libttsmimic_lang_cmu_us_rms_la-cmu_us_rms_cg_f0_trees.Tpo -c -o lang/cmu_us_rms/libttsmimic_lang_cmu_us_rms_la-cmu_us_rms_cg_f0_trees.lo `test -f 'lang/cmu_us_rms/cmu_us_rms_cg_f0_trees.c' || echo '$(srcdir)/'`lang/cmu_us_rms/cmu_us_rms_cg_f0_trees.c
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) lang/cmu_us_rms/$(DEPDIR)/libttsmimic_lang_cmu_us_rms_la-cmu_us_rms_cg_f0_trees.Tpo lang/cmu_us_rms/$(DEPDIR)/libttsmimic_lang_cmu_us_rms_la-cmu_us_rms_cg_f0_trees.Plo
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='lang/cmu_us_rms/cmu_us_rms_cg_f0_trees.c' object='lang/cmu_us_rms/libttsmimic_lang_cmu_us_rms_la-cmu_us_rms_cg_f0_trees.lo' libtool=yes @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_lang_cmu_us_rms_la_CFLAGS) $(CFLAGS) -c -o lang/cmu_us_rms/libmimic_lang_cmu_us_rms_la-cmu_us_rms_cg_f0_trees.lo `test -f 'lang/cmu_us_rms/cmu_us_rms_cg_f0_trees.c' || echo '$(srcdir)/'`lang/cmu_us_rms/cmu_us_rms_cg_f0_trees.c
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_lang_cmu_us_rms_la_CFLAGS) $(CFLAGS) -c -o lang/cmu_us_rms/libttsmimic_lang_cmu_us_rms_la-cmu_us_rms_cg_f0_trees.lo `test -f 'lang/cmu_us_rms/cmu_us_rms_cg_f0_trees.c' || echo '$(srcdir)/'`lang/cmu_us_rms/cmu_us_rms_cg_f0_trees.c
 
-lang/cmu_us_rms/libmimic_lang_cmu_us_rms_la-cmu_us_rms_cg_phonestate.lo: lang/cmu_us_rms/cmu_us_rms_cg_phonestate.c
-@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_lang_cmu_us_rms_la_CFLAGS) $(CFLAGS) -MT lang/cmu_us_rms/libmimic_lang_cmu_us_rms_la-cmu_us_rms_cg_phonestate.lo -MD -MP -MF lang/cmu_us_rms/$(DEPDIR)/libmimic_lang_cmu_us_rms_la-cmu_us_rms_cg_phonestate.Tpo -c -o lang/cmu_us_rms/libmimic_lang_cmu_us_rms_la-cmu_us_rms_cg_phonestate.lo `test -f 'lang/cmu_us_rms/cmu_us_rms_cg_phonestate.c' || echo '$(srcdir)/'`lang/cmu_us_rms/cmu_us_rms_cg_phonestate.c
-@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) lang/cmu_us_rms/$(DEPDIR)/libmimic_lang_cmu_us_rms_la-cmu_us_rms_cg_phonestate.Tpo lang/cmu_us_rms/$(DEPDIR)/libmimic_lang_cmu_us_rms_la-cmu_us_rms_cg_phonestate.Plo
-@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='lang/cmu_us_rms/cmu_us_rms_cg_phonestate.c' object='lang/cmu_us_rms/libmimic_lang_cmu_us_rms_la-cmu_us_rms_cg_phonestate.lo' libtool=yes @AMDEPBACKSLASH@
+lang/cmu_us_rms/libttsmimic_lang_cmu_us_rms_la-cmu_us_rms_cg_phonestate.lo: lang/cmu_us_rms/cmu_us_rms_cg_phonestate.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_lang_cmu_us_rms_la_CFLAGS) $(CFLAGS) -MT lang/cmu_us_rms/libttsmimic_lang_cmu_us_rms_la-cmu_us_rms_cg_phonestate.lo -MD -MP -MF lang/cmu_us_rms/$(DEPDIR)/libttsmimic_lang_cmu_us_rms_la-cmu_us_rms_cg_phonestate.Tpo -c -o lang/cmu_us_rms/libttsmimic_lang_cmu_us_rms_la-cmu_us_rms_cg_phonestate.lo `test -f 'lang/cmu_us_rms/cmu_us_rms_cg_phonestate.c' || echo '$(srcdir)/'`lang/cmu_us_rms/cmu_us_rms_cg_phonestate.c
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) lang/cmu_us_rms/$(DEPDIR)/libttsmimic_lang_cmu_us_rms_la-cmu_us_rms_cg_phonestate.Tpo lang/cmu_us_rms/$(DEPDIR)/libttsmimic_lang_cmu_us_rms_la-cmu_us_rms_cg_phonestate.Plo
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='lang/cmu_us_rms/cmu_us_rms_cg_phonestate.c' object='lang/cmu_us_rms/libttsmimic_lang_cmu_us_rms_la-cmu_us_rms_cg_phonestate.lo' libtool=yes @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_lang_cmu_us_rms_la_CFLAGS) $(CFLAGS) -c -o lang/cmu_us_rms/libmimic_lang_cmu_us_rms_la-cmu_us_rms_cg_phonestate.lo `test -f 'lang/cmu_us_rms/cmu_us_rms_cg_phonestate.c' || echo '$(srcdir)/'`lang/cmu_us_rms/cmu_us_rms_cg_phonestate.c
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_lang_cmu_us_rms_la_CFLAGS) $(CFLAGS) -c -o lang/cmu_us_rms/libttsmimic_lang_cmu_us_rms_la-cmu_us_rms_cg_phonestate.lo `test -f 'lang/cmu_us_rms/cmu_us_rms_cg_phonestate.c' || echo '$(srcdir)/'`lang/cmu_us_rms/cmu_us_rms_cg_phonestate.c
 
-lang/cmu_us_rms/libmimic_lang_cmu_us_rms_la-cmu_us_rms_cg_single_mcep_trees.lo: lang/cmu_us_rms/cmu_us_rms_cg_single_mcep_trees.c
-@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_lang_cmu_us_rms_la_CFLAGS) $(CFLAGS) -MT lang/cmu_us_rms/libmimic_lang_cmu_us_rms_la-cmu_us_rms_cg_single_mcep_trees.lo -MD -MP -MF lang/cmu_us_rms/$(DEPDIR)/libmimic_lang_cmu_us_rms_la-cmu_us_rms_cg_single_mcep_trees.Tpo -c -o lang/cmu_us_rms/libmimic_lang_cmu_us_rms_la-cmu_us_rms_cg_single_mcep_trees.lo `test -f 'lang/cmu_us_rms/cmu_us_rms_cg_single_mcep_trees.c' || echo '$(srcdir)/'`lang/cmu_us_rms/cmu_us_rms_cg_single_mcep_trees.c
-@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) lang/cmu_us_rms/$(DEPDIR)/libmimic_lang_cmu_us_rms_la-cmu_us_rms_cg_single_mcep_trees.Tpo lang/cmu_us_rms/$(DEPDIR)/libmimic_lang_cmu_us_rms_la-cmu_us_rms_cg_single_mcep_trees.Plo
-@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='lang/cmu_us_rms/cmu_us_rms_cg_single_mcep_trees.c' object='lang/cmu_us_rms/libmimic_lang_cmu_us_rms_la-cmu_us_rms_cg_single_mcep_trees.lo' libtool=yes @AMDEPBACKSLASH@
+lang/cmu_us_rms/libttsmimic_lang_cmu_us_rms_la-cmu_us_rms_cg_single_mcep_trees.lo: lang/cmu_us_rms/cmu_us_rms_cg_single_mcep_trees.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_lang_cmu_us_rms_la_CFLAGS) $(CFLAGS) -MT lang/cmu_us_rms/libttsmimic_lang_cmu_us_rms_la-cmu_us_rms_cg_single_mcep_trees.lo -MD -MP -MF lang/cmu_us_rms/$(DEPDIR)/libttsmimic_lang_cmu_us_rms_la-cmu_us_rms_cg_single_mcep_trees.Tpo -c -o lang/cmu_us_rms/libttsmimic_lang_cmu_us_rms_la-cmu_us_rms_cg_single_mcep_trees.lo `test -f 'lang/cmu_us_rms/cmu_us_rms_cg_single_mcep_trees.c' || echo '$(srcdir)/'`lang/cmu_us_rms/cmu_us_rms_cg_single_mcep_trees.c
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) lang/cmu_us_rms/$(DEPDIR)/libttsmimic_lang_cmu_us_rms_la-cmu_us_rms_cg_single_mcep_trees.Tpo lang/cmu_us_rms/$(DEPDIR)/libttsmimic_lang_cmu_us_rms_la-cmu_us_rms_cg_single_mcep_trees.Plo
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='lang/cmu_us_rms/cmu_us_rms_cg_single_mcep_trees.c' object='lang/cmu_us_rms/libttsmimic_lang_cmu_us_rms_la-cmu_us_rms_cg_single_mcep_trees.lo' libtool=yes @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_lang_cmu_us_rms_la_CFLAGS) $(CFLAGS) -c -o lang/cmu_us_rms/libmimic_lang_cmu_us_rms_la-cmu_us_rms_cg_single_mcep_trees.lo `test -f 'lang/cmu_us_rms/cmu_us_rms_cg_single_mcep_trees.c' || echo '$(srcdir)/'`lang/cmu_us_rms/cmu_us_rms_cg_single_mcep_trees.c
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_lang_cmu_us_rms_la_CFLAGS) $(CFLAGS) -c -o lang/cmu_us_rms/libttsmimic_lang_cmu_us_rms_la-cmu_us_rms_cg_single_mcep_trees.lo `test -f 'lang/cmu_us_rms/cmu_us_rms_cg_single_mcep_trees.c' || echo '$(srcdir)/'`lang/cmu_us_rms/cmu_us_rms_cg_single_mcep_trees.c
 
-lang/cmu_us_rms/libmimic_lang_cmu_us_rms_la-cmu_us_rms_cg_single_params.lo: lang/cmu_us_rms/cmu_us_rms_cg_single_params.c
-@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_lang_cmu_us_rms_la_CFLAGS) $(CFLAGS) -MT lang/cmu_us_rms/libmimic_lang_cmu_us_rms_la-cmu_us_rms_cg_single_params.lo -MD -MP -MF lang/cmu_us_rms/$(DEPDIR)/libmimic_lang_cmu_us_rms_la-cmu_us_rms_cg_single_params.Tpo -c -o lang/cmu_us_rms/libmimic_lang_cmu_us_rms_la-cmu_us_rms_cg_single_params.lo `test -f 'lang/cmu_us_rms/cmu_us_rms_cg_single_params.c' || echo '$(srcdir)/'`lang/cmu_us_rms/cmu_us_rms_cg_single_params.c
-@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) lang/cmu_us_rms/$(DEPDIR)/libmimic_lang_cmu_us_rms_la-cmu_us_rms_cg_single_params.Tpo lang/cmu_us_rms/$(DEPDIR)/libmimic_lang_cmu_us_rms_la-cmu_us_rms_cg_single_params.Plo
-@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='lang/cmu_us_rms/cmu_us_rms_cg_single_params.c' object='lang/cmu_us_rms/libmimic_lang_cmu_us_rms_la-cmu_us_rms_cg_single_params.lo' libtool=yes @AMDEPBACKSLASH@
+lang/cmu_us_rms/libttsmimic_lang_cmu_us_rms_la-cmu_us_rms_cg_single_params.lo: lang/cmu_us_rms/cmu_us_rms_cg_single_params.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_lang_cmu_us_rms_la_CFLAGS) $(CFLAGS) -MT lang/cmu_us_rms/libttsmimic_lang_cmu_us_rms_la-cmu_us_rms_cg_single_params.lo -MD -MP -MF lang/cmu_us_rms/$(DEPDIR)/libttsmimic_lang_cmu_us_rms_la-cmu_us_rms_cg_single_params.Tpo -c -o lang/cmu_us_rms/libttsmimic_lang_cmu_us_rms_la-cmu_us_rms_cg_single_params.lo `test -f 'lang/cmu_us_rms/cmu_us_rms_cg_single_params.c' || echo '$(srcdir)/'`lang/cmu_us_rms/cmu_us_rms_cg_single_params.c
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) lang/cmu_us_rms/$(DEPDIR)/libttsmimic_lang_cmu_us_rms_la-cmu_us_rms_cg_single_params.Tpo lang/cmu_us_rms/$(DEPDIR)/libttsmimic_lang_cmu_us_rms_la-cmu_us_rms_cg_single_params.Plo
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='lang/cmu_us_rms/cmu_us_rms_cg_single_params.c' object='lang/cmu_us_rms/libttsmimic_lang_cmu_us_rms_la-cmu_us_rms_cg_single_params.lo' libtool=yes @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_lang_cmu_us_rms_la_CFLAGS) $(CFLAGS) -c -o lang/cmu_us_rms/libmimic_lang_cmu_us_rms_la-cmu_us_rms_cg_single_params.lo `test -f 'lang/cmu_us_rms/cmu_us_rms_cg_single_params.c' || echo '$(srcdir)/'`lang/cmu_us_rms/cmu_us_rms_cg_single_params.c
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_lang_cmu_us_rms_la_CFLAGS) $(CFLAGS) -c -o lang/cmu_us_rms/libttsmimic_lang_cmu_us_rms_la-cmu_us_rms_cg_single_params.lo `test -f 'lang/cmu_us_rms/cmu_us_rms_cg_single_params.c' || echo '$(srcdir)/'`lang/cmu_us_rms/cmu_us_rms_cg_single_params.c
 
-lang/cmu_us_rms/libmimic_lang_cmu_us_rms_la-cmu_us_rms_spamf0_accent.lo: lang/cmu_us_rms/cmu_us_rms_spamf0_accent.c
-@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_lang_cmu_us_rms_la_CFLAGS) $(CFLAGS) -MT lang/cmu_us_rms/libmimic_lang_cmu_us_rms_la-cmu_us_rms_spamf0_accent.lo -MD -MP -MF lang/cmu_us_rms/$(DEPDIR)/libmimic_lang_cmu_us_rms_la-cmu_us_rms_spamf0_accent.Tpo -c -o lang/cmu_us_rms/libmimic_lang_cmu_us_rms_la-cmu_us_rms_spamf0_accent.lo `test -f 'lang/cmu_us_rms/cmu_us_rms_spamf0_accent.c' || echo '$(srcdir)/'`lang/cmu_us_rms/cmu_us_rms_spamf0_accent.c
-@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) lang/cmu_us_rms/$(DEPDIR)/libmimic_lang_cmu_us_rms_la-cmu_us_rms_spamf0_accent.Tpo lang/cmu_us_rms/$(DEPDIR)/libmimic_lang_cmu_us_rms_la-cmu_us_rms_spamf0_accent.Plo
-@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='lang/cmu_us_rms/cmu_us_rms_spamf0_accent.c' object='lang/cmu_us_rms/libmimic_lang_cmu_us_rms_la-cmu_us_rms_spamf0_accent.lo' libtool=yes @AMDEPBACKSLASH@
+lang/cmu_us_rms/libttsmimic_lang_cmu_us_rms_la-cmu_us_rms_spamf0_accent.lo: lang/cmu_us_rms/cmu_us_rms_spamf0_accent.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_lang_cmu_us_rms_la_CFLAGS) $(CFLAGS) -MT lang/cmu_us_rms/libttsmimic_lang_cmu_us_rms_la-cmu_us_rms_spamf0_accent.lo -MD -MP -MF lang/cmu_us_rms/$(DEPDIR)/libttsmimic_lang_cmu_us_rms_la-cmu_us_rms_spamf0_accent.Tpo -c -o lang/cmu_us_rms/libttsmimic_lang_cmu_us_rms_la-cmu_us_rms_spamf0_accent.lo `test -f 'lang/cmu_us_rms/cmu_us_rms_spamf0_accent.c' || echo '$(srcdir)/'`lang/cmu_us_rms/cmu_us_rms_spamf0_accent.c
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) lang/cmu_us_rms/$(DEPDIR)/libttsmimic_lang_cmu_us_rms_la-cmu_us_rms_spamf0_accent.Tpo lang/cmu_us_rms/$(DEPDIR)/libttsmimic_lang_cmu_us_rms_la-cmu_us_rms_spamf0_accent.Plo
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='lang/cmu_us_rms/cmu_us_rms_spamf0_accent.c' object='lang/cmu_us_rms/libttsmimic_lang_cmu_us_rms_la-cmu_us_rms_spamf0_accent.lo' libtool=yes @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_lang_cmu_us_rms_la_CFLAGS) $(CFLAGS) -c -o lang/cmu_us_rms/libmimic_lang_cmu_us_rms_la-cmu_us_rms_spamf0_accent.lo `test -f 'lang/cmu_us_rms/cmu_us_rms_spamf0_accent.c' || echo '$(srcdir)/'`lang/cmu_us_rms/cmu_us_rms_spamf0_accent.c
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_lang_cmu_us_rms_la_CFLAGS) $(CFLAGS) -c -o lang/cmu_us_rms/libttsmimic_lang_cmu_us_rms_la-cmu_us_rms_spamf0_accent.lo `test -f 'lang/cmu_us_rms/cmu_us_rms_spamf0_accent.c' || echo '$(srcdir)/'`lang/cmu_us_rms/cmu_us_rms_spamf0_accent.c
 
-lang/cmu_us_rms/libmimic_lang_cmu_us_rms_la-cmu_us_rms_spamf0_accent_params.lo: lang/cmu_us_rms/cmu_us_rms_spamf0_accent_params.c
-@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_lang_cmu_us_rms_la_CFLAGS) $(CFLAGS) -MT lang/cmu_us_rms/libmimic_lang_cmu_us_rms_la-cmu_us_rms_spamf0_accent_params.lo -MD -MP -MF lang/cmu_us_rms/$(DEPDIR)/libmimic_lang_cmu_us_rms_la-cmu_us_rms_spamf0_accent_params.Tpo -c -o lang/cmu_us_rms/libmimic_lang_cmu_us_rms_la-cmu_us_rms_spamf0_accent_params.lo `test -f 'lang/cmu_us_rms/cmu_us_rms_spamf0_accent_params.c' || echo '$(srcdir)/'`lang/cmu_us_rms/cmu_us_rms_spamf0_accent_params.c
-@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) lang/cmu_us_rms/$(DEPDIR)/libmimic_lang_cmu_us_rms_la-cmu_us_rms_spamf0_accent_params.Tpo lang/cmu_us_rms/$(DEPDIR)/libmimic_lang_cmu_us_rms_la-cmu_us_rms_spamf0_accent_params.Plo
-@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='lang/cmu_us_rms/cmu_us_rms_spamf0_accent_params.c' object='lang/cmu_us_rms/libmimic_lang_cmu_us_rms_la-cmu_us_rms_spamf0_accent_params.lo' libtool=yes @AMDEPBACKSLASH@
+lang/cmu_us_rms/libttsmimic_lang_cmu_us_rms_la-cmu_us_rms_spamf0_accent_params.lo: lang/cmu_us_rms/cmu_us_rms_spamf0_accent_params.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_lang_cmu_us_rms_la_CFLAGS) $(CFLAGS) -MT lang/cmu_us_rms/libttsmimic_lang_cmu_us_rms_la-cmu_us_rms_spamf0_accent_params.lo -MD -MP -MF lang/cmu_us_rms/$(DEPDIR)/libttsmimic_lang_cmu_us_rms_la-cmu_us_rms_spamf0_accent_params.Tpo -c -o lang/cmu_us_rms/libttsmimic_lang_cmu_us_rms_la-cmu_us_rms_spamf0_accent_params.lo `test -f 'lang/cmu_us_rms/cmu_us_rms_spamf0_accent_params.c' || echo '$(srcdir)/'`lang/cmu_us_rms/cmu_us_rms_spamf0_accent_params.c
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) lang/cmu_us_rms/$(DEPDIR)/libttsmimic_lang_cmu_us_rms_la-cmu_us_rms_spamf0_accent_params.Tpo lang/cmu_us_rms/$(DEPDIR)/libttsmimic_lang_cmu_us_rms_la-cmu_us_rms_spamf0_accent_params.Plo
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='lang/cmu_us_rms/cmu_us_rms_spamf0_accent_params.c' object='lang/cmu_us_rms/libttsmimic_lang_cmu_us_rms_la-cmu_us_rms_spamf0_accent_params.lo' libtool=yes @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_lang_cmu_us_rms_la_CFLAGS) $(CFLAGS) -c -o lang/cmu_us_rms/libmimic_lang_cmu_us_rms_la-cmu_us_rms_spamf0_accent_params.lo `test -f 'lang/cmu_us_rms/cmu_us_rms_spamf0_accent_params.c' || echo '$(srcdir)/'`lang/cmu_us_rms/cmu_us_rms_spamf0_accent_params.c
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_lang_cmu_us_rms_la_CFLAGS) $(CFLAGS) -c -o lang/cmu_us_rms/libttsmimic_lang_cmu_us_rms_la-cmu_us_rms_spamf0_accent_params.lo `test -f 'lang/cmu_us_rms/cmu_us_rms_spamf0_accent_params.c' || echo '$(srcdir)/'`lang/cmu_us_rms/cmu_us_rms_spamf0_accent_params.c
 
-lang/cmu_us_rms/libmimic_lang_cmu_us_rms_la-cmu_us_rms_spamf0_phrase.lo: lang/cmu_us_rms/cmu_us_rms_spamf0_phrase.c
-@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_lang_cmu_us_rms_la_CFLAGS) $(CFLAGS) -MT lang/cmu_us_rms/libmimic_lang_cmu_us_rms_la-cmu_us_rms_spamf0_phrase.lo -MD -MP -MF lang/cmu_us_rms/$(DEPDIR)/libmimic_lang_cmu_us_rms_la-cmu_us_rms_spamf0_phrase.Tpo -c -o lang/cmu_us_rms/libmimic_lang_cmu_us_rms_la-cmu_us_rms_spamf0_phrase.lo `test -f 'lang/cmu_us_rms/cmu_us_rms_spamf0_phrase.c' || echo '$(srcdir)/'`lang/cmu_us_rms/cmu_us_rms_spamf0_phrase.c
-@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) lang/cmu_us_rms/$(DEPDIR)/libmimic_lang_cmu_us_rms_la-cmu_us_rms_spamf0_phrase.Tpo lang/cmu_us_rms/$(DEPDIR)/libmimic_lang_cmu_us_rms_la-cmu_us_rms_spamf0_phrase.Plo
-@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='lang/cmu_us_rms/cmu_us_rms_spamf0_phrase.c' object='lang/cmu_us_rms/libmimic_lang_cmu_us_rms_la-cmu_us_rms_spamf0_phrase.lo' libtool=yes @AMDEPBACKSLASH@
+lang/cmu_us_rms/libttsmimic_lang_cmu_us_rms_la-cmu_us_rms_spamf0_phrase.lo: lang/cmu_us_rms/cmu_us_rms_spamf0_phrase.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_lang_cmu_us_rms_la_CFLAGS) $(CFLAGS) -MT lang/cmu_us_rms/libttsmimic_lang_cmu_us_rms_la-cmu_us_rms_spamf0_phrase.lo -MD -MP -MF lang/cmu_us_rms/$(DEPDIR)/libttsmimic_lang_cmu_us_rms_la-cmu_us_rms_spamf0_phrase.Tpo -c -o lang/cmu_us_rms/libttsmimic_lang_cmu_us_rms_la-cmu_us_rms_spamf0_phrase.lo `test -f 'lang/cmu_us_rms/cmu_us_rms_spamf0_phrase.c' || echo '$(srcdir)/'`lang/cmu_us_rms/cmu_us_rms_spamf0_phrase.c
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) lang/cmu_us_rms/$(DEPDIR)/libttsmimic_lang_cmu_us_rms_la-cmu_us_rms_spamf0_phrase.Tpo lang/cmu_us_rms/$(DEPDIR)/libttsmimic_lang_cmu_us_rms_la-cmu_us_rms_spamf0_phrase.Plo
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='lang/cmu_us_rms/cmu_us_rms_spamf0_phrase.c' object='lang/cmu_us_rms/libttsmimic_lang_cmu_us_rms_la-cmu_us_rms_spamf0_phrase.lo' libtool=yes @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_lang_cmu_us_rms_la_CFLAGS) $(CFLAGS) -c -o lang/cmu_us_rms/libmimic_lang_cmu_us_rms_la-cmu_us_rms_spamf0_phrase.lo `test -f 'lang/cmu_us_rms/cmu_us_rms_spamf0_phrase.c' || echo '$(srcdir)/'`lang/cmu_us_rms/cmu_us_rms_spamf0_phrase.c
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_lang_cmu_us_rms_la_CFLAGS) $(CFLAGS) -c -o lang/cmu_us_rms/libttsmimic_lang_cmu_us_rms_la-cmu_us_rms_spamf0_phrase.lo `test -f 'lang/cmu_us_rms/cmu_us_rms_spamf0_phrase.c' || echo '$(srcdir)/'`lang/cmu_us_rms/cmu_us_rms_spamf0_phrase.c
 
-lang/cmu_us_slt/libmimic_lang_cmu_us_slt_la-cmu_us_slt.lo: lang/cmu_us_slt/cmu_us_slt.c
-@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_lang_cmu_us_slt_la_CFLAGS) $(CFLAGS) -MT lang/cmu_us_slt/libmimic_lang_cmu_us_slt_la-cmu_us_slt.lo -MD -MP -MF lang/cmu_us_slt/$(DEPDIR)/libmimic_lang_cmu_us_slt_la-cmu_us_slt.Tpo -c -o lang/cmu_us_slt/libmimic_lang_cmu_us_slt_la-cmu_us_slt.lo `test -f 'lang/cmu_us_slt/cmu_us_slt.c' || echo '$(srcdir)/'`lang/cmu_us_slt/cmu_us_slt.c
-@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) lang/cmu_us_slt/$(DEPDIR)/libmimic_lang_cmu_us_slt_la-cmu_us_slt.Tpo lang/cmu_us_slt/$(DEPDIR)/libmimic_lang_cmu_us_slt_la-cmu_us_slt.Plo
-@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='lang/cmu_us_slt/cmu_us_slt.c' object='lang/cmu_us_slt/libmimic_lang_cmu_us_slt_la-cmu_us_slt.lo' libtool=yes @AMDEPBACKSLASH@
+lang/cmu_us_slt/libttsmimic_lang_cmu_us_slt_la-cmu_us_slt.lo: lang/cmu_us_slt/cmu_us_slt.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_lang_cmu_us_slt_la_CFLAGS) $(CFLAGS) -MT lang/cmu_us_slt/libttsmimic_lang_cmu_us_slt_la-cmu_us_slt.lo -MD -MP -MF lang/cmu_us_slt/$(DEPDIR)/libttsmimic_lang_cmu_us_slt_la-cmu_us_slt.Tpo -c -o lang/cmu_us_slt/libttsmimic_lang_cmu_us_slt_la-cmu_us_slt.lo `test -f 'lang/cmu_us_slt/cmu_us_slt.c' || echo '$(srcdir)/'`lang/cmu_us_slt/cmu_us_slt.c
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) lang/cmu_us_slt/$(DEPDIR)/libttsmimic_lang_cmu_us_slt_la-cmu_us_slt.Tpo lang/cmu_us_slt/$(DEPDIR)/libttsmimic_lang_cmu_us_slt_la-cmu_us_slt.Plo
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='lang/cmu_us_slt/cmu_us_slt.c' object='lang/cmu_us_slt/libttsmimic_lang_cmu_us_slt_la-cmu_us_slt.lo' libtool=yes @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_lang_cmu_us_slt_la_CFLAGS) $(CFLAGS) -c -o lang/cmu_us_slt/libmimic_lang_cmu_us_slt_la-cmu_us_slt.lo `test -f 'lang/cmu_us_slt/cmu_us_slt.c' || echo '$(srcdir)/'`lang/cmu_us_slt/cmu_us_slt.c
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_lang_cmu_us_slt_la_CFLAGS) $(CFLAGS) -c -o lang/cmu_us_slt/libttsmimic_lang_cmu_us_slt_la-cmu_us_slt.lo `test -f 'lang/cmu_us_slt/cmu_us_slt.c' || echo '$(srcdir)/'`lang/cmu_us_slt/cmu_us_slt.c
 
-lang/cmu_us_slt/libmimic_lang_cmu_us_slt_la-cmu_us_slt_cg.lo: lang/cmu_us_slt/cmu_us_slt_cg.c
-@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_lang_cmu_us_slt_la_CFLAGS) $(CFLAGS) -MT lang/cmu_us_slt/libmimic_lang_cmu_us_slt_la-cmu_us_slt_cg.lo -MD -MP -MF lang/cmu_us_slt/$(DEPDIR)/libmimic_lang_cmu_us_slt_la-cmu_us_slt_cg.Tpo -c -o lang/cmu_us_slt/libmimic_lang_cmu_us_slt_la-cmu_us_slt_cg.lo `test -f 'lang/cmu_us_slt/cmu_us_slt_cg.c' || echo '$(srcdir)/'`lang/cmu_us_slt/cmu_us_slt_cg.c
-@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) lang/cmu_us_slt/$(DEPDIR)/libmimic_lang_cmu_us_slt_la-cmu_us_slt_cg.Tpo lang/cmu_us_slt/$(DEPDIR)/libmimic_lang_cmu_us_slt_la-cmu_us_slt_cg.Plo
-@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='lang/cmu_us_slt/cmu_us_slt_cg.c' object='lang/cmu_us_slt/libmimic_lang_cmu_us_slt_la-cmu_us_slt_cg.lo' libtool=yes @AMDEPBACKSLASH@
+lang/cmu_us_slt/libttsmimic_lang_cmu_us_slt_la-cmu_us_slt_cg.lo: lang/cmu_us_slt/cmu_us_slt_cg.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_lang_cmu_us_slt_la_CFLAGS) $(CFLAGS) -MT lang/cmu_us_slt/libttsmimic_lang_cmu_us_slt_la-cmu_us_slt_cg.lo -MD -MP -MF lang/cmu_us_slt/$(DEPDIR)/libttsmimic_lang_cmu_us_slt_la-cmu_us_slt_cg.Tpo -c -o lang/cmu_us_slt/libttsmimic_lang_cmu_us_slt_la-cmu_us_slt_cg.lo `test -f 'lang/cmu_us_slt/cmu_us_slt_cg.c' || echo '$(srcdir)/'`lang/cmu_us_slt/cmu_us_slt_cg.c
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) lang/cmu_us_slt/$(DEPDIR)/libttsmimic_lang_cmu_us_slt_la-cmu_us_slt_cg.Tpo lang/cmu_us_slt/$(DEPDIR)/libttsmimic_lang_cmu_us_slt_la-cmu_us_slt_cg.Plo
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='lang/cmu_us_slt/cmu_us_slt_cg.c' object='lang/cmu_us_slt/libttsmimic_lang_cmu_us_slt_la-cmu_us_slt_cg.lo' libtool=yes @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_lang_cmu_us_slt_la_CFLAGS) $(CFLAGS) -c -o lang/cmu_us_slt/libmimic_lang_cmu_us_slt_la-cmu_us_slt_cg.lo `test -f 'lang/cmu_us_slt/cmu_us_slt_cg.c' || echo '$(srcdir)/'`lang/cmu_us_slt/cmu_us_slt_cg.c
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_lang_cmu_us_slt_la_CFLAGS) $(CFLAGS) -c -o lang/cmu_us_slt/libttsmimic_lang_cmu_us_slt_la-cmu_us_slt_cg.lo `test -f 'lang/cmu_us_slt/cmu_us_slt_cg.c' || echo '$(srcdir)/'`lang/cmu_us_slt/cmu_us_slt_cg.c
 
-lang/cmu_us_slt/libmimic_lang_cmu_us_slt_la-cmu_us_slt_cg_durmodel.lo: lang/cmu_us_slt/cmu_us_slt_cg_durmodel.c
-@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_lang_cmu_us_slt_la_CFLAGS) $(CFLAGS) -MT lang/cmu_us_slt/libmimic_lang_cmu_us_slt_la-cmu_us_slt_cg_durmodel.lo -MD -MP -MF lang/cmu_us_slt/$(DEPDIR)/libmimic_lang_cmu_us_slt_la-cmu_us_slt_cg_durmodel.Tpo -c -o lang/cmu_us_slt/libmimic_lang_cmu_us_slt_la-cmu_us_slt_cg_durmodel.lo `test -f 'lang/cmu_us_slt/cmu_us_slt_cg_durmodel.c' || echo '$(srcdir)/'`lang/cmu_us_slt/cmu_us_slt_cg_durmodel.c
-@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) lang/cmu_us_slt/$(DEPDIR)/libmimic_lang_cmu_us_slt_la-cmu_us_slt_cg_durmodel.Tpo lang/cmu_us_slt/$(DEPDIR)/libmimic_lang_cmu_us_slt_la-cmu_us_slt_cg_durmodel.Plo
-@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='lang/cmu_us_slt/cmu_us_slt_cg_durmodel.c' object='lang/cmu_us_slt/libmimic_lang_cmu_us_slt_la-cmu_us_slt_cg_durmodel.lo' libtool=yes @AMDEPBACKSLASH@
+lang/cmu_us_slt/libttsmimic_lang_cmu_us_slt_la-cmu_us_slt_cg_durmodel.lo: lang/cmu_us_slt/cmu_us_slt_cg_durmodel.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_lang_cmu_us_slt_la_CFLAGS) $(CFLAGS) -MT lang/cmu_us_slt/libttsmimic_lang_cmu_us_slt_la-cmu_us_slt_cg_durmodel.lo -MD -MP -MF lang/cmu_us_slt/$(DEPDIR)/libttsmimic_lang_cmu_us_slt_la-cmu_us_slt_cg_durmodel.Tpo -c -o lang/cmu_us_slt/libttsmimic_lang_cmu_us_slt_la-cmu_us_slt_cg_durmodel.lo `test -f 'lang/cmu_us_slt/cmu_us_slt_cg_durmodel.c' || echo '$(srcdir)/'`lang/cmu_us_slt/cmu_us_slt_cg_durmodel.c
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) lang/cmu_us_slt/$(DEPDIR)/libttsmimic_lang_cmu_us_slt_la-cmu_us_slt_cg_durmodel.Tpo lang/cmu_us_slt/$(DEPDIR)/libttsmimic_lang_cmu_us_slt_la-cmu_us_slt_cg_durmodel.Plo
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='lang/cmu_us_slt/cmu_us_slt_cg_durmodel.c' object='lang/cmu_us_slt/libttsmimic_lang_cmu_us_slt_la-cmu_us_slt_cg_durmodel.lo' libtool=yes @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_lang_cmu_us_slt_la_CFLAGS) $(CFLAGS) -c -o lang/cmu_us_slt/libmimic_lang_cmu_us_slt_la-cmu_us_slt_cg_durmodel.lo `test -f 'lang/cmu_us_slt/cmu_us_slt_cg_durmodel.c' || echo '$(srcdir)/'`lang/cmu_us_slt/cmu_us_slt_cg_durmodel.c
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_lang_cmu_us_slt_la_CFLAGS) $(CFLAGS) -c -o lang/cmu_us_slt/libttsmimic_lang_cmu_us_slt_la-cmu_us_slt_cg_durmodel.lo `test -f 'lang/cmu_us_slt/cmu_us_slt_cg_durmodel.c' || echo '$(srcdir)/'`lang/cmu_us_slt/cmu_us_slt_cg_durmodel.c
 
-lang/cmu_us_slt/libmimic_lang_cmu_us_slt_la-cmu_us_slt_cg_f0_trees.lo: lang/cmu_us_slt/cmu_us_slt_cg_f0_trees.c
-@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_lang_cmu_us_slt_la_CFLAGS) $(CFLAGS) -MT lang/cmu_us_slt/libmimic_lang_cmu_us_slt_la-cmu_us_slt_cg_f0_trees.lo -MD -MP -MF lang/cmu_us_slt/$(DEPDIR)/libmimic_lang_cmu_us_slt_la-cmu_us_slt_cg_f0_trees.Tpo -c -o lang/cmu_us_slt/libmimic_lang_cmu_us_slt_la-cmu_us_slt_cg_f0_trees.lo `test -f 'lang/cmu_us_slt/cmu_us_slt_cg_f0_trees.c' || echo '$(srcdir)/'`lang/cmu_us_slt/cmu_us_slt_cg_f0_trees.c
-@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) lang/cmu_us_slt/$(DEPDIR)/libmimic_lang_cmu_us_slt_la-cmu_us_slt_cg_f0_trees.Tpo lang/cmu_us_slt/$(DEPDIR)/libmimic_lang_cmu_us_slt_la-cmu_us_slt_cg_f0_trees.Plo
-@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='lang/cmu_us_slt/cmu_us_slt_cg_f0_trees.c' object='lang/cmu_us_slt/libmimic_lang_cmu_us_slt_la-cmu_us_slt_cg_f0_trees.lo' libtool=yes @AMDEPBACKSLASH@
+lang/cmu_us_slt/libttsmimic_lang_cmu_us_slt_la-cmu_us_slt_cg_f0_trees.lo: lang/cmu_us_slt/cmu_us_slt_cg_f0_trees.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_lang_cmu_us_slt_la_CFLAGS) $(CFLAGS) -MT lang/cmu_us_slt/libttsmimic_lang_cmu_us_slt_la-cmu_us_slt_cg_f0_trees.lo -MD -MP -MF lang/cmu_us_slt/$(DEPDIR)/libttsmimic_lang_cmu_us_slt_la-cmu_us_slt_cg_f0_trees.Tpo -c -o lang/cmu_us_slt/libttsmimic_lang_cmu_us_slt_la-cmu_us_slt_cg_f0_trees.lo `test -f 'lang/cmu_us_slt/cmu_us_slt_cg_f0_trees.c' || echo '$(srcdir)/'`lang/cmu_us_slt/cmu_us_slt_cg_f0_trees.c
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) lang/cmu_us_slt/$(DEPDIR)/libttsmimic_lang_cmu_us_slt_la-cmu_us_slt_cg_f0_trees.Tpo lang/cmu_us_slt/$(DEPDIR)/libttsmimic_lang_cmu_us_slt_la-cmu_us_slt_cg_f0_trees.Plo
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='lang/cmu_us_slt/cmu_us_slt_cg_f0_trees.c' object='lang/cmu_us_slt/libttsmimic_lang_cmu_us_slt_la-cmu_us_slt_cg_f0_trees.lo' libtool=yes @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_lang_cmu_us_slt_la_CFLAGS) $(CFLAGS) -c -o lang/cmu_us_slt/libmimic_lang_cmu_us_slt_la-cmu_us_slt_cg_f0_trees.lo `test -f 'lang/cmu_us_slt/cmu_us_slt_cg_f0_trees.c' || echo '$(srcdir)/'`lang/cmu_us_slt/cmu_us_slt_cg_f0_trees.c
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_lang_cmu_us_slt_la_CFLAGS) $(CFLAGS) -c -o lang/cmu_us_slt/libttsmimic_lang_cmu_us_slt_la-cmu_us_slt_cg_f0_trees.lo `test -f 'lang/cmu_us_slt/cmu_us_slt_cg_f0_trees.c' || echo '$(srcdir)/'`lang/cmu_us_slt/cmu_us_slt_cg_f0_trees.c
 
-lang/cmu_us_slt/libmimic_lang_cmu_us_slt_la-cmu_us_slt_cg_phonestate.lo: lang/cmu_us_slt/cmu_us_slt_cg_phonestate.c
-@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_lang_cmu_us_slt_la_CFLAGS) $(CFLAGS) -MT lang/cmu_us_slt/libmimic_lang_cmu_us_slt_la-cmu_us_slt_cg_phonestate.lo -MD -MP -MF lang/cmu_us_slt/$(DEPDIR)/libmimic_lang_cmu_us_slt_la-cmu_us_slt_cg_phonestate.Tpo -c -o lang/cmu_us_slt/libmimic_lang_cmu_us_slt_la-cmu_us_slt_cg_phonestate.lo `test -f 'lang/cmu_us_slt/cmu_us_slt_cg_phonestate.c' || echo '$(srcdir)/'`lang/cmu_us_slt/cmu_us_slt_cg_phonestate.c
-@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) lang/cmu_us_slt/$(DEPDIR)/libmimic_lang_cmu_us_slt_la-cmu_us_slt_cg_phonestate.Tpo lang/cmu_us_slt/$(DEPDIR)/libmimic_lang_cmu_us_slt_la-cmu_us_slt_cg_phonestate.Plo
-@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='lang/cmu_us_slt/cmu_us_slt_cg_phonestate.c' object='lang/cmu_us_slt/libmimic_lang_cmu_us_slt_la-cmu_us_slt_cg_phonestate.lo' libtool=yes @AMDEPBACKSLASH@
+lang/cmu_us_slt/libttsmimic_lang_cmu_us_slt_la-cmu_us_slt_cg_phonestate.lo: lang/cmu_us_slt/cmu_us_slt_cg_phonestate.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_lang_cmu_us_slt_la_CFLAGS) $(CFLAGS) -MT lang/cmu_us_slt/libttsmimic_lang_cmu_us_slt_la-cmu_us_slt_cg_phonestate.lo -MD -MP -MF lang/cmu_us_slt/$(DEPDIR)/libttsmimic_lang_cmu_us_slt_la-cmu_us_slt_cg_phonestate.Tpo -c -o lang/cmu_us_slt/libttsmimic_lang_cmu_us_slt_la-cmu_us_slt_cg_phonestate.lo `test -f 'lang/cmu_us_slt/cmu_us_slt_cg_phonestate.c' || echo '$(srcdir)/'`lang/cmu_us_slt/cmu_us_slt_cg_phonestate.c
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) lang/cmu_us_slt/$(DEPDIR)/libttsmimic_lang_cmu_us_slt_la-cmu_us_slt_cg_phonestate.Tpo lang/cmu_us_slt/$(DEPDIR)/libttsmimic_lang_cmu_us_slt_la-cmu_us_slt_cg_phonestate.Plo
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='lang/cmu_us_slt/cmu_us_slt_cg_phonestate.c' object='lang/cmu_us_slt/libttsmimic_lang_cmu_us_slt_la-cmu_us_slt_cg_phonestate.lo' libtool=yes @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_lang_cmu_us_slt_la_CFLAGS) $(CFLAGS) -c -o lang/cmu_us_slt/libmimic_lang_cmu_us_slt_la-cmu_us_slt_cg_phonestate.lo `test -f 'lang/cmu_us_slt/cmu_us_slt_cg_phonestate.c' || echo '$(srcdir)/'`lang/cmu_us_slt/cmu_us_slt_cg_phonestate.c
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_lang_cmu_us_slt_la_CFLAGS) $(CFLAGS) -c -o lang/cmu_us_slt/libttsmimic_lang_cmu_us_slt_la-cmu_us_slt_cg_phonestate.lo `test -f 'lang/cmu_us_slt/cmu_us_slt_cg_phonestate.c' || echo '$(srcdir)/'`lang/cmu_us_slt/cmu_us_slt_cg_phonestate.c
 
-lang/cmu_us_slt/libmimic_lang_cmu_us_slt_la-cmu_us_slt_cg_single_mcep_trees.lo: lang/cmu_us_slt/cmu_us_slt_cg_single_mcep_trees.c
-@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_lang_cmu_us_slt_la_CFLAGS) $(CFLAGS) -MT lang/cmu_us_slt/libmimic_lang_cmu_us_slt_la-cmu_us_slt_cg_single_mcep_trees.lo -MD -MP -MF lang/cmu_us_slt/$(DEPDIR)/libmimic_lang_cmu_us_slt_la-cmu_us_slt_cg_single_mcep_trees.Tpo -c -o lang/cmu_us_slt/libmimic_lang_cmu_us_slt_la-cmu_us_slt_cg_single_mcep_trees.lo `test -f 'lang/cmu_us_slt/cmu_us_slt_cg_single_mcep_trees.c' || echo '$(srcdir)/'`lang/cmu_us_slt/cmu_us_slt_cg_single_mcep_trees.c
-@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) lang/cmu_us_slt/$(DEPDIR)/libmimic_lang_cmu_us_slt_la-cmu_us_slt_cg_single_mcep_trees.Tpo lang/cmu_us_slt/$(DEPDIR)/libmimic_lang_cmu_us_slt_la-cmu_us_slt_cg_single_mcep_trees.Plo
-@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='lang/cmu_us_slt/cmu_us_slt_cg_single_mcep_trees.c' object='lang/cmu_us_slt/libmimic_lang_cmu_us_slt_la-cmu_us_slt_cg_single_mcep_trees.lo' libtool=yes @AMDEPBACKSLASH@
+lang/cmu_us_slt/libttsmimic_lang_cmu_us_slt_la-cmu_us_slt_cg_single_mcep_trees.lo: lang/cmu_us_slt/cmu_us_slt_cg_single_mcep_trees.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_lang_cmu_us_slt_la_CFLAGS) $(CFLAGS) -MT lang/cmu_us_slt/libttsmimic_lang_cmu_us_slt_la-cmu_us_slt_cg_single_mcep_trees.lo -MD -MP -MF lang/cmu_us_slt/$(DEPDIR)/libttsmimic_lang_cmu_us_slt_la-cmu_us_slt_cg_single_mcep_trees.Tpo -c -o lang/cmu_us_slt/libttsmimic_lang_cmu_us_slt_la-cmu_us_slt_cg_single_mcep_trees.lo `test -f 'lang/cmu_us_slt/cmu_us_slt_cg_single_mcep_trees.c' || echo '$(srcdir)/'`lang/cmu_us_slt/cmu_us_slt_cg_single_mcep_trees.c
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) lang/cmu_us_slt/$(DEPDIR)/libttsmimic_lang_cmu_us_slt_la-cmu_us_slt_cg_single_mcep_trees.Tpo lang/cmu_us_slt/$(DEPDIR)/libttsmimic_lang_cmu_us_slt_la-cmu_us_slt_cg_single_mcep_trees.Plo
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='lang/cmu_us_slt/cmu_us_slt_cg_single_mcep_trees.c' object='lang/cmu_us_slt/libttsmimic_lang_cmu_us_slt_la-cmu_us_slt_cg_single_mcep_trees.lo' libtool=yes @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_lang_cmu_us_slt_la_CFLAGS) $(CFLAGS) -c -o lang/cmu_us_slt/libmimic_lang_cmu_us_slt_la-cmu_us_slt_cg_single_mcep_trees.lo `test -f 'lang/cmu_us_slt/cmu_us_slt_cg_single_mcep_trees.c' || echo '$(srcdir)/'`lang/cmu_us_slt/cmu_us_slt_cg_single_mcep_trees.c
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_lang_cmu_us_slt_la_CFLAGS) $(CFLAGS) -c -o lang/cmu_us_slt/libttsmimic_lang_cmu_us_slt_la-cmu_us_slt_cg_single_mcep_trees.lo `test -f 'lang/cmu_us_slt/cmu_us_slt_cg_single_mcep_trees.c' || echo '$(srcdir)/'`lang/cmu_us_slt/cmu_us_slt_cg_single_mcep_trees.c
 
-lang/cmu_us_slt/libmimic_lang_cmu_us_slt_la-cmu_us_slt_cg_single_params.lo: lang/cmu_us_slt/cmu_us_slt_cg_single_params.c
-@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_lang_cmu_us_slt_la_CFLAGS) $(CFLAGS) -MT lang/cmu_us_slt/libmimic_lang_cmu_us_slt_la-cmu_us_slt_cg_single_params.lo -MD -MP -MF lang/cmu_us_slt/$(DEPDIR)/libmimic_lang_cmu_us_slt_la-cmu_us_slt_cg_single_params.Tpo -c -o lang/cmu_us_slt/libmimic_lang_cmu_us_slt_la-cmu_us_slt_cg_single_params.lo `test -f 'lang/cmu_us_slt/cmu_us_slt_cg_single_params.c' || echo '$(srcdir)/'`lang/cmu_us_slt/cmu_us_slt_cg_single_params.c
-@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) lang/cmu_us_slt/$(DEPDIR)/libmimic_lang_cmu_us_slt_la-cmu_us_slt_cg_single_params.Tpo lang/cmu_us_slt/$(DEPDIR)/libmimic_lang_cmu_us_slt_la-cmu_us_slt_cg_single_params.Plo
-@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='lang/cmu_us_slt/cmu_us_slt_cg_single_params.c' object='lang/cmu_us_slt/libmimic_lang_cmu_us_slt_la-cmu_us_slt_cg_single_params.lo' libtool=yes @AMDEPBACKSLASH@
+lang/cmu_us_slt/libttsmimic_lang_cmu_us_slt_la-cmu_us_slt_cg_single_params.lo: lang/cmu_us_slt/cmu_us_slt_cg_single_params.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_lang_cmu_us_slt_la_CFLAGS) $(CFLAGS) -MT lang/cmu_us_slt/libttsmimic_lang_cmu_us_slt_la-cmu_us_slt_cg_single_params.lo -MD -MP -MF lang/cmu_us_slt/$(DEPDIR)/libttsmimic_lang_cmu_us_slt_la-cmu_us_slt_cg_single_params.Tpo -c -o lang/cmu_us_slt/libttsmimic_lang_cmu_us_slt_la-cmu_us_slt_cg_single_params.lo `test -f 'lang/cmu_us_slt/cmu_us_slt_cg_single_params.c' || echo '$(srcdir)/'`lang/cmu_us_slt/cmu_us_slt_cg_single_params.c
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) lang/cmu_us_slt/$(DEPDIR)/libttsmimic_lang_cmu_us_slt_la-cmu_us_slt_cg_single_params.Tpo lang/cmu_us_slt/$(DEPDIR)/libttsmimic_lang_cmu_us_slt_la-cmu_us_slt_cg_single_params.Plo
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='lang/cmu_us_slt/cmu_us_slt_cg_single_params.c' object='lang/cmu_us_slt/libttsmimic_lang_cmu_us_slt_la-cmu_us_slt_cg_single_params.lo' libtool=yes @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_lang_cmu_us_slt_la_CFLAGS) $(CFLAGS) -c -o lang/cmu_us_slt/libmimic_lang_cmu_us_slt_la-cmu_us_slt_cg_single_params.lo `test -f 'lang/cmu_us_slt/cmu_us_slt_cg_single_params.c' || echo '$(srcdir)/'`lang/cmu_us_slt/cmu_us_slt_cg_single_params.c
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_lang_cmu_us_slt_la_CFLAGS) $(CFLAGS) -c -o lang/cmu_us_slt/libttsmimic_lang_cmu_us_slt_la-cmu_us_slt_cg_single_params.lo `test -f 'lang/cmu_us_slt/cmu_us_slt_cg_single_params.c' || echo '$(srcdir)/'`lang/cmu_us_slt/cmu_us_slt_cg_single_params.c
 
-lang/cmu_us_slt/libmimic_lang_cmu_us_slt_la-cmu_us_slt_spamf0_accent.lo: lang/cmu_us_slt/cmu_us_slt_spamf0_accent.c
-@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_lang_cmu_us_slt_la_CFLAGS) $(CFLAGS) -MT lang/cmu_us_slt/libmimic_lang_cmu_us_slt_la-cmu_us_slt_spamf0_accent.lo -MD -MP -MF lang/cmu_us_slt/$(DEPDIR)/libmimic_lang_cmu_us_slt_la-cmu_us_slt_spamf0_accent.Tpo -c -o lang/cmu_us_slt/libmimic_lang_cmu_us_slt_la-cmu_us_slt_spamf0_accent.lo `test -f 'lang/cmu_us_slt/cmu_us_slt_spamf0_accent.c' || echo '$(srcdir)/'`lang/cmu_us_slt/cmu_us_slt_spamf0_accent.c
-@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) lang/cmu_us_slt/$(DEPDIR)/libmimic_lang_cmu_us_slt_la-cmu_us_slt_spamf0_accent.Tpo lang/cmu_us_slt/$(DEPDIR)/libmimic_lang_cmu_us_slt_la-cmu_us_slt_spamf0_accent.Plo
-@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='lang/cmu_us_slt/cmu_us_slt_spamf0_accent.c' object='lang/cmu_us_slt/libmimic_lang_cmu_us_slt_la-cmu_us_slt_spamf0_accent.lo' libtool=yes @AMDEPBACKSLASH@
+lang/cmu_us_slt/libttsmimic_lang_cmu_us_slt_la-cmu_us_slt_spamf0_accent.lo: lang/cmu_us_slt/cmu_us_slt_spamf0_accent.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_lang_cmu_us_slt_la_CFLAGS) $(CFLAGS) -MT lang/cmu_us_slt/libttsmimic_lang_cmu_us_slt_la-cmu_us_slt_spamf0_accent.lo -MD -MP -MF lang/cmu_us_slt/$(DEPDIR)/libttsmimic_lang_cmu_us_slt_la-cmu_us_slt_spamf0_accent.Tpo -c -o lang/cmu_us_slt/libttsmimic_lang_cmu_us_slt_la-cmu_us_slt_spamf0_accent.lo `test -f 'lang/cmu_us_slt/cmu_us_slt_spamf0_accent.c' || echo '$(srcdir)/'`lang/cmu_us_slt/cmu_us_slt_spamf0_accent.c
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) lang/cmu_us_slt/$(DEPDIR)/libttsmimic_lang_cmu_us_slt_la-cmu_us_slt_spamf0_accent.Tpo lang/cmu_us_slt/$(DEPDIR)/libttsmimic_lang_cmu_us_slt_la-cmu_us_slt_spamf0_accent.Plo
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='lang/cmu_us_slt/cmu_us_slt_spamf0_accent.c' object='lang/cmu_us_slt/libttsmimic_lang_cmu_us_slt_la-cmu_us_slt_spamf0_accent.lo' libtool=yes @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_lang_cmu_us_slt_la_CFLAGS) $(CFLAGS) -c -o lang/cmu_us_slt/libmimic_lang_cmu_us_slt_la-cmu_us_slt_spamf0_accent.lo `test -f 'lang/cmu_us_slt/cmu_us_slt_spamf0_accent.c' || echo '$(srcdir)/'`lang/cmu_us_slt/cmu_us_slt_spamf0_accent.c
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_lang_cmu_us_slt_la_CFLAGS) $(CFLAGS) -c -o lang/cmu_us_slt/libttsmimic_lang_cmu_us_slt_la-cmu_us_slt_spamf0_accent.lo `test -f 'lang/cmu_us_slt/cmu_us_slt_spamf0_accent.c' || echo '$(srcdir)/'`lang/cmu_us_slt/cmu_us_slt_spamf0_accent.c
 
-lang/cmu_us_slt/libmimic_lang_cmu_us_slt_la-cmu_us_slt_spamf0_accent_params.lo: lang/cmu_us_slt/cmu_us_slt_spamf0_accent_params.c
-@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_lang_cmu_us_slt_la_CFLAGS) $(CFLAGS) -MT lang/cmu_us_slt/libmimic_lang_cmu_us_slt_la-cmu_us_slt_spamf0_accent_params.lo -MD -MP -MF lang/cmu_us_slt/$(DEPDIR)/libmimic_lang_cmu_us_slt_la-cmu_us_slt_spamf0_accent_params.Tpo -c -o lang/cmu_us_slt/libmimic_lang_cmu_us_slt_la-cmu_us_slt_spamf0_accent_params.lo `test -f 'lang/cmu_us_slt/cmu_us_slt_spamf0_accent_params.c' || echo '$(srcdir)/'`lang/cmu_us_slt/cmu_us_slt_spamf0_accent_params.c
-@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) lang/cmu_us_slt/$(DEPDIR)/libmimic_lang_cmu_us_slt_la-cmu_us_slt_spamf0_accent_params.Tpo lang/cmu_us_slt/$(DEPDIR)/libmimic_lang_cmu_us_slt_la-cmu_us_slt_spamf0_accent_params.Plo
-@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='lang/cmu_us_slt/cmu_us_slt_spamf0_accent_params.c' object='lang/cmu_us_slt/libmimic_lang_cmu_us_slt_la-cmu_us_slt_spamf0_accent_params.lo' libtool=yes @AMDEPBACKSLASH@
+lang/cmu_us_slt/libttsmimic_lang_cmu_us_slt_la-cmu_us_slt_spamf0_accent_params.lo: lang/cmu_us_slt/cmu_us_slt_spamf0_accent_params.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_lang_cmu_us_slt_la_CFLAGS) $(CFLAGS) -MT lang/cmu_us_slt/libttsmimic_lang_cmu_us_slt_la-cmu_us_slt_spamf0_accent_params.lo -MD -MP -MF lang/cmu_us_slt/$(DEPDIR)/libttsmimic_lang_cmu_us_slt_la-cmu_us_slt_spamf0_accent_params.Tpo -c -o lang/cmu_us_slt/libttsmimic_lang_cmu_us_slt_la-cmu_us_slt_spamf0_accent_params.lo `test -f 'lang/cmu_us_slt/cmu_us_slt_spamf0_accent_params.c' || echo '$(srcdir)/'`lang/cmu_us_slt/cmu_us_slt_spamf0_accent_params.c
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) lang/cmu_us_slt/$(DEPDIR)/libttsmimic_lang_cmu_us_slt_la-cmu_us_slt_spamf0_accent_params.Tpo lang/cmu_us_slt/$(DEPDIR)/libttsmimic_lang_cmu_us_slt_la-cmu_us_slt_spamf0_accent_params.Plo
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='lang/cmu_us_slt/cmu_us_slt_spamf0_accent_params.c' object='lang/cmu_us_slt/libttsmimic_lang_cmu_us_slt_la-cmu_us_slt_spamf0_accent_params.lo' libtool=yes @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_lang_cmu_us_slt_la_CFLAGS) $(CFLAGS) -c -o lang/cmu_us_slt/libmimic_lang_cmu_us_slt_la-cmu_us_slt_spamf0_accent_params.lo `test -f 'lang/cmu_us_slt/cmu_us_slt_spamf0_accent_params.c' || echo '$(srcdir)/'`lang/cmu_us_slt/cmu_us_slt_spamf0_accent_params.c
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_lang_cmu_us_slt_la_CFLAGS) $(CFLAGS) -c -o lang/cmu_us_slt/libttsmimic_lang_cmu_us_slt_la-cmu_us_slt_spamf0_accent_params.lo `test -f 'lang/cmu_us_slt/cmu_us_slt_spamf0_accent_params.c' || echo '$(srcdir)/'`lang/cmu_us_slt/cmu_us_slt_spamf0_accent_params.c
 
-lang/cmu_us_slt/libmimic_lang_cmu_us_slt_la-cmu_us_slt_spamf0_phrase.lo: lang/cmu_us_slt/cmu_us_slt_spamf0_phrase.c
-@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_lang_cmu_us_slt_la_CFLAGS) $(CFLAGS) -MT lang/cmu_us_slt/libmimic_lang_cmu_us_slt_la-cmu_us_slt_spamf0_phrase.lo -MD -MP -MF lang/cmu_us_slt/$(DEPDIR)/libmimic_lang_cmu_us_slt_la-cmu_us_slt_spamf0_phrase.Tpo -c -o lang/cmu_us_slt/libmimic_lang_cmu_us_slt_la-cmu_us_slt_spamf0_phrase.lo `test -f 'lang/cmu_us_slt/cmu_us_slt_spamf0_phrase.c' || echo '$(srcdir)/'`lang/cmu_us_slt/cmu_us_slt_spamf0_phrase.c
-@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) lang/cmu_us_slt/$(DEPDIR)/libmimic_lang_cmu_us_slt_la-cmu_us_slt_spamf0_phrase.Tpo lang/cmu_us_slt/$(DEPDIR)/libmimic_lang_cmu_us_slt_la-cmu_us_slt_spamf0_phrase.Plo
-@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='lang/cmu_us_slt/cmu_us_slt_spamf0_phrase.c' object='lang/cmu_us_slt/libmimic_lang_cmu_us_slt_la-cmu_us_slt_spamf0_phrase.lo' libtool=yes @AMDEPBACKSLASH@
+lang/cmu_us_slt/libttsmimic_lang_cmu_us_slt_la-cmu_us_slt_spamf0_phrase.lo: lang/cmu_us_slt/cmu_us_slt_spamf0_phrase.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_lang_cmu_us_slt_la_CFLAGS) $(CFLAGS) -MT lang/cmu_us_slt/libttsmimic_lang_cmu_us_slt_la-cmu_us_slt_spamf0_phrase.lo -MD -MP -MF lang/cmu_us_slt/$(DEPDIR)/libttsmimic_lang_cmu_us_slt_la-cmu_us_slt_spamf0_phrase.Tpo -c -o lang/cmu_us_slt/libttsmimic_lang_cmu_us_slt_la-cmu_us_slt_spamf0_phrase.lo `test -f 'lang/cmu_us_slt/cmu_us_slt_spamf0_phrase.c' || echo '$(srcdir)/'`lang/cmu_us_slt/cmu_us_slt_spamf0_phrase.c
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) lang/cmu_us_slt/$(DEPDIR)/libttsmimic_lang_cmu_us_slt_la-cmu_us_slt_spamf0_phrase.Tpo lang/cmu_us_slt/$(DEPDIR)/libttsmimic_lang_cmu_us_slt_la-cmu_us_slt_spamf0_phrase.Plo
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='lang/cmu_us_slt/cmu_us_slt_spamf0_phrase.c' object='lang/cmu_us_slt/libttsmimic_lang_cmu_us_slt_la-cmu_us_slt_spamf0_phrase.lo' libtool=yes @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_lang_cmu_us_slt_la_CFLAGS) $(CFLAGS) -c -o lang/cmu_us_slt/libmimic_lang_cmu_us_slt_la-cmu_us_slt_spamf0_phrase.lo `test -f 'lang/cmu_us_slt/cmu_us_slt_spamf0_phrase.c' || echo '$(srcdir)/'`lang/cmu_us_slt/cmu_us_slt_spamf0_phrase.c
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_lang_cmu_us_slt_la_CFLAGS) $(CFLAGS) -c -o lang/cmu_us_slt/libttsmimic_lang_cmu_us_slt_la-cmu_us_slt_spamf0_phrase.lo `test -f 'lang/cmu_us_slt/cmu_us_slt_spamf0_phrase.c' || echo '$(srcdir)/'`lang/cmu_us_slt/cmu_us_slt_spamf0_phrase.c
 
-lang/vid_gb_ap/libmimic_lang_vid_gb_ap_la-vid_gb_ap.lo: lang/vid_gb_ap/vid_gb_ap.c
-@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_lang_vid_gb_ap_la_CFLAGS) $(CFLAGS) -MT lang/vid_gb_ap/libmimic_lang_vid_gb_ap_la-vid_gb_ap.lo -MD -MP -MF lang/vid_gb_ap/$(DEPDIR)/libmimic_lang_vid_gb_ap_la-vid_gb_ap.Tpo -c -o lang/vid_gb_ap/libmimic_lang_vid_gb_ap_la-vid_gb_ap.lo `test -f 'lang/vid_gb_ap/vid_gb_ap.c' || echo '$(srcdir)/'`lang/vid_gb_ap/vid_gb_ap.c
-@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) lang/vid_gb_ap/$(DEPDIR)/libmimic_lang_vid_gb_ap_la-vid_gb_ap.Tpo lang/vid_gb_ap/$(DEPDIR)/libmimic_lang_vid_gb_ap_la-vid_gb_ap.Plo
-@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='lang/vid_gb_ap/vid_gb_ap.c' object='lang/vid_gb_ap/libmimic_lang_vid_gb_ap_la-vid_gb_ap.lo' libtool=yes @AMDEPBACKSLASH@
+lang/vid_gb_ap/libttsmimic_lang_vid_gb_ap_la-vid_gb_ap.lo: lang/vid_gb_ap/vid_gb_ap.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_lang_vid_gb_ap_la_CFLAGS) $(CFLAGS) -MT lang/vid_gb_ap/libttsmimic_lang_vid_gb_ap_la-vid_gb_ap.lo -MD -MP -MF lang/vid_gb_ap/$(DEPDIR)/libttsmimic_lang_vid_gb_ap_la-vid_gb_ap.Tpo -c -o lang/vid_gb_ap/libttsmimic_lang_vid_gb_ap_la-vid_gb_ap.lo `test -f 'lang/vid_gb_ap/vid_gb_ap.c' || echo '$(srcdir)/'`lang/vid_gb_ap/vid_gb_ap.c
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) lang/vid_gb_ap/$(DEPDIR)/libttsmimic_lang_vid_gb_ap_la-vid_gb_ap.Tpo lang/vid_gb_ap/$(DEPDIR)/libttsmimic_lang_vid_gb_ap_la-vid_gb_ap.Plo
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='lang/vid_gb_ap/vid_gb_ap.c' object='lang/vid_gb_ap/libttsmimic_lang_vid_gb_ap_la-vid_gb_ap.lo' libtool=yes @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_lang_vid_gb_ap_la_CFLAGS) $(CFLAGS) -c -o lang/vid_gb_ap/libmimic_lang_vid_gb_ap_la-vid_gb_ap.lo `test -f 'lang/vid_gb_ap/vid_gb_ap.c' || echo '$(srcdir)/'`lang/vid_gb_ap/vid_gb_ap.c
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_lang_vid_gb_ap_la_CFLAGS) $(CFLAGS) -c -o lang/vid_gb_ap/libttsmimic_lang_vid_gb_ap_la-vid_gb_ap.lo `test -f 'lang/vid_gb_ap/vid_gb_ap.c' || echo '$(srcdir)/'`lang/vid_gb_ap/vid_gb_ap.c
 
-lang/vid_gb_ap/libmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_01_mcep_trees.lo: lang/vid_gb_ap/vid_gb_ap_cg_01_mcep_trees.c
-@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_lang_vid_gb_ap_la_CFLAGS) $(CFLAGS) -MT lang/vid_gb_ap/libmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_01_mcep_trees.lo -MD -MP -MF lang/vid_gb_ap/$(DEPDIR)/libmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_01_mcep_trees.Tpo -c -o lang/vid_gb_ap/libmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_01_mcep_trees.lo `test -f 'lang/vid_gb_ap/vid_gb_ap_cg_01_mcep_trees.c' || echo '$(srcdir)/'`lang/vid_gb_ap/vid_gb_ap_cg_01_mcep_trees.c
-@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) lang/vid_gb_ap/$(DEPDIR)/libmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_01_mcep_trees.Tpo lang/vid_gb_ap/$(DEPDIR)/libmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_01_mcep_trees.Plo
-@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='lang/vid_gb_ap/vid_gb_ap_cg_01_mcep_trees.c' object='lang/vid_gb_ap/libmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_01_mcep_trees.lo' libtool=yes @AMDEPBACKSLASH@
+lang/vid_gb_ap/libttsmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_01_mcep_trees.lo: lang/vid_gb_ap/vid_gb_ap_cg_01_mcep_trees.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_lang_vid_gb_ap_la_CFLAGS) $(CFLAGS) -MT lang/vid_gb_ap/libttsmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_01_mcep_trees.lo -MD -MP -MF lang/vid_gb_ap/$(DEPDIR)/libttsmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_01_mcep_trees.Tpo -c -o lang/vid_gb_ap/libttsmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_01_mcep_trees.lo `test -f 'lang/vid_gb_ap/vid_gb_ap_cg_01_mcep_trees.c' || echo '$(srcdir)/'`lang/vid_gb_ap/vid_gb_ap_cg_01_mcep_trees.c
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) lang/vid_gb_ap/$(DEPDIR)/libttsmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_01_mcep_trees.Tpo lang/vid_gb_ap/$(DEPDIR)/libttsmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_01_mcep_trees.Plo
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='lang/vid_gb_ap/vid_gb_ap_cg_01_mcep_trees.c' object='lang/vid_gb_ap/libttsmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_01_mcep_trees.lo' libtool=yes @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_lang_vid_gb_ap_la_CFLAGS) $(CFLAGS) -c -o lang/vid_gb_ap/libmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_01_mcep_trees.lo `test -f 'lang/vid_gb_ap/vid_gb_ap_cg_01_mcep_trees.c' || echo '$(srcdir)/'`lang/vid_gb_ap/vid_gb_ap_cg_01_mcep_trees.c
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_lang_vid_gb_ap_la_CFLAGS) $(CFLAGS) -c -o lang/vid_gb_ap/libttsmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_01_mcep_trees.lo `test -f 'lang/vid_gb_ap/vid_gb_ap_cg_01_mcep_trees.c' || echo '$(srcdir)/'`lang/vid_gb_ap/vid_gb_ap_cg_01_mcep_trees.c
 
-lang/vid_gb_ap/libmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_01_params.lo: lang/vid_gb_ap/vid_gb_ap_cg_01_params.c
-@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_lang_vid_gb_ap_la_CFLAGS) $(CFLAGS) -MT lang/vid_gb_ap/libmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_01_params.lo -MD -MP -MF lang/vid_gb_ap/$(DEPDIR)/libmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_01_params.Tpo -c -o lang/vid_gb_ap/libmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_01_params.lo `test -f 'lang/vid_gb_ap/vid_gb_ap_cg_01_params.c' || echo '$(srcdir)/'`lang/vid_gb_ap/vid_gb_ap_cg_01_params.c
-@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) lang/vid_gb_ap/$(DEPDIR)/libmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_01_params.Tpo lang/vid_gb_ap/$(DEPDIR)/libmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_01_params.Plo
-@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='lang/vid_gb_ap/vid_gb_ap_cg_01_params.c' object='lang/vid_gb_ap/libmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_01_params.lo' libtool=yes @AMDEPBACKSLASH@
+lang/vid_gb_ap/libttsmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_01_params.lo: lang/vid_gb_ap/vid_gb_ap_cg_01_params.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_lang_vid_gb_ap_la_CFLAGS) $(CFLAGS) -MT lang/vid_gb_ap/libttsmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_01_params.lo -MD -MP -MF lang/vid_gb_ap/$(DEPDIR)/libttsmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_01_params.Tpo -c -o lang/vid_gb_ap/libttsmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_01_params.lo `test -f 'lang/vid_gb_ap/vid_gb_ap_cg_01_params.c' || echo '$(srcdir)/'`lang/vid_gb_ap/vid_gb_ap_cg_01_params.c
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) lang/vid_gb_ap/$(DEPDIR)/libttsmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_01_params.Tpo lang/vid_gb_ap/$(DEPDIR)/libttsmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_01_params.Plo
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='lang/vid_gb_ap/vid_gb_ap_cg_01_params.c' object='lang/vid_gb_ap/libttsmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_01_params.lo' libtool=yes @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_lang_vid_gb_ap_la_CFLAGS) $(CFLAGS) -c -o lang/vid_gb_ap/libmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_01_params.lo `test -f 'lang/vid_gb_ap/vid_gb_ap_cg_01_params.c' || echo '$(srcdir)/'`lang/vid_gb_ap/vid_gb_ap_cg_01_params.c
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_lang_vid_gb_ap_la_CFLAGS) $(CFLAGS) -c -o lang/vid_gb_ap/libttsmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_01_params.lo `test -f 'lang/vid_gb_ap/vid_gb_ap_cg_01_params.c' || echo '$(srcdir)/'`lang/vid_gb_ap/vid_gb_ap_cg_01_params.c
 
-lang/vid_gb_ap/libmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_08_durmodel.lo: lang/vid_gb_ap/vid_gb_ap_cg_08_durmodel.c
-@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_lang_vid_gb_ap_la_CFLAGS) $(CFLAGS) -MT lang/vid_gb_ap/libmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_08_durmodel.lo -MD -MP -MF lang/vid_gb_ap/$(DEPDIR)/libmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_08_durmodel.Tpo -c -o lang/vid_gb_ap/libmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_08_durmodel.lo `test -f 'lang/vid_gb_ap/vid_gb_ap_cg_08_durmodel.c' || echo '$(srcdir)/'`lang/vid_gb_ap/vid_gb_ap_cg_08_durmodel.c
-@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) lang/vid_gb_ap/$(DEPDIR)/libmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_08_durmodel.Tpo lang/vid_gb_ap/$(DEPDIR)/libmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_08_durmodel.Plo
-@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='lang/vid_gb_ap/vid_gb_ap_cg_08_durmodel.c' object='lang/vid_gb_ap/libmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_08_durmodel.lo' libtool=yes @AMDEPBACKSLASH@
+lang/vid_gb_ap/libttsmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_08_durmodel.lo: lang/vid_gb_ap/vid_gb_ap_cg_08_durmodel.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_lang_vid_gb_ap_la_CFLAGS) $(CFLAGS) -MT lang/vid_gb_ap/libttsmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_08_durmodel.lo -MD -MP -MF lang/vid_gb_ap/$(DEPDIR)/libttsmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_08_durmodel.Tpo -c -o lang/vid_gb_ap/libttsmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_08_durmodel.lo `test -f 'lang/vid_gb_ap/vid_gb_ap_cg_08_durmodel.c' || echo '$(srcdir)/'`lang/vid_gb_ap/vid_gb_ap_cg_08_durmodel.c
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) lang/vid_gb_ap/$(DEPDIR)/libttsmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_08_durmodel.Tpo lang/vid_gb_ap/$(DEPDIR)/libttsmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_08_durmodel.Plo
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='lang/vid_gb_ap/vid_gb_ap_cg_08_durmodel.c' object='lang/vid_gb_ap/libttsmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_08_durmodel.lo' libtool=yes @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_lang_vid_gb_ap_la_CFLAGS) $(CFLAGS) -c -o lang/vid_gb_ap/libmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_08_durmodel.lo `test -f 'lang/vid_gb_ap/vid_gb_ap_cg_08_durmodel.c' || echo '$(srcdir)/'`lang/vid_gb_ap/vid_gb_ap_cg_08_durmodel.c
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_lang_vid_gb_ap_la_CFLAGS) $(CFLAGS) -c -o lang/vid_gb_ap/libttsmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_08_durmodel.lo `test -f 'lang/vid_gb_ap/vid_gb_ap_cg_08_durmodel.c' || echo '$(srcdir)/'`lang/vid_gb_ap/vid_gb_ap_cg_08_durmodel.c
 
-lang/vid_gb_ap/libmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_10_durmodel.lo: lang/vid_gb_ap/vid_gb_ap_cg_10_durmodel.c
-@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_lang_vid_gb_ap_la_CFLAGS) $(CFLAGS) -MT lang/vid_gb_ap/libmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_10_durmodel.lo -MD -MP -MF lang/vid_gb_ap/$(DEPDIR)/libmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_10_durmodel.Tpo -c -o lang/vid_gb_ap/libmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_10_durmodel.lo `test -f 'lang/vid_gb_ap/vid_gb_ap_cg_10_durmodel.c' || echo '$(srcdir)/'`lang/vid_gb_ap/vid_gb_ap_cg_10_durmodel.c
-@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) lang/vid_gb_ap/$(DEPDIR)/libmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_10_durmodel.Tpo lang/vid_gb_ap/$(DEPDIR)/libmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_10_durmodel.Plo
-@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='lang/vid_gb_ap/vid_gb_ap_cg_10_durmodel.c' object='lang/vid_gb_ap/libmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_10_durmodel.lo' libtool=yes @AMDEPBACKSLASH@
+lang/vid_gb_ap/libttsmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_10_durmodel.lo: lang/vid_gb_ap/vid_gb_ap_cg_10_durmodel.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_lang_vid_gb_ap_la_CFLAGS) $(CFLAGS) -MT lang/vid_gb_ap/libttsmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_10_durmodel.lo -MD -MP -MF lang/vid_gb_ap/$(DEPDIR)/libttsmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_10_durmodel.Tpo -c -o lang/vid_gb_ap/libttsmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_10_durmodel.lo `test -f 'lang/vid_gb_ap/vid_gb_ap_cg_10_durmodel.c' || echo '$(srcdir)/'`lang/vid_gb_ap/vid_gb_ap_cg_10_durmodel.c
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) lang/vid_gb_ap/$(DEPDIR)/libttsmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_10_durmodel.Tpo lang/vid_gb_ap/$(DEPDIR)/libttsmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_10_durmodel.Plo
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='lang/vid_gb_ap/vid_gb_ap_cg_10_durmodel.c' object='lang/vid_gb_ap/libttsmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_10_durmodel.lo' libtool=yes @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_lang_vid_gb_ap_la_CFLAGS) $(CFLAGS) -c -o lang/vid_gb_ap/libmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_10_durmodel.lo `test -f 'lang/vid_gb_ap/vid_gb_ap_cg_10_durmodel.c' || echo '$(srcdir)/'`lang/vid_gb_ap/vid_gb_ap_cg_10_durmodel.c
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_lang_vid_gb_ap_la_CFLAGS) $(CFLAGS) -c -o lang/vid_gb_ap/libttsmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_10_durmodel.lo `test -f 'lang/vid_gb_ap/vid_gb_ap_cg_10_durmodel.c' || echo '$(srcdir)/'`lang/vid_gb_ap/vid_gb_ap_cg_10_durmodel.c
 
-lang/vid_gb_ap/libmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_12_mcep_trees.lo: lang/vid_gb_ap/vid_gb_ap_cg_12_mcep_trees.c
-@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_lang_vid_gb_ap_la_CFLAGS) $(CFLAGS) -MT lang/vid_gb_ap/libmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_12_mcep_trees.lo -MD -MP -MF lang/vid_gb_ap/$(DEPDIR)/libmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_12_mcep_trees.Tpo -c -o lang/vid_gb_ap/libmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_12_mcep_trees.lo `test -f 'lang/vid_gb_ap/vid_gb_ap_cg_12_mcep_trees.c' || echo '$(srcdir)/'`lang/vid_gb_ap/vid_gb_ap_cg_12_mcep_trees.c
-@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) lang/vid_gb_ap/$(DEPDIR)/libmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_12_mcep_trees.Tpo lang/vid_gb_ap/$(DEPDIR)/libmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_12_mcep_trees.Plo
-@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='lang/vid_gb_ap/vid_gb_ap_cg_12_mcep_trees.c' object='lang/vid_gb_ap/libmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_12_mcep_trees.lo' libtool=yes @AMDEPBACKSLASH@
+lang/vid_gb_ap/libttsmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_12_mcep_trees.lo: lang/vid_gb_ap/vid_gb_ap_cg_12_mcep_trees.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_lang_vid_gb_ap_la_CFLAGS) $(CFLAGS) -MT lang/vid_gb_ap/libttsmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_12_mcep_trees.lo -MD -MP -MF lang/vid_gb_ap/$(DEPDIR)/libttsmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_12_mcep_trees.Tpo -c -o lang/vid_gb_ap/libttsmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_12_mcep_trees.lo `test -f 'lang/vid_gb_ap/vid_gb_ap_cg_12_mcep_trees.c' || echo '$(srcdir)/'`lang/vid_gb_ap/vid_gb_ap_cg_12_mcep_trees.c
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) lang/vid_gb_ap/$(DEPDIR)/libttsmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_12_mcep_trees.Tpo lang/vid_gb_ap/$(DEPDIR)/libttsmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_12_mcep_trees.Plo
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='lang/vid_gb_ap/vid_gb_ap_cg_12_mcep_trees.c' object='lang/vid_gb_ap/libttsmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_12_mcep_trees.lo' libtool=yes @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_lang_vid_gb_ap_la_CFLAGS) $(CFLAGS) -c -o lang/vid_gb_ap/libmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_12_mcep_trees.lo `test -f 'lang/vid_gb_ap/vid_gb_ap_cg_12_mcep_trees.c' || echo '$(srcdir)/'`lang/vid_gb_ap/vid_gb_ap_cg_12_mcep_trees.c
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_lang_vid_gb_ap_la_CFLAGS) $(CFLAGS) -c -o lang/vid_gb_ap/libttsmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_12_mcep_trees.lo `test -f 'lang/vid_gb_ap/vid_gb_ap_cg_12_mcep_trees.c' || echo '$(srcdir)/'`lang/vid_gb_ap/vid_gb_ap_cg_12_mcep_trees.c
 
-lang/vid_gb_ap/libmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_12_params.lo: lang/vid_gb_ap/vid_gb_ap_cg_12_params.c
-@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_lang_vid_gb_ap_la_CFLAGS) $(CFLAGS) -MT lang/vid_gb_ap/libmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_12_params.lo -MD -MP -MF lang/vid_gb_ap/$(DEPDIR)/libmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_12_params.Tpo -c -o lang/vid_gb_ap/libmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_12_params.lo `test -f 'lang/vid_gb_ap/vid_gb_ap_cg_12_params.c' || echo '$(srcdir)/'`lang/vid_gb_ap/vid_gb_ap_cg_12_params.c
-@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) lang/vid_gb_ap/$(DEPDIR)/libmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_12_params.Tpo lang/vid_gb_ap/$(DEPDIR)/libmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_12_params.Plo
-@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='lang/vid_gb_ap/vid_gb_ap_cg_12_params.c' object='lang/vid_gb_ap/libmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_12_params.lo' libtool=yes @AMDEPBACKSLASH@
+lang/vid_gb_ap/libttsmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_12_params.lo: lang/vid_gb_ap/vid_gb_ap_cg_12_params.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_lang_vid_gb_ap_la_CFLAGS) $(CFLAGS) -MT lang/vid_gb_ap/libttsmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_12_params.lo -MD -MP -MF lang/vid_gb_ap/$(DEPDIR)/libttsmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_12_params.Tpo -c -o lang/vid_gb_ap/libttsmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_12_params.lo `test -f 'lang/vid_gb_ap/vid_gb_ap_cg_12_params.c' || echo '$(srcdir)/'`lang/vid_gb_ap/vid_gb_ap_cg_12_params.c
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) lang/vid_gb_ap/$(DEPDIR)/libttsmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_12_params.Tpo lang/vid_gb_ap/$(DEPDIR)/libttsmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_12_params.Plo
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='lang/vid_gb_ap/vid_gb_ap_cg_12_params.c' object='lang/vid_gb_ap/libttsmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_12_params.lo' libtool=yes @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_lang_vid_gb_ap_la_CFLAGS) $(CFLAGS) -c -o lang/vid_gb_ap/libmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_12_params.lo `test -f 'lang/vid_gb_ap/vid_gb_ap_cg_12_params.c' || echo '$(srcdir)/'`lang/vid_gb_ap/vid_gb_ap_cg_12_params.c
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_lang_vid_gb_ap_la_CFLAGS) $(CFLAGS) -c -o lang/vid_gb_ap/libttsmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_12_params.lo `test -f 'lang/vid_gb_ap/vid_gb_ap_cg_12_params.c' || echo '$(srcdir)/'`lang/vid_gb_ap/vid_gb_ap_cg_12_params.c
 
-lang/vid_gb_ap/libmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_17_durmodel.lo: lang/vid_gb_ap/vid_gb_ap_cg_17_durmodel.c
-@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_lang_vid_gb_ap_la_CFLAGS) $(CFLAGS) -MT lang/vid_gb_ap/libmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_17_durmodel.lo -MD -MP -MF lang/vid_gb_ap/$(DEPDIR)/libmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_17_durmodel.Tpo -c -o lang/vid_gb_ap/libmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_17_durmodel.lo `test -f 'lang/vid_gb_ap/vid_gb_ap_cg_17_durmodel.c' || echo '$(srcdir)/'`lang/vid_gb_ap/vid_gb_ap_cg_17_durmodel.c
-@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) lang/vid_gb_ap/$(DEPDIR)/libmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_17_durmodel.Tpo lang/vid_gb_ap/$(DEPDIR)/libmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_17_durmodel.Plo
-@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='lang/vid_gb_ap/vid_gb_ap_cg_17_durmodel.c' object='lang/vid_gb_ap/libmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_17_durmodel.lo' libtool=yes @AMDEPBACKSLASH@
+lang/vid_gb_ap/libttsmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_17_durmodel.lo: lang/vid_gb_ap/vid_gb_ap_cg_17_durmodel.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_lang_vid_gb_ap_la_CFLAGS) $(CFLAGS) -MT lang/vid_gb_ap/libttsmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_17_durmodel.lo -MD -MP -MF lang/vid_gb_ap/$(DEPDIR)/libttsmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_17_durmodel.Tpo -c -o lang/vid_gb_ap/libttsmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_17_durmodel.lo `test -f 'lang/vid_gb_ap/vid_gb_ap_cg_17_durmodel.c' || echo '$(srcdir)/'`lang/vid_gb_ap/vid_gb_ap_cg_17_durmodel.c
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) lang/vid_gb_ap/$(DEPDIR)/libttsmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_17_durmodel.Tpo lang/vid_gb_ap/$(DEPDIR)/libttsmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_17_durmodel.Plo
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='lang/vid_gb_ap/vid_gb_ap_cg_17_durmodel.c' object='lang/vid_gb_ap/libttsmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_17_durmodel.lo' libtool=yes @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_lang_vid_gb_ap_la_CFLAGS) $(CFLAGS) -c -o lang/vid_gb_ap/libmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_17_durmodel.lo `test -f 'lang/vid_gb_ap/vid_gb_ap_cg_17_durmodel.c' || echo '$(srcdir)/'`lang/vid_gb_ap/vid_gb_ap_cg_17_durmodel.c
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_lang_vid_gb_ap_la_CFLAGS) $(CFLAGS) -c -o lang/vid_gb_ap/libttsmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_17_durmodel.lo `test -f 'lang/vid_gb_ap/vid_gb_ap_cg_17_durmodel.c' || echo '$(srcdir)/'`lang/vid_gb_ap/vid_gb_ap_cg_17_durmodel.c
 
-lang/vid_gb_ap/libmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_17_mcep_trees.lo: lang/vid_gb_ap/vid_gb_ap_cg_17_mcep_trees.c
-@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_lang_vid_gb_ap_la_CFLAGS) $(CFLAGS) -MT lang/vid_gb_ap/libmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_17_mcep_trees.lo -MD -MP -MF lang/vid_gb_ap/$(DEPDIR)/libmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_17_mcep_trees.Tpo -c -o lang/vid_gb_ap/libmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_17_mcep_trees.lo `test -f 'lang/vid_gb_ap/vid_gb_ap_cg_17_mcep_trees.c' || echo '$(srcdir)/'`lang/vid_gb_ap/vid_gb_ap_cg_17_mcep_trees.c
-@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) lang/vid_gb_ap/$(DEPDIR)/libmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_17_mcep_trees.Tpo lang/vid_gb_ap/$(DEPDIR)/libmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_17_mcep_trees.Plo
-@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='lang/vid_gb_ap/vid_gb_ap_cg_17_mcep_trees.c' object='lang/vid_gb_ap/libmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_17_mcep_trees.lo' libtool=yes @AMDEPBACKSLASH@
+lang/vid_gb_ap/libttsmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_17_mcep_trees.lo: lang/vid_gb_ap/vid_gb_ap_cg_17_mcep_trees.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_lang_vid_gb_ap_la_CFLAGS) $(CFLAGS) -MT lang/vid_gb_ap/libttsmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_17_mcep_trees.lo -MD -MP -MF lang/vid_gb_ap/$(DEPDIR)/libttsmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_17_mcep_trees.Tpo -c -o lang/vid_gb_ap/libttsmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_17_mcep_trees.lo `test -f 'lang/vid_gb_ap/vid_gb_ap_cg_17_mcep_trees.c' || echo '$(srcdir)/'`lang/vid_gb_ap/vid_gb_ap_cg_17_mcep_trees.c
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) lang/vid_gb_ap/$(DEPDIR)/libttsmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_17_mcep_trees.Tpo lang/vid_gb_ap/$(DEPDIR)/libttsmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_17_mcep_trees.Plo
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='lang/vid_gb_ap/vid_gb_ap_cg_17_mcep_trees.c' object='lang/vid_gb_ap/libttsmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_17_mcep_trees.lo' libtool=yes @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_lang_vid_gb_ap_la_CFLAGS) $(CFLAGS) -c -o lang/vid_gb_ap/libmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_17_mcep_trees.lo `test -f 'lang/vid_gb_ap/vid_gb_ap_cg_17_mcep_trees.c' || echo '$(srcdir)/'`lang/vid_gb_ap/vid_gb_ap_cg_17_mcep_trees.c
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_lang_vid_gb_ap_la_CFLAGS) $(CFLAGS) -c -o lang/vid_gb_ap/libttsmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_17_mcep_trees.lo `test -f 'lang/vid_gb_ap/vid_gb_ap_cg_17_mcep_trees.c' || echo '$(srcdir)/'`lang/vid_gb_ap/vid_gb_ap_cg_17_mcep_trees.c
 
-lang/vid_gb_ap/libmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_17_params.lo: lang/vid_gb_ap/vid_gb_ap_cg_17_params.c
-@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_lang_vid_gb_ap_la_CFLAGS) $(CFLAGS) -MT lang/vid_gb_ap/libmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_17_params.lo -MD -MP -MF lang/vid_gb_ap/$(DEPDIR)/libmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_17_params.Tpo -c -o lang/vid_gb_ap/libmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_17_params.lo `test -f 'lang/vid_gb_ap/vid_gb_ap_cg_17_params.c' || echo '$(srcdir)/'`lang/vid_gb_ap/vid_gb_ap_cg_17_params.c
-@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) lang/vid_gb_ap/$(DEPDIR)/libmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_17_params.Tpo lang/vid_gb_ap/$(DEPDIR)/libmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_17_params.Plo
-@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='lang/vid_gb_ap/vid_gb_ap_cg_17_params.c' object='lang/vid_gb_ap/libmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_17_params.lo' libtool=yes @AMDEPBACKSLASH@
+lang/vid_gb_ap/libttsmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_17_params.lo: lang/vid_gb_ap/vid_gb_ap_cg_17_params.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_lang_vid_gb_ap_la_CFLAGS) $(CFLAGS) -MT lang/vid_gb_ap/libttsmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_17_params.lo -MD -MP -MF lang/vid_gb_ap/$(DEPDIR)/libttsmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_17_params.Tpo -c -o lang/vid_gb_ap/libttsmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_17_params.lo `test -f 'lang/vid_gb_ap/vid_gb_ap_cg_17_params.c' || echo '$(srcdir)/'`lang/vid_gb_ap/vid_gb_ap_cg_17_params.c
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) lang/vid_gb_ap/$(DEPDIR)/libttsmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_17_params.Tpo lang/vid_gb_ap/$(DEPDIR)/libttsmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_17_params.Plo
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='lang/vid_gb_ap/vid_gb_ap_cg_17_params.c' object='lang/vid_gb_ap/libttsmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_17_params.lo' libtool=yes @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_lang_vid_gb_ap_la_CFLAGS) $(CFLAGS) -c -o lang/vid_gb_ap/libmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_17_params.lo `test -f 'lang/vid_gb_ap/vid_gb_ap_cg_17_params.c' || echo '$(srcdir)/'`lang/vid_gb_ap/vid_gb_ap_cg_17_params.c
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_lang_vid_gb_ap_la_CFLAGS) $(CFLAGS) -c -o lang/vid_gb_ap/libttsmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_17_params.lo `test -f 'lang/vid_gb_ap/vid_gb_ap_cg_17_params.c' || echo '$(srcdir)/'`lang/vid_gb_ap/vid_gb_ap_cg_17_params.c
 
-lang/vid_gb_ap/libmimic_lang_vid_gb_ap_la-vid_gb_ap_cg.lo: lang/vid_gb_ap/vid_gb_ap_cg.c
-@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_lang_vid_gb_ap_la_CFLAGS) $(CFLAGS) -MT lang/vid_gb_ap/libmimic_lang_vid_gb_ap_la-vid_gb_ap_cg.lo -MD -MP -MF lang/vid_gb_ap/$(DEPDIR)/libmimic_lang_vid_gb_ap_la-vid_gb_ap_cg.Tpo -c -o lang/vid_gb_ap/libmimic_lang_vid_gb_ap_la-vid_gb_ap_cg.lo `test -f 'lang/vid_gb_ap/vid_gb_ap_cg.c' || echo '$(srcdir)/'`lang/vid_gb_ap/vid_gb_ap_cg.c
-@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) lang/vid_gb_ap/$(DEPDIR)/libmimic_lang_vid_gb_ap_la-vid_gb_ap_cg.Tpo lang/vid_gb_ap/$(DEPDIR)/libmimic_lang_vid_gb_ap_la-vid_gb_ap_cg.Plo
-@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='lang/vid_gb_ap/vid_gb_ap_cg.c' object='lang/vid_gb_ap/libmimic_lang_vid_gb_ap_la-vid_gb_ap_cg.lo' libtool=yes @AMDEPBACKSLASH@
+lang/vid_gb_ap/libttsmimic_lang_vid_gb_ap_la-vid_gb_ap_cg.lo: lang/vid_gb_ap/vid_gb_ap_cg.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_lang_vid_gb_ap_la_CFLAGS) $(CFLAGS) -MT lang/vid_gb_ap/libttsmimic_lang_vid_gb_ap_la-vid_gb_ap_cg.lo -MD -MP -MF lang/vid_gb_ap/$(DEPDIR)/libttsmimic_lang_vid_gb_ap_la-vid_gb_ap_cg.Tpo -c -o lang/vid_gb_ap/libttsmimic_lang_vid_gb_ap_la-vid_gb_ap_cg.lo `test -f 'lang/vid_gb_ap/vid_gb_ap_cg.c' || echo '$(srcdir)/'`lang/vid_gb_ap/vid_gb_ap_cg.c
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) lang/vid_gb_ap/$(DEPDIR)/libttsmimic_lang_vid_gb_ap_la-vid_gb_ap_cg.Tpo lang/vid_gb_ap/$(DEPDIR)/libttsmimic_lang_vid_gb_ap_la-vid_gb_ap_cg.Plo
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='lang/vid_gb_ap/vid_gb_ap_cg.c' object='lang/vid_gb_ap/libttsmimic_lang_vid_gb_ap_la-vid_gb_ap_cg.lo' libtool=yes @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_lang_vid_gb_ap_la_CFLAGS) $(CFLAGS) -c -o lang/vid_gb_ap/libmimic_lang_vid_gb_ap_la-vid_gb_ap_cg.lo `test -f 'lang/vid_gb_ap/vid_gb_ap_cg.c' || echo '$(srcdir)/'`lang/vid_gb_ap/vid_gb_ap_cg.c
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_lang_vid_gb_ap_la_CFLAGS) $(CFLAGS) -c -o lang/vid_gb_ap/libttsmimic_lang_vid_gb_ap_la-vid_gb_ap_cg.lo `test -f 'lang/vid_gb_ap/vid_gb_ap_cg.c' || echo '$(srcdir)/'`lang/vid_gb_ap/vid_gb_ap_cg.c
 
-lang/vid_gb_ap/libmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_f0_trees.lo: lang/vid_gb_ap/vid_gb_ap_cg_f0_trees.c
-@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_lang_vid_gb_ap_la_CFLAGS) $(CFLAGS) -MT lang/vid_gb_ap/libmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_f0_trees.lo -MD -MP -MF lang/vid_gb_ap/$(DEPDIR)/libmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_f0_trees.Tpo -c -o lang/vid_gb_ap/libmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_f0_trees.lo `test -f 'lang/vid_gb_ap/vid_gb_ap_cg_f0_trees.c' || echo '$(srcdir)/'`lang/vid_gb_ap/vid_gb_ap_cg_f0_trees.c
-@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) lang/vid_gb_ap/$(DEPDIR)/libmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_f0_trees.Tpo lang/vid_gb_ap/$(DEPDIR)/libmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_f0_trees.Plo
-@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='lang/vid_gb_ap/vid_gb_ap_cg_f0_trees.c' object='lang/vid_gb_ap/libmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_f0_trees.lo' libtool=yes @AMDEPBACKSLASH@
+lang/vid_gb_ap/libttsmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_f0_trees.lo: lang/vid_gb_ap/vid_gb_ap_cg_f0_trees.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_lang_vid_gb_ap_la_CFLAGS) $(CFLAGS) -MT lang/vid_gb_ap/libttsmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_f0_trees.lo -MD -MP -MF lang/vid_gb_ap/$(DEPDIR)/libttsmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_f0_trees.Tpo -c -o lang/vid_gb_ap/libttsmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_f0_trees.lo `test -f 'lang/vid_gb_ap/vid_gb_ap_cg_f0_trees.c' || echo '$(srcdir)/'`lang/vid_gb_ap/vid_gb_ap_cg_f0_trees.c
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) lang/vid_gb_ap/$(DEPDIR)/libttsmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_f0_trees.Tpo lang/vid_gb_ap/$(DEPDIR)/libttsmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_f0_trees.Plo
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='lang/vid_gb_ap/vid_gb_ap_cg_f0_trees.c' object='lang/vid_gb_ap/libttsmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_f0_trees.lo' libtool=yes @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_lang_vid_gb_ap_la_CFLAGS) $(CFLAGS) -c -o lang/vid_gb_ap/libmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_f0_trees.lo `test -f 'lang/vid_gb_ap/vid_gb_ap_cg_f0_trees.c' || echo '$(srcdir)/'`lang/vid_gb_ap/vid_gb_ap_cg_f0_trees.c
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_lang_vid_gb_ap_la_CFLAGS) $(CFLAGS) -c -o lang/vid_gb_ap/libttsmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_f0_trees.lo `test -f 'lang/vid_gb_ap/vid_gb_ap_cg_f0_trees.c' || echo '$(srcdir)/'`lang/vid_gb_ap/vid_gb_ap_cg_f0_trees.c
 
-lang/vid_gb_ap/libmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_phonestate.lo: lang/vid_gb_ap/vid_gb_ap_cg_phonestate.c
-@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_lang_vid_gb_ap_la_CFLAGS) $(CFLAGS) -MT lang/vid_gb_ap/libmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_phonestate.lo -MD -MP -MF lang/vid_gb_ap/$(DEPDIR)/libmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_phonestate.Tpo -c -o lang/vid_gb_ap/libmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_phonestate.lo `test -f 'lang/vid_gb_ap/vid_gb_ap_cg_phonestate.c' || echo '$(srcdir)/'`lang/vid_gb_ap/vid_gb_ap_cg_phonestate.c
-@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) lang/vid_gb_ap/$(DEPDIR)/libmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_phonestate.Tpo lang/vid_gb_ap/$(DEPDIR)/libmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_phonestate.Plo
-@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='lang/vid_gb_ap/vid_gb_ap_cg_phonestate.c' object='lang/vid_gb_ap/libmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_phonestate.lo' libtool=yes @AMDEPBACKSLASH@
+lang/vid_gb_ap/libttsmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_phonestate.lo: lang/vid_gb_ap/vid_gb_ap_cg_phonestate.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_lang_vid_gb_ap_la_CFLAGS) $(CFLAGS) -MT lang/vid_gb_ap/libttsmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_phonestate.lo -MD -MP -MF lang/vid_gb_ap/$(DEPDIR)/libttsmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_phonestate.Tpo -c -o lang/vid_gb_ap/libttsmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_phonestate.lo `test -f 'lang/vid_gb_ap/vid_gb_ap_cg_phonestate.c' || echo '$(srcdir)/'`lang/vid_gb_ap/vid_gb_ap_cg_phonestate.c
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) lang/vid_gb_ap/$(DEPDIR)/libttsmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_phonestate.Tpo lang/vid_gb_ap/$(DEPDIR)/libttsmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_phonestate.Plo
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='lang/vid_gb_ap/vid_gb_ap_cg_phonestate.c' object='lang/vid_gb_ap/libttsmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_phonestate.lo' libtool=yes @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libmimic_lang_vid_gb_ap_la_CFLAGS) $(CFLAGS) -c -o lang/vid_gb_ap/libmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_phonestate.lo `test -f 'lang/vid_gb_ap/vid_gb_ap_cg_phonestate.c' || echo '$(srcdir)/'`lang/vid_gb_ap/vid_gb_ap_cg_phonestate.c
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libttsmimic_lang_vid_gb_ap_la_CFLAGS) $(CFLAGS) -c -o lang/vid_gb_ap/libttsmimic_lang_vid_gb_ap_la-vid_gb_ap_cg_phonestate.lo `test -f 'lang/vid_gb_ap/vid_gb_ap_cg_phonestate.c' || echo '$(srcdir)/'`lang/vid_gb_ap/vid_gb_ap_cg_phonestate.c
 
 testsuite/testsuite_multi_thread-multi_thread_main.o: testsuite/multi_thread_main.c
 @am__fastdepCC_TRUE@	$(AM_V_CC)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(testsuite_multi_thread_CFLAGS) $(CFLAGS) -MT testsuite/testsuite_multi_thread-multi_thread_main.o -MD -MP -MF testsuite/$(DEPDIR)/testsuite_multi_thread-multi_thread_main.Tpo -c -o testsuite/testsuite_multi_thread-multi_thread_main.o `test -f 'testsuite/multi_thread_main.c' || echo '$(srcdir)/'`testsuite/multi_thread_main.c

--- a/configure
+++ b/configure
@@ -12391,7 +12391,7 @@ done
 
 
 
-PKGCONFIG_MIMIC_CFLAGS="-I${includedir}/mimic -I${includedir}/mimic/lang"
+PKGCONFIG_MIMIC_CFLAGS="-I${includedir}/ttsmimic -I${includedir}/ttsmimic/lang"
 PKGCONFIG_MIMIC_LIBS="-L${libdir}"
 PKGCONFIG_MIMIC_DEPS=
 

--- a/configure
+++ b/configure
@@ -12919,7 +12919,7 @@ if test "x$enable_cmu_us_kal" != xno ; then :
 
 $as_echo "#define ENABLE_CMU_US_KAL 1" >>confdefs.h
 
-    PKGCONFIG_MIMIC_LIBS="${PKGCONFIG_MIMIC_LIBS} -lmimic_lang_cmu_us_kal"
+    PKGCONFIG_MIMIC_LIBS="${PKGCONFIG_MIMIC_LIBS} -lttsmimic_lang_cmu_us_kal"
 
 else
 
@@ -12939,7 +12939,7 @@ if test "x$enable_cmu_time_awb" != xno ; then :
 
 $as_echo "#define ENABLE_CMU_TIME_AWB 1" >>confdefs.h
 
-    PKGCONFIG_MIMIC_LIBS="${PKGCONFIG_MIMIC_LIBS} -lmimic_lang_cmu_time_awb"
+    PKGCONFIG_MIMIC_LIBS="${PKGCONFIG_MIMIC_LIBS} -lttsmimic_lang_cmu_time_awb"
 
 else
 
@@ -12959,7 +12959,7 @@ if test "x$enable_cmu_us_kal16" != xno ; then :
 
 $as_echo "#define ENABLE_CMU_US_KAL16 1" >>confdefs.h
 
-    PKGCONFIG_MIMIC_LIBS="${PKGCONFIG_MIMIC_LIBS} -lmimic_lang_cmu_us_kal16"
+    PKGCONFIG_MIMIC_LIBS="${PKGCONFIG_MIMIC_LIBS} -lttsmimic_lang_cmu_us_kal16"
 
 else
 
@@ -12979,7 +12979,7 @@ if test "x$enable_cmu_us_awb" != xno ; then :
 
 $as_echo "#define ENABLE_CMU_US_AWB 1" >>confdefs.h
 
-    PKGCONFIG_MIMIC_LIBS="${PKGCONFIG_MIMIC_LIBS} -lmimic_lang_cmu_us_awb"
+    PKGCONFIG_MIMIC_LIBS="${PKGCONFIG_MIMIC_LIBS} -lttsmimic_lang_cmu_us_awb"
 
 else
 
@@ -12999,7 +12999,7 @@ if test "x$enable_cmu_us_rms" != xno ; then :
 
 $as_echo "#define ENABLE_CMU_US_RMS 1" >>confdefs.h
 
-    PKGCONFIG_MIMIC_LIBS="${PKGCONFIG_MIMIC_LIBS} -lmimic_lang_cmu_us_rms"
+    PKGCONFIG_MIMIC_LIBS="${PKGCONFIG_MIMIC_LIBS} -lttsmimic_lang_cmu_us_rms"
 
 else
 
@@ -13019,7 +13019,7 @@ if test "x$enable_cmu_us_slt" != xno ; then :
 
 $as_echo "#define ENABLE_CMU_US_SLT 1" >>confdefs.h
 
-    PKGCONFIG_MIMIC_LIBS="${PKGCONFIG_MIMIC_LIBS} -lmimic_lang_cmu_us_slt"
+    PKGCONFIG_MIMIC_LIBS="${PKGCONFIG_MIMIC_LIBS} -lttsmimic_lang_cmu_us_slt"
 
 else
 
@@ -13039,7 +13039,7 @@ if test "x$enable_vid_gb_ap" != xno ; then :
 
 $as_echo "#define ENABLE_VID_GB_AP 1" >>confdefs.h
 
-    PKGCONFIG_MIMIC_LIBS="${PKGCONFIG_MIMIC_LIBS} -lmimic_lang_vid_gb_ap"
+    PKGCONFIG_MIMIC_LIBS="${PKGCONFIG_MIMIC_LIBS} -lttsmimic_lang_vid_gb_ap"
 
 else
 
@@ -13059,7 +13059,7 @@ if test "x$enable_cmulex" != xno ; then :
 
 $as_echo "#define ENABLE_CMULEX 1" >>confdefs.h
 
-    PKGCONFIG_MIMIC_LIBS="${PKGCONFIG_MIMIC_LIBS} -lmimic_lang_cmulex"
+    PKGCONFIG_MIMIC_LIBS="${PKGCONFIG_MIMIC_LIBS} -lttsmimic_lang_cmulex"
 
 else
 
@@ -13079,8 +13079,8 @@ if test "x$enable_indiclex" != xno ; then :
 
 $as_echo "#define ENABLE_INDICLEX 1" >>confdefs.h
 
-    PKGCONFIG_MIMIC_LIBS="${PKGCONFIG_MIMIC_LIBS} -lmimic_lang_cmu_indic_lex"
-    PKGCONFIG_MIMIC_LIBS="${PKGCONFIG_MIMIC_LIBS} -lmimic_lang_cmu_grapheme_lex"
+    PKGCONFIG_MIMIC_LIBS="${PKGCONFIG_MIMIC_LIBS} -lttsmimic_lang_cmu_indic_lex"
+    PKGCONFIG_MIMIC_LIBS="${PKGCONFIG_MIMIC_LIBS} -lttsmimic_lang_cmu_grapheme_lex"
 
 else
 
@@ -13100,8 +13100,8 @@ if test "x$enable_indic_analysis" != xno ; then :
 
 $as_echo "#define ENABLE_INDIC_ANALYSIS 1" >>confdefs.h
 
-    PKGCONFIG_MIMIC_LIBS="${PKGCONFIG_MIMIC_LIBS} -lmimic_lang_cmu_grapheme_lang"
-    PKGCONFIG_MIMIC_LIBS="${PKGCONFIG_MIMIC_LIBS} -lmimic_lang_cmu_indic_lang"
+    PKGCONFIG_MIMIC_LIBS="${PKGCONFIG_MIMIC_LIBS} -lttsmimic_lang_cmu_grapheme_lang"
+    PKGCONFIG_MIMIC_LIBS="${PKGCONFIG_MIMIC_LIBS} -lttsmimic_lang_cmu_indic_lang"
 
 else
 
@@ -13121,7 +13121,7 @@ if test "x$enable_usenglish" != xno ; then :
 
 $as_echo "#define ENABLE_USENGLISH 1" >>confdefs.h
 
-    PKGCONFIG_MIMIC_LIBS="${PKGCONFIG_MIMIC_LIBS} -lmimic_lang_usenglish"
+    PKGCONFIG_MIMIC_LIBS="${PKGCONFIG_MIMIC_LIBS} -lttsmimic_lang_usenglish"
 else
 
 $as_echo "#define ENABLE_USENGLISH 0" >>confdefs.h
@@ -13129,7 +13129,7 @@ $as_echo "#define ENABLE_USENGLISH 0" >>confdefs.h
 fi
 
 
-PKGCONFIG_MIMIC_LIBS="${PKGCONFIG_MIMIC_LIBS} -lmimic_lang_all_langs -lmimic_lang_all_voices -lmimic"
+PKGCONFIG_MIMIC_LIBS="${PKGCONFIG_MIMIC_LIBS} -lttsmimic_lang_all_langs -lttsmimic_lang_all_voices -lttsmimic"
 
 
 

--- a/configure.ac
+++ b/configure.ac
@@ -357,64 +357,64 @@ dnl lexicons then languages and we append the lib required on each case.
 AM_CONDITIONAL([VOICE_CMU_US_KAL], [test "x$enable_cmu_us_kal" != xno])
 AS_IF([test "x$enable_cmu_us_kal" != xno ],
   [ AC_DEFINE([ENABLE_CMU_US_KAL], [1], [Enable cmu_us_kal voice])
-    PKGCONFIG_MIMIC_LIBS="${PKGCONFIG_MIMIC_LIBS} -lmimic_lang_cmu_us_kal"
+    PKGCONFIG_MIMIC_LIBS="${PKGCONFIG_MIMIC_LIBS} -lttsmimic_lang_cmu_us_kal"
   ],
   [ AC_DEFINE([ENABLE_CMU_US_KAL], [0], [Enable cmu_us_kal voice]) ])
 
 AM_CONDITIONAL([VOICE_CMU_TIME_AWB], [test "x$enable_cmu_time_awb" != xno])
 AS_IF([test "x$enable_cmu_time_awb" != xno ],
   [ AC_DEFINE([ENABLE_CMU_TIME_AWB], [1], [Enable cmu_time_awb voice])
-    PKGCONFIG_MIMIC_LIBS="${PKGCONFIG_MIMIC_LIBS} -lmimic_lang_cmu_time_awb"
+    PKGCONFIG_MIMIC_LIBS="${PKGCONFIG_MIMIC_LIBS} -lttsmimic_lang_cmu_time_awb"
   ],
   [ AC_DEFINE([ENABLE_CMU_TIME_AWB], [0], [Enable cmu_time_awb voice]) ])
 
 AM_CONDITIONAL([VOICE_CMU_US_KAL16], [test "x$enable_cmu_us_kal16" != xno])
 AS_IF([test "x$enable_cmu_us_kal16" != xno ],
   [ AC_DEFINE([ENABLE_CMU_US_KAL16], [1], [Enable cmu_us_kal16 voice])
-    PKGCONFIG_MIMIC_LIBS="${PKGCONFIG_MIMIC_LIBS} -lmimic_lang_cmu_us_kal16"
+    PKGCONFIG_MIMIC_LIBS="${PKGCONFIG_MIMIC_LIBS} -lttsmimic_lang_cmu_us_kal16"
   ],
   [ AC_DEFINE([ENABLE_CMU_US_KAL16], [0], [Enable cmu_us_kal16 voice]) ])
 
 AM_CONDITIONAL([VOICE_CMU_US_AWB], [test "x$enable_cmu_us_awb" != xno])
 AS_IF([test "x$enable_cmu_us_awb" != xno ],
   [ AC_DEFINE([ENABLE_CMU_US_AWB], [1], [Enable cmu_us_awb voice]) 
-    PKGCONFIG_MIMIC_LIBS="${PKGCONFIG_MIMIC_LIBS} -lmimic_lang_cmu_us_awb"
+    PKGCONFIG_MIMIC_LIBS="${PKGCONFIG_MIMIC_LIBS} -lttsmimic_lang_cmu_us_awb"
   ],
   [ AC_DEFINE([ENABLE_CMU_US_AWB], [0], [Enable cmu_us_awb voice]) ])
 
 AM_CONDITIONAL([VOICE_CMU_US_RMS], [test "x$enable_cmu_us_rms" != xno])
 AS_IF([test "x$enable_cmu_us_rms" != xno ],
   [ AC_DEFINE([ENABLE_CMU_US_RMS], [1], [Enable cmu_us_rms voice]) 
-    PKGCONFIG_MIMIC_LIBS="${PKGCONFIG_MIMIC_LIBS} -lmimic_lang_cmu_us_rms"
+    PKGCONFIG_MIMIC_LIBS="${PKGCONFIG_MIMIC_LIBS} -lttsmimic_lang_cmu_us_rms"
   ],
   [ AC_DEFINE([ENABLE_CMU_US_RMS], [0], [Enable cmu_us_rms voice]) ])
 
 AM_CONDITIONAL([VOICE_CMU_US_SLT], [test "x$enable_cmu_us_slt" != xno])
 AS_IF([test "x$enable_cmu_us_slt" != xno ],
   [ AC_DEFINE([ENABLE_CMU_US_SLT], [1], [Enable cmu_us_slt voice])
-    PKGCONFIG_MIMIC_LIBS="${PKGCONFIG_MIMIC_LIBS} -lmimic_lang_cmu_us_slt"
+    PKGCONFIG_MIMIC_LIBS="${PKGCONFIG_MIMIC_LIBS} -lttsmimic_lang_cmu_us_slt"
   ],
   [ AC_DEFINE([ENABLE_CMU_US_SLT], [0], [Enable cmu_us_slt voice]) ])
 
 AM_CONDITIONAL([VOICE_VID_GB_AP], [test "x$enable_vid_gb_ap" != xno])
 AS_IF([test "x$enable_vid_gb_ap" != xno ],
   [ AC_DEFINE([ENABLE_VID_GB_AP], [1], [Enable vid_gb_ap voice])
-    PKGCONFIG_MIMIC_LIBS="${PKGCONFIG_MIMIC_LIBS} -lmimic_lang_vid_gb_ap"
+    PKGCONFIG_MIMIC_LIBS="${PKGCONFIG_MIMIC_LIBS} -lttsmimic_lang_vid_gb_ap"
   ],
   [ AC_DEFINE([ENABLE_VID_GB_AP], [0], [Enable vid_gb_ap voice]) ])
 
 AM_CONDITIONAL([LEX_CMULEX], [test "x$enable_cmulex" != xno])
 AS_IF([test "x$enable_cmulex" != xno ],
   [ AC_DEFINE([ENABLE_CMULEX], [1], [Enable CMU US English lexicon])
-    PKGCONFIG_MIMIC_LIBS="${PKGCONFIG_MIMIC_LIBS} -lmimic_lang_cmulex"
+    PKGCONFIG_MIMIC_LIBS="${PKGCONFIG_MIMIC_LIBS} -lttsmimic_lang_cmulex"
   ],
   [ AC_DEFINE([ENABLE_CMULEX], [0], [Enable CMU US English lexicon]) ])
 
 AM_CONDITIONAL([LEX_INDIC], [test "x$enable_indiclex" != xno])
 AS_IF([test "x$enable_indiclex" != xno ],
   [ AC_DEFINE([ENABLE_INDICLEX], [1], [Enable Indic lexicon])
-    PKGCONFIG_MIMIC_LIBS="${PKGCONFIG_MIMIC_LIBS} -lmimic_lang_cmu_indic_lex"
-    PKGCONFIG_MIMIC_LIBS="${PKGCONFIG_MIMIC_LIBS} -lmimic_lang_cmu_grapheme_lex"
+    PKGCONFIG_MIMIC_LIBS="${PKGCONFIG_MIMIC_LIBS} -lttsmimic_lang_cmu_indic_lex"
+    PKGCONFIG_MIMIC_LIBS="${PKGCONFIG_MIMIC_LIBS} -lttsmimic_lang_cmu_grapheme_lex"
   ],
   [ AC_DEFINE([ENABLE_INDICLEX], [0], [Enable Indic lexicon]) ])
 
@@ -422,19 +422,19 @@ AM_CONDITIONAL([LANG_INDIC_ANALYSIS],
   [test "x$enable_indic_analysis" != xno])
 AS_IF([test "x$enable_indic_analysis" != xno ],
   [ AC_DEFINE([ENABLE_INDIC_ANALYSIS], [1], [Enable Indic text analysis])
-    PKGCONFIG_MIMIC_LIBS="${PKGCONFIG_MIMIC_LIBS} -lmimic_lang_cmu_grapheme_lang"
-    PKGCONFIG_MIMIC_LIBS="${PKGCONFIG_MIMIC_LIBS} -lmimic_lang_cmu_indic_lang"
+    PKGCONFIG_MIMIC_LIBS="${PKGCONFIG_MIMIC_LIBS} -lttsmimic_lang_cmu_grapheme_lang"
+    PKGCONFIG_MIMIC_LIBS="${PKGCONFIG_MIMIC_LIBS} -lttsmimic_lang_cmu_indic_lang"
   ],
   [ AC_DEFINE([ENABLE_INDIC_ANALYSIS], [0], [Enable Indic text analysis]) ])
 
 AM_CONDITIONAL([LANG_USENGLISH], [test "x$enable_usenglish" != xno])
 AS_IF([test "x$enable_usenglish" != xno ],
   [ AC_DEFINE([ENABLE_USENGLISH], [1], [Enable US English text analysis])
-    PKGCONFIG_MIMIC_LIBS="${PKGCONFIG_MIMIC_LIBS} -lmimic_lang_usenglish" ],
+    PKGCONFIG_MIMIC_LIBS="${PKGCONFIG_MIMIC_LIBS} -lttsmimic_lang_usenglish" ],
   [ AC_DEFINE([ENABLE_USENGLISH], [0], [Enable US English text analysis]) ])
 
 
-PKGCONFIG_MIMIC_LIBS="${PKGCONFIG_MIMIC_LIBS} -lmimic_lang_all_langs -lmimic_lang_all_voices -lmimic"
+PKGCONFIG_MIMIC_LIBS="${PKGCONFIG_MIMIC_LIBS} -lttsmimic_lang_all_langs -lttsmimic_lang_all_voices -lttsmimic"
 
 AC_SUBST(PKGCONFIG_MIMIC_CFLAGS)
 AC_SUBST(PKGCONFIG_MIMIC_LIBS)

--- a/configure.ac
+++ b/configure.ac
@@ -69,7 +69,7 @@ AC_CHECK_HEADERS([sys/socket.h])
 
 
 dnl: pkg-config mimic.pc file:
-PKGCONFIG_MIMIC_CFLAGS="-I${includedir}/mimic -I${includedir}/mimic/lang"
+PKGCONFIG_MIMIC_CFLAGS="-I${includedir}/ttsmimic -I${includedir}/ttsmimic/lang"
 PKGCONFIG_MIMIC_LIBS="-L${libdir}"
 PKGCONFIG_MIMIC_DEPS=
 


### PR DESCRIPTION
Closes #63 

This PR renames libmimic* libraries to libttsmimic*.
The `libmimic` name is already being used by a [package](https://packages.debian.org/source/jessie/libmimic), therefore a rename is needed.
I have chosen libttsmimic as it refers both to mimic and to text-to-speech (tts).

Feel free to review and merge.