### PR TITLE
Initial ICU support for multilingual text analysis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,13 +47,16 @@ addons:
     - libtool
     - pkg-config
     - libasound2-dev
+    - libicu-dev
     - binutils-arm-linux-gnueabihf
     - gcc-arm-linux-gnueabihf
+    - g++-arm-linux-gnueabihf
     - libc6-dev-armhf-cross
     - pkg-config-arm-linux-gnueabihf
     - mingw32
     - mingw32-runtime
     - wine
+    - xvfb
   coverity_scan:
     project:
       name: "MycroftAI/mimic"

--- a/Makefile.am
+++ b/Makefile.am
@@ -16,8 +16,8 @@ lib_LTLIBRARIES =
 
 lib_LTLIBRARIES += libttsmimic.la
 libttsmimic_la_SOURCES = 
-libttsmimic_la_CFLAGS = 
-libttsmimic_la_LDFLAGS = -no-undefined
+libttsmimic_la_CFLAGS =  $(ICU_CFLAGS)
+libttsmimic_la_LDFLAGS = -no-undefined $(ICU_LIBS)
 libttsmimic_la_LIBADD = 
 
 libttsmimic_lang_all_langs_la_SOURCES = main/mimic_lang_list.c
@@ -527,6 +527,7 @@ libttsmimic_la_SOURCES += \
   src/utils/cst_string.c \
   src/utils/cst_tokenstream.c \
   src/utils/cst_url.c \
+  src/utils/cst_icu.c \
   src/utils/cst_val.c \
   src/utils/cst_val_const.c \
   src/utils/cst_val_user.c \
@@ -585,6 +586,7 @@ noinst_HEADERS += unittests/cutest.h
 
 myunittests = unittests/hrg_test \
               unittests/regex_test \
+              unittests/string_test \
               unittests/token_test \
               unittests/voice_select \
               unittests/wave_test
@@ -619,6 +621,11 @@ unittests_nums_test_LDADD = libttsmimic.la \
 
 unittests_regex_test_SOURCES = unittests/regex_test_main.c
 unittests_regex_test_LDADD = libttsmimic.la
+
+unittests_string_test_SOURCES = unittests/string_test_main.c
+unittests_string_test_CFLAGS = $(ICU_CFLAGS)
+unittests_string_test_LDADD = libttsmimic.la $(ICU_LIBS)
+
 
 unittests_token_test_SOURCES = unittests/token_test_main.c
 unittests_token_test_CFLAGS = -DTEST_FILE=\"$(top_srcdir)/unittests/data.one\" \
@@ -770,6 +777,7 @@ headers_HEADERS += \
   include/cst_ffeatures.h \
   include/cst_file.h \
   include/cst_hrg.h \
+  include/cst_icu.h \
   include/cst_item.h \
   include/cst_lexicon.h \
   include/cst_lts.h \

--- a/README.md
+++ b/README.md
@@ -31,14 +31,15 @@ Mimic is a fast, lightweight Text-to-speech engine developed by [Mycroft A.I.](h
 - automake and libtool
 - pkg-config
 - ALSA/PortAudio/PulseAudio (_Recommended:_ ALSA)
+- ICU library and headers
 
 ####Instructions
 
-- Install *gcc*, *make*, *automake*, *libtool*, *pkg-config* and *ALSA*
+- Install *gcc*, *make*, *automake*, *libtool*, *pkg-config*, *libicu-dev* and *ALSA*
 
 #####On Debian/Ubuntu
 ```
-$ sudo apt-get install gcc make pkg-config automake libtool libasound2-dev
+$ sudo apt-get install gcc make pkg-config automake libtool libicu-dev libasound2-dev
 ```
 
 ###Mac OSX
@@ -47,6 +48,7 @@ $ sudo apt-get install gcc make pkg-config automake libtool libasound2-dev
 - GNU make
 - pkg-config
 - PortAudio
+- ICU library
 
 ####Instructions
 
@@ -55,9 +57,9 @@ $ sudo apt-get install gcc make pkg-config automake libtool libasound2-dev
   $ /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
   ```
 
-- Install *pkg-config* and *PortAudio*
+- Install *pkg-config*, *libtool*, *icu* and *PortAudio*
   ```
-  $ brew install pkg-config portaudio
+  $ brew install pkg-config libtool portaudio icu4c
   ```
 
 ###Windows
@@ -67,70 +69,40 @@ $ sudo apt-get install gcc make pkg-config automake libtool libasound2-dev
 The fastest and most straightforward way to build mimic for windows is by
 cross-compilation from linux.
 
-From a debian based linux system, install the `mingw-w64` package.
+From a debian based linux system, install the dependencies, including mingw32
+packages. Install `wine` too for testing
 
 1. Install dependencies:
 
-   ```
-   sudo apt-get install mingw-w64 make pkg-config
-   ```
+```
+sudo apt-get install gcc make pkg-config automake libtool libicu-dev mingw32 mingw32-runtime wine
+```
 
-2. Create a working directory:
+2. Run the windows build script:
+```
+./run_testsuite.sh winbuild
+```
 
-   ```
-   mkdir mimic_windows mimic_windows/install
-   cd mimic_windows
-   WORKDIR="$PWD"
-   ```
+3. Test it
 
-3. Download PortAudio and mimic
-
-   ```
-   # PortAudio
-   wget http://www.portaudio.com/archives/pa_stable_v19_20140130.tgz
-   tar xzf pa_stable_v19_20140130.tgz # creates directory "portaudio"
-   # Mimic  
-   git clone git@github.com:MycroftAI/mimic.git --depth=1 # creates directory "mimic"
-   ```
-4. Cross compile PortAudio
-
-   ```
-   mkdir portaudio_build
-   cd portaudio_build
-   ../portaudio/configure  --host=i686-pc-mingw32 --build=x86_64-linux-gnu \
-      CC=i686-w64-mingw32-gcc LD=i686-w64-mingw32-ld \
-      --prefix="$WORKDIR/install"
-   make
-   make install
-   ```
-5. Cross compile mimic
-
-   ```
-   cd "$WORKDIR"
-   mkdir mimic_build
-   cd mimic_build
-   ../mimic/configure --host=i686-pc-mingw32 --build=x86_64-linux-gnu \
-           --with-audio=portaudio \
-           --prefix="$WORKDIR/install" \
-           CC=i686-w64-mingw32-gcc LD=i686-w64-mingw32-ld \
-           PKG_CONFIG_PATH="$WORKDIR/install/lib/pkgconfig/"
-   make
-   make install
-   ```
-
-6. Test it
-
-The directory `$WORKDIR/install` will contain `bin/mimic.exe` file
+The directory `install` will contain `bin/mimic.exe` file
 
 ```
 wine ./mimic.exe -t "hello world" 
 ```
+
+4. Distribute it
+
+You can distribute the compiled mimic by adding to a zip file everything in the
+`install/bin` directory.
+
 
 #### Native Windows building
 
 * A good C compiler (_Recommended:_ GCC under [Cygwin](https://cygwin.com/) or [mingw32](http://www.mingw.org/))
 * GNU Make
 * PortAudio
+* ICU
 
 ######Note
 - Audio device and audio libraries are optional, as mimic can write its output to a waveform file

--- a/configure.ac
+++ b/configure.ac
@@ -73,6 +73,12 @@ PKGCONFIG_MIMIC_CFLAGS="-I${includedir}/ttsmimic -I${includedir}/ttsmimic/lang"
 PKGCONFIG_MIMIC_LIBS="-L${libdir}"
 PKGCONFIG_MIMIC_DEPS=
 
+dnl Check ICU
+PKG_CHECK_MODULES([ICU], [icu-i18n],
+                  [m4_ignore], [m4_ignore])
+AC_DEFINE([U_CHARSET_IS_UTF8], [1], [mimic accepts UTF-8 only])
+
+PKGCONFIG_MIMIC_DEPS="${PKGCONFIG_MIMIC_DEPS} icu-i18n"
 
 
 dnl

--- a/include/cst_icu.h
+++ b/include/cst_icu.h
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2016 Sergio Oller <sergioller@gmail.com>
+
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ * 
+ * * Redistributions of source code must retain the above copyright
+ *   notice, this list of conditions and the following disclaimer.
+ * * Redistributions in binary form must reproduce the above
+ *   copyright notice, this list of conditions and the following disclaimer
+ *   in the documentation and/or other materials provided with the
+ *   distribution.
+ * * Neither the name of the  nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ * 
+ */
+#ifndef CST_ICU_H__
+#define CST_ICU_H__
+
+#include "config.h"
+#include <stdint.h>
+#include <unicode/ustring.h>
+#include <unicode/ucasemap.h>
+#include <unicode/uregex.h>
+#include <unicode/utypes.h>
+#include <cst_string.h>
+
+cst_string *cst_tolower_l(const cst_string *in, const char *locale);
+cst_string *cst_toupper_l(const cst_string *in, const char *locale);
+URegularExpression *new_cst_uregex(cst_string *pattern, uint32_t flags);
+void delete_cst_uregex(URegularExpression * uregex);
+int cst_uregex_match(URegularExpression * uregex, const cst_string *str);
+
+#endif

--- a/src/utils/cst_icu.c
+++ b/src/utils/cst_icu.c
@@ -1,0 +1,145 @@
+/*
+ * icu functions
+ * 
+ * Copyright 2016 Sergio Oller <sergioller@gmail.com>
+
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ * 
+ * * Redistributions of source code must retain the above copyright
+ *   notice, this list of conditions and the following disclaimer.
+ * * Redistributions in binary form must reproduce the above
+ *   copyright notice, this list of conditions and the following disclaimer
+ *   in the documentation and/or other materials provided with the
+ *   distribution.
+ * * Neither the name of the  nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ * 
+ */
+
+#include "cst_icu.h"
+#include "cst_alloc.h"
+#include "cst_string.h"
+
+cst_string *cst_tolower_l(const cst_string *in, const char *locale)
+{
+    if (locale == NULL)
+    {
+        locale = "C";
+    }
+    if (in == NULL)
+    {
+        return NULL;
+    }
+    cst_string *output = NULL;
+    int32_t output_size;
+    UCaseMap *csm;
+    UErrorCode status = U_ZERO_ERROR;
+    csm = ucasemap_open(locale, 0, &status);
+    output_size = ucasemap_utf8ToLower(csm, NULL, 0, in, -1, &status);
+    if (status == U_BUFFER_OVERFLOW_ERROR)
+    {
+        status = U_ZERO_ERROR;
+    }
+    output = cst_alloc(char, output_size + 1);
+    ucasemap_utf8ToLower(csm, output, output_size + 1, in, -1, &status);
+    ucasemap_close(csm);
+    if (U_FAILURE(status))
+    {
+        cst_free(output);
+        cst_errmsg
+            ("Error lowering (with locale %s) the string %s.\nError message: %s",
+             locale, in, u_errorName(status));
+        return NULL;
+    }
+    return output;
+}
+
+
+cst_string *cst_toupper_l(const cst_string *in, const char *locale)
+{
+    if (locale == NULL)
+    {
+        locale = "C";
+    }
+    if (in == NULL)
+    {
+        return NULL;
+    }
+    cst_string *output = NULL;
+    int32_t output_size;
+    UCaseMap *csm;
+    UErrorCode status = U_ZERO_ERROR;
+    csm = ucasemap_open(locale, 0, &status);
+    output_size = ucasemap_utf8ToUpper(csm, NULL, 0, in, -1, &status);
+    if (status == U_BUFFER_OVERFLOW_ERROR)
+    {
+        status = U_ZERO_ERROR;
+    }
+    output = cst_alloc(char, output_size + 1);
+    ucasemap_utf8ToUpper(csm, output, output_size + 1, in, -1, &status);
+    ucasemap_close(csm);
+    if (U_FAILURE(status))
+    {
+        cst_free(output);
+        cst_errmsg
+            ("Error uppering (with locale %s) the string %s.\nError message: %s",
+             locale, in, u_errorName(status));
+        return NULL;
+    }
+
+    return output;
+}
+
+/* Compile regex */
+URegularExpression *new_cst_uregex(cst_string *pattern, uint32_t flags)
+{
+    URegularExpression *output;
+    UErrorCode status = U_ZERO_ERROR;
+    output = uregex_openC((const char *) pattern, flags, NULL, &status);
+    if (U_FAILURE(status))
+    {
+        cst_errmsg("Error creating uregex: %s", u_errorName(status));
+        return NULL;
+    }
+    return output;
+}
+
+/* free regex */
+void delete_cst_uregex(URegularExpression * uregex)
+{
+    uregex_close(uregex);
+    return;
+}
+
+/* match regex string */
+int cst_uregex_match(URegularExpression * uregex, const cst_string *str)
+{
+    UErrorCode status = U_ZERO_ERROR;
+    UText *ut = NULL;
+    UBool ismatch;
+    ut = utext_openUTF8(ut, str, -1, &status);
+    uregex_setUText(uregex, ut, &status);
+    ismatch = uregex_matches(uregex, 0, &status);
+    uregex_reset(uregex, 0, &status);
+    if (U_FAILURE(status))
+    {
+        cst_errmsg("Error cst_uregex_match: %s", u_errorName(status));
+        return -1;
+    }
+    return ((int) ismatch);
+}

--- a/unittests/string_test_main.c
+++ b/unittests/string_test_main.c
@@ -1,0 +1,81 @@
+/*
+ * string tests
+ * 
+ * Copyright 2016 Sergio Oller <sergioller@gmail.com>
+
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ * 
+ * * Redistributions of source code must retain the above copyright
+ *   notice, this list of conditions and the following disclaimer.
+ * * Redistributions in binary form must reproduce the above
+ *   copyright notice, this list of conditions and the following disclaimer
+ *   in the documentation and/or other materials provided with the
+ *   distribution.
+ * * Neither the name of the  nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ * 
+ */
+#include <stdio.h>
+#include "cst_icu.h"
+
+#include "cutest.h"
+
+void test_uregex_match()
+{
+    int match;
+    URegularExpression *uregex;
+    uregex = new_cst_uregex("^[àé]$", UREGEX_CASE_INSENSITIVE);
+    match = cst_uregex_match(uregex, "a");
+    TEST_CHECK(match == 0);
+    match = cst_uregex_match(uregex, "à");
+    TEST_CHECK(match == 1);
+    match = cst_uregex_match(uregex, "À");
+    TEST_CHECK(match == 1);
+    delete_cst_uregex(uregex);
+    uregex = new_cst_uregex("^🐨.*$", 0);
+    match = cst_uregex_match(uregex, "🐨 is a koala");
+    TEST_CHECK(match == 1);
+    match = cst_uregex_match(uregex, "😀 is not a koala");
+    TEST_CHECK(match == 0);
+    return;
+}
+
+void test_change_case_l()
+{
+    cst_string in[] = "¡hola MUNDO!";
+    cst_string *out;
+    out = cst_tolower_l(in, "es_ES");
+    printf("in: %s\nout: %s\n", in, out);
+    TEST_CHECK(cst_streq(out, "¡hola mundo!"));
+    out = cst_toupper_l(in, "es_ES");
+    printf("in: %s\nout: %s\n", in, out);
+    TEST_CHECK(cst_streq(out, "¡HOLA MUNDO!"));
+    return;
+}
+
+TEST_LIST =
+{
+    {
+    "uregex_match", test_uregex_match}
+    ,
+    {
+    "test_change_case_l", test_change_case_l}
+    ,
+    {
+    0}
+};


### PR DESCRIPTION
The [International Components for Unicode](https://en.wikipedia.org/wiki/International_Components_for_Unicode) libraries provide Unicode support into mimic. They can handle Unicode regular expressions and conversions to lower case and upper case, among many other things. We need these tools for proper token_to_words analysis in languages different than English.

This pull request just brings in some basic functions for regular expression matching and upper/lower case conversion. I don't see the benefit of providing a wrapper for each ICU function, although providing a wrapper for some generic functions is --from my point of view-- beneficial (for instance as an example of "how to use ICU").

This PR does not replace any mimic function so for now we will have two regular expression engines (the one embedded in mimic and the one from ICU) and two sets of case conversion functions. I have not compared the performance of both engines, although I can imagine that the ICU will be slower as it considers many more cases.

Depending on the size of the ICU libraries and their performance we may decide to drop the embedded regular expression engine. For now, I would rather go for "let's make things work" and later we will decide on how and if we optimize them.

Feel free to review and comment it.