### PR TITLE
Fix portaudio windows build

### DIFF
--- a/src/audio/auclient.c
+++ b/src/audio/auclient.c
@@ -49,7 +49,7 @@
 #include "cst_wave.h"
 #include "cst_audio.h"
 
-#ifndef CST_NO_SOCKETS
+#if HAVE_SYS_SOCKET_H == 1
 
 #include <unistd.h>
 


### PR DESCRIPTION
Once ICU support is merged, this PR will have only a single commit that will allow to compile mimic with  PortAudio support  in the Travis Windows build.

I keep both PR separate because they deal with different things, although I require ICU support being merged to prevent merge conflicts