### PR TITLE
Improve mimic build with ICU

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,6 +1,6 @@
 ACLOCAL_AMFLAGS = -I m4
 
-AM_CPPFLAGS = -I$(top_srcdir)/include
+AM_CPPFLAGS = -I$(top_srcdir)/include $(ICU_CFLAGS)
 
 SUBDIRS = .
 
@@ -16,9 +16,9 @@ lib_LTLIBRARIES =
 
 lib_LTLIBRARIES += libttsmimic.la
 libttsmimic_la_SOURCES = 
-libttsmimic_la_CFLAGS =  $(ICU_CFLAGS)
-libttsmimic_la_LDFLAGS = -no-undefined $(ICU_LIBS)
-libttsmimic_la_LIBADD = 
+libttsmimic_la_CFLAGS =
+libttsmimic_la_LDFLAGS = -no-undefined
+libttsmimic_la_LIBADD = $(ICU_LIBS)
 
 libttsmimic_lang_all_langs_la_SOURCES = main/mimic_lang_list.c
 libttsmimic_lang_all_langs_la_LDFLAGS = -no-undefined
@@ -623,7 +623,6 @@ unittests_regex_test_SOURCES = unittests/regex_test_main.c
 unittests_regex_test_LDADD = libttsmimic.la
 
 unittests_string_test_SOURCES = unittests/string_test_main.c
-unittests_string_test_CFLAGS = $(ICU_CFLAGS)
 unittests_string_test_LDADD = libttsmimic.la $(ICU_LIBS)
 
 

--- a/run_testsuite.sh
+++ b/run_testsuite.sh
@@ -80,6 +80,14 @@ crosscompile_mimic()
     cd "$WORKDIR" || exit 1
     mkdir mimic_build || exit 1
     cd mimic_build || exit 1
+    # Ubuntu precise & trusty bug (inherited from debian):
+    # ${HOST_TRIPLET}-pkg-config ignores PKG_CONFIG_PATH
+    # We need PKG_CONFIG_PATH="$WORKDIR/install/lib/pkgconfig/"
+    # so we use pkg-config without the triplet.
+    # and we set PKG_CONFIG_PATH manually to the right search paths
+    # pkg-config in Debian stretch and in Ubuntu xenial has this bug fixed so
+    # in the future the ${HOST_TRIPLET}-pkg-config can be used with a simple
+    # PKG_CONFIG_PATH="$WORKDIR/install/lib/pkgconfig/"
     ../configure --build="${BUILD_TRIPLET}" \
                  --host="${HOST_TRIPLET}" \
                  --prefix="$WORKDIR/install" \
@@ -87,7 +95,8 @@ crosscompile_mimic()
                  LD=${HOST_TRIPLET}-ld \
                  RANLIB=${HOST_TRIPLET}-ranlib \
                  AR=${HOST_TRIPLET}-ar \
-                 PKG_CONFIG_PATH="$WORKDIR/install/lib/pkgconfig/" \
+                 PKG_CONFIG_PATH="$WORKDIR/install/lib/pkgconfig/:/usr/lib/${HOST_TRIPLET}/pkgconfig:/usr/${HOST_TRIPLET}/lib/pkgconfig" \
+                 PKG_CONFIG=`which pkg-config` \
                  "$@" || exit 1
     make || exit 1
     make install || exit 1


### PR DESCRIPTION
Changing these flags makes it easier to add support for more languages. In summary:

- ICU_CFLAGS are more "global" (so anyone including `cst_icu.h` gets the right flags automatically)
- libttsmimic.la's ICU_LIBS are moved to LIBADD so any binary depending on libttsmimic can have ICU_LIBS if necessary automatically (prevent missing symbols) 
- Workaround a bug in PKG_CONFIG on cross compilation on precise and trusty