### PR TITLE
Prefixed audio functions with "mimic_"

### DIFF
--- a/include/cst_audio.h
+++ b/include/cst_audio.h
@@ -61,7 +61,7 @@ typedef enum {
     CST_AUDIO_MULAW
 } cst_audiofmt;
 /* Returns the number of bytes per sample for a given audio format */
-int audio_bps(cst_audiofmt fmt);
+int mimic_audio_bps(cst_audiofmt fmt);
 
 typedef struct cst_audiodev_struct {
     int sps, real_sps;
@@ -73,32 +73,32 @@ typedef struct cst_audiodev_struct {
 } cst_audiodev;
 
 /* Generic audio functions */
-int audio_init();
-cst_audiodev *audio_open(int sps, int channels, cst_audiofmt fmt);
-int audio_close(cst_audiodev *ad);
-int audio_write(cst_audiodev *ad, void *buff, int num_bytes);
-int audio_flush(cst_audiodev *ad);      /* wait for buffers to empty */
-int audio_drain(cst_audiodev *ad);      /* empty buffers now */
-int audio_exit();
+int mimic_audio_init();
+cst_audiodev *mimic_audio_open(int sps, int channels, cst_audiofmt fmt);
+int mimic_audio_close(cst_audiodev *ad);
+int mimic_audio_write(cst_audiodev *ad, void *buff, int num_bytes);
+int mimic_audio_flush(cst_audiodev *ad);      /* wait for buffers to empty */
+int mimic_audio_drain(cst_audiodev *ad);      /* empty buffers now */
+int mimic_audio_exit();
 
 /* Generic high level audio functions */
-int play_wave(cst_wave *w);
-int play_wave_sync(cst_wave *w, cst_relation *rel,
+int mimic_play_wave(cst_wave *w);
+int mimic_play_wave_sync(cst_wave *w, cst_relation *rel,
                    int (*call_back) (cst_item *));
-int play_wave_client(cst_wave *w, const char *servername, int port,
+int mimic_play_wave_client(cst_wave *w, const char *servername, int port,
                      const char *encoding);
 int auserver(int port);
 
 /* Play wave to specified device */
-int play_wave_device(cst_wave *w, cst_audiodev *ad);
+int mimic_play_wave_device(cst_wave *w, cst_audiodev *ad);
 
 /* Output to a file as if its an audio device */
-cst_audiodev *audio_open_file(int sps, int channels, cst_audiofmt fmt,
+cst_audiodev *mimic_audio_open_file(int sps, int channels, cst_audiofmt fmt,
                               const char *filename);
-int audio_close_file(cst_audiodev *ad);
-int audio_write_file(cst_audiodev *ad, void *buff, int num_bytes);
-int audio_drain_file(cst_audiodev *ad);
-int audio_flush_file(cst_audiodev *ad);
+int mimic_audio_close_file(cst_audiodev *ad);
+int mimic_audio_write_file(cst_audiodev *ad, void *buff, int num_bytes);
+int mimic_audio_drain_file(cst_audiodev *ad);
+int mimic_audio_flush_file(cst_audiodev *ad);
 
 /* For audio streaming */
 #define CST_AUDIO_STREAM_STOP -1
@@ -124,5 +124,5 @@ typedef int (*cst_audio_stream_callback) (const cst_wave *w, int start,
 int audio_stream_chunk(const cst_wave *w, int start, int size,
                        int last, cst_audio_streaming_info *asi);
 
-void shutdown_audio(int signum);
+void mimic_audio_shutdown(int signum);
 #endif

--- a/main/mimic_main.c
+++ b/main/mimic_main.c
@@ -62,7 +62,7 @@ cst_lexicon *cmu_lex_init(void);
 #ifdef _WIN32
 BOOL WINAPI windows_signal_handler(DWORD signum)
 {
-    shutdown_audio(signum);
+    mimic_audio_shutdown(signum);
     if (signum == CTRL_C_EVENT)
         return TRUE;
     else
@@ -71,7 +71,7 @@ BOOL WINAPI windows_signal_handler(DWORD signum)
 #else
 void sigint_handler(int signum)
 {
-    shutdown_audio(signum);
+    mimic_audio_shutdown(signum);
 }
 #endif
 

--- a/src/audio/au_alsa.c
+++ b/src/audio/au_alsa.c
@@ -293,7 +293,7 @@ int audio_write_alsa(cst_audiodev *ad, void *samples, int num_bytes)
     char *buf = (char *) samples;
 
     /* Determine frame size in bytes */
-    frame_size = audio_bps(ad->real_fmt) * ad->real_channels;
+    frame_size = mimic_audio_bps(ad->real_fmt) * ad->real_channels;
     /* Require that only complete frames are handed in */
     assert((num_bytes % frame_size) == 0);
     num_frames = num_bytes / frame_size;

--- a/src/audio/au_portaudio.c
+++ b/src/audio/au_portaudio.c
@@ -241,7 +241,7 @@ int audio_write_portaudio(cst_audiodev *ad, void *buff, int num_bytes)
     data->num_frames = num_frames;
     data->channels = ad->channels;
     data->bufpos = 0;
-    data->sample_size = audio_bps(ad->fmt);
+    data->sample_size = mimic_audio_bps(ad->fmt);
     data->abort_requested = 0;
     hdl->cd = data;
     /* Stream */

--- a/src/audio/au_streaming.c
+++ b/src/audio/au_streaming.c
@@ -77,13 +77,13 @@ int audio_stream_chunk(const cst_wave *w, int start, int size,
     static cst_audiodev *ad = 0;
 
     if (start == 0)
-        ad = audio_open(w->sample_rate, w->num_channels, CST_AUDIO_LINEAR16);
+        ad = mimic_audio_open(w->sample_rate, w->num_channels, CST_AUDIO_LINEAR16);
 
-    audio_write(ad, &w->samples[start], size * sizeof(short));
+    mimic_audio_write(ad, &w->samples[start], size * sizeof(short));
 
     if (last == 1)
     {
-        audio_close(ad);
+        mimic_audio_close(ad);
         ad = NULL;
     }
 

--- a/src/audio/auclient.c
+++ b/src/audio/auclient.c
@@ -53,7 +53,7 @@
 
 #include <unistd.h>
 
-int play_wave_client(cst_wave *w, const char *servername, int port,
+int mimic_play_wave_client(cst_wave *w, const char *servername, int port,
                      const char *encoding)
 {
     int audiofd, q, i, n, r;

--- a/src/audio/auserver.c
+++ b/src/audio/auserver.c
@@ -79,7 +79,7 @@ static int play_wave_from_socket(snd_header * header, int audiostream)
         cst_errmsg("could not open tmp/awb.wav for writing");
         return -1;
     }
-    if ((audio_device = audio_open(header->sample_rate, 1,
+    if ((audio_device = mimic_audio_open(header->sample_rate, 1,
                                    (header->encoding == CST_SND_SHORT) ?
                                    CST_AUDIO_LINEAR16 : CST_AUDIO_LINEAR8)) ==
         NULL)
@@ -122,7 +122,7 @@ static int play_wave_from_socket(snd_header * header, int audiostream)
         if (r <= 0)
         {                       /* I'm not getting any data from the server */
             cst_fclose(fff);
-            audio_close(audio_device);
+            mimic_audio_close(audio_device);
             free(bytes);
             free(shorts);
             return CST_ERROR_FORMAT;
@@ -130,19 +130,19 @@ static int play_wave_from_socket(snd_header * header, int audiostream)
 
         for (q = r; q > 0; q -= n)
         {
-            n = audio_write(audio_device, shorts, q);
+            n = mimic_audio_write(audio_device, shorts, q);
             cst_fwrite(fff, shorts, 2, q);
             if (n <= 0)
             {
                 cst_fclose(fff);
-                audio_close(audio_device);
+                mimic_audio_close(audio_device);
                 free(bytes);
                 free(shorts);
                 return CST_ERROR_FORMAT;
             }
         }
     }
-    audio_close(audio_device);
+    mimic_audio_close(audio_device);
     cst_fclose(fff);
     free(bytes);
     free(shorts);

--- a/src/synth/mimic.c
+++ b/src/synth/mimic.c
@@ -55,14 +55,14 @@ int mimic_lang_list_length = 0;
 int mimic_init()
 {
     cst_regex_init();
-    audio_init();
+    mimic_audio_init();
 
     return 0;
 }
 
 int mimic_exit()
 {
-    audio_exit();
+    mimic_audio_exit();
     return 0;
 }
 
@@ -408,7 +408,7 @@ int mimic_process_output(cst_utterance *u, const char *outtype,
 
     if (cst_streq(outtype, "play"))
     {
-        if (play_wave(w) == EINTR)
+        if (mimic_play_wave(w) == EINTR)
             return -EINTR;
     }
     else if (cst_streq(outtype, "stream"))

--- a/testsuite/by_word_main.c
+++ b/testsuite/by_word_main.c
@@ -63,7 +63,7 @@ int audio_stream_chunk_by_word(const cst_wave *w, int start, int size,
     /*    printf("in by word streaming\n"); */
 
     if (start == 0)
-        ad = audio_open(w->sample_rate, w->num_channels, CST_AUDIO_LINEAR16);
+        ad = mimic_audio_open(w->sample_rate, w->num_channels, CST_AUDIO_LINEAR16);
 
     if (asi->item == NULL)
         asi->item = relation_head(utt_relation(asi->utt, "Token"));
@@ -91,16 +91,16 @@ int audio_stream_chunk_by_word(const cst_wave *w, int start, int size,
         }
 
     }
-    n = audio_write(ad, &w->samples[start], size * sizeof(int16_t));
+    n = mimic_audio_write(ad, &w->samples[start], size * sizeof(int16_t));
 
     if ((size_t) n != size * sizeof(int16_t))
     {
-        fprintf(stderr, "Error in audio_write unexpected number of bytes written\n");
+        fprintf(stderr, "Error in mimic_audio_write unexpected number of bytes written\n");
         return CST_AUDIO_STREAM_CONT;
     }
     if (last == 1)
     {
-        audio_close(ad);
+        mimic_audio_close(ad);
         asi->item = NULL;
         ad = NULL;
     }

--- a/testsuite/kal_test_main.c
+++ b/testsuite/kal_test_main.c
@@ -73,7 +73,7 @@ int main(int argc, char **argv)
         durs += (float) w->num_samples / (float) w->sample_rate;
 
         if (cst_streq(argv[2], "play"))
-            play_wave(w);
+            mimic_play_wave(w);
         else if (!cst_streq(argv[2], "none"))
             cst_wave_save_riff(w, argv[2]);
         delete_utterance(u);

--- a/testsuite/play_client_main.c
+++ b/testsuite/play_client_main.c
@@ -125,11 +125,11 @@ int main(int argc, char **argv)
         if (cst_wave_load_riff(w, argv[i]) != CST_OK_FORMAT)
         {
             fprintf(stderr,
-                    "play_wave: can't read file or wrong format \"%s\"\n",
+                    "mimic_play_wave: can't read file or wrong format \"%s\"\n",
                     argv[i]);
             continue;
         }
-        play_wave_client(w, server, port, encoding);
+        mimic_play_wave_client(w, server, port, encoding);
         delete_wave(w);
     }
 

--- a/testsuite/play_sync_main.c
+++ b/testsuite/play_sync_main.c
@@ -67,7 +67,7 @@ int main(int argc, char **argv)
 
     if (argc != 3)
     {
-        fprintf(stderr, "usage: play_wave_sync WAVEFILE LABELFILE\n");
+        fprintf(stderr, "usage: mimic_play_wave_sync WAVEFILE LABELFILE\n");
         return 1;
     }
 
@@ -79,7 +79,7 @@ int main(int argc, char **argv)
     if (relation_load(r, argv[2]) != CST_OK_FORMAT)
         return -1;
 
-    play_wave_sync(w, r, my_call_back);
+    mimic_play_wave_sync(w, r, my_call_back);
 
     return 0;
 }

--- a/testsuite/play_wave_main.c
+++ b/testsuite/play_wave_main.c
@@ -49,7 +49,7 @@ int main(int argc, char **argv)
 
     if (argc == 1)
     {
-        fprintf(stderr, "usage: play_wave WAVEFILE\n");
+        fprintf(stderr, "usage: mimic_play_wave WAVEFILE\n");
         return 1;
     }
 
@@ -59,11 +59,11 @@ int main(int argc, char **argv)
         if (cst_wave_load_riff(w, argv[i]) != CST_OK_FORMAT)
         {
             fprintf(stderr,
-                    "play_wave: can't read file or wrong format \"%s\"\n",
+                    "mimic_play_wave: can't read file or wrong format \"%s\"\n",
                     argv[i]);
             continue;
         }
-        play_wave(w);
+        mimic_play_wave(w);
         delete_wave(w);
     }
 


### PR DESCRIPTION
Renamed all public audio functions by prefixing mimic_ to avoid name clashes.
Native audio functions were not renamed.

Closes #83 