### PR TITLE
Initial step towards Spanish support: Tokenizer and simple token to words

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -125,6 +125,25 @@ libttsmimic_lang_cmu_indic_lang_la_SOURCES = \
 
 ################# END: LANG_INDIC ########################################
 
+############## START: LANG_ES_ANALYSIS #################################
+if LANG_ES_ANALYSIS
+    lib_LTLIBRARIES += libttsmimic_lang_es.la
+    libttsmimic_lang_all_langs_la_LIBADD += libttsmimic_lang_es.la
+endif
+
+libttsmimic_lang_es_la_LDFLAGS = -no-undefined
+libttsmimic_lang_es_la_LIBADD = libttsmimic.la
+libttsmimic_lang_es_la_SOURCES = \
+  lang/es_lang/es_init.c \
+  lang/es_lang/es_lang.h \
+  lang/es_lang/es_text_analysis.c \
+  lang/es_lang/es_tokenizer.c
+
+langheader_HEADERS += \
+  lang/es_lang/es_lang.h
+
+############## END: LANG_ES_ANALYSIS  ##################################
+
 ############## START: LEX_CMULEX #########################################
 if LEX_CMULEX
     lib_LTLIBRARIES += libttsmimic_lang_cmulex.la
@@ -599,6 +618,17 @@ if LANG_USENGLISH
   myunittests += unittests/lex_test unittests/lts_test unittests/nums_test
 endif
 endif
+
+if LANG_ES_ANALYSIS
+  myunittests += unittests/es_tokenstream_test
+  unittests_es_tokenstream_test_SOURCES = unittests/es_tokenstream_test_main.c
+  unittests_es_tokenstream_test_CFLAGS = \
+    -DTEST_FILE=\"$(top_srcdir)/unittests/es_text.txt\" \
+    -I$(top_srcdir)/lang/es_lang
+  unittests_es_tokenstream_test_LDADD = libttsmimic.la \
+                                        libttsmimic_lang_es.la
+endif
+
 
 check_PROGRAMS = $(myunittests)
 

--- a/configure.ac
+++ b/configure.ac
@@ -230,6 +230,11 @@ AC_ARG_ENABLE([lang-indic],
   [],
   [enable_lang_indic=${enable_lang_all}])
 
+AC_ARG_ENABLE([lang-es],
+  [AS_HELP_STRING([--disable-lang-es],
+      [disable Spanish language support])],
+  [],
+  [enable_lang_es=${enable_lang_all}])
 
 dnl -------------------- Language analysis ---------------------------
 dnl For US English en-us:
@@ -245,6 +250,12 @@ AC_ARG_ENABLE([indic_analysis],
       [disable indic text analysis support])],
   [],
   [enable_indic_analysis=${enable_lang_indic}])
+
+AC_ARG_ENABLE([es_analysis],
+  [AS_HELP_STRING([--disable-es-analysis],
+      [disable Spanish text analysis support])],
+  [],
+  [enable_es_analysis=${enable_lang_es}])
 
 
 dnl ------------------- Lexicons ------------------------------
@@ -438,6 +449,12 @@ AS_IF([test "x$enable_usenglish" != xno ],
   [ AC_DEFINE([ENABLE_USENGLISH], [1], [Enable US English text analysis])
     PKGCONFIG_MIMIC_LIBS="${PKGCONFIG_MIMIC_LIBS} -lttsmimic_lang_usenglish" ],
   [ AC_DEFINE([ENABLE_USENGLISH], [0], [Enable US English text analysis]) ])
+
+AM_CONDITIONAL([LANG_ES_ANALYSIS], [test "x$enable_es_analysis" != xno])
+AS_IF([test "x$enable_es_analysis" != xno ],
+  [ AC_DEFINE([ENABLE_ES_ANALYSIS], [1], [Enable Spanish text analysis])
+    PKGCONFIG_MIMIC_LIBS="${PKGCONFIG_MIMIC_LIBS} -lttsmimic_lang_es" ],
+  [ AC_DEFINE([ENABLE_ES_ANALYSIS], [0], [Enable Spanish text analysis]) ])
 
 
 PKGCONFIG_MIMIC_LIBS="${PKGCONFIG_MIMIC_LIBS} -lttsmimic_lang_all_langs -lttsmimic_lang_all_voices -lttsmimic"

--- a/configure.ac
+++ b/configure.ac
@@ -231,10 +231,10 @@ AC_ARG_ENABLE([lang-indic],
   [enable_lang_indic=${enable_lang_all}])
 
 AC_ARG_ENABLE([lang-es],
-  [AS_HELP_STRING([--disable-lang-es],
-      [disable Spanish language support])],
+  [AS_HELP_STRING([--enable-lang-es],
+      [(NOT WORKING YET) enable Spanish language support])],
   [],
-  [enable_lang_es=${enable_lang_all}])
+  [enable_lang_es=no])
 
 dnl -------------------- Language analysis ---------------------------
 dnl For US English en-us:

--- a/lang/es_lang/es_init.c
+++ b/lang/es_lang/es_init.c
@@ -1,0 +1,37 @@
+#include "cst_ffeatures.h"
+#include "es_lang.h"
+
+void es_init(cst_voice *v)
+{
+    /* Basic generic functions that need to be registered always */
+    basic_ff_register(v->ffunctions);
+
+    /* 1. Tokenizer */
+    es_init_tokenizer(v);
+
+    /* 2. Utterance break function */
+    feat_set(v->features,"utt_break",breakfunc_val(&default_utt_break));
+
+    /* 3. Text analyser */
+    feat_set(v->features,"tokentowords_func",itemfunc_val(&es_tokentowords));
+
+    /* 4. very simple POS tagger */
+    /* TO DO */
+
+    /* 5. Phrasing */
+    /* TO DO */
+
+    /* 6a. Phoneset */
+    /* TO DO */
+
+
+    /* 8. Intonation */
+    /* TO DO */
+
+    /* 10. Duration */
+    /* TO DO? */
+
+    /* 11. f0 model */
+    /* TO DO? */
+
+}

--- a/lang/es_lang/es_lang.h
+++ b/lang/es_lang/es_lang.h
@@ -1,0 +1,5 @@
+#include "mimic.h"
+
+void es_init(cst_voice *v);
+void es_init_tokenizer(cst_voice *v);
+cst_val *es_tokentowords(cst_item *token);

--- a/lang/es_lang/es_text_analysis.c
+++ b/lang/es_lang/es_text_analysis.c
@@ -1,0 +1,84 @@
+#include "es_lang.h"
+#include "cst_icu.h"
+#include "mimic.h"
+
+cst_utterance *es_textanalysis(cst_utterance *u);
+cst_val *es_tokentowords(cst_item *token);
+static cst_val *es_tokentowords_one(cst_item *token, const char *name);
+
+
+cst_utterance *es_textanalysis(cst_utterance *u)
+{
+    if (!feat_present(u->features, "tokentowords_func"))
+	utt_set_feat(u, "tokentowords_func", itemfunc_val(es_tokentowords));
+
+    return default_textanalysis(u);
+}
+
+cst_val *es_tokentowords(cst_item *token)
+{
+    return es_tokentowords_one(token, item_feat_string(token, "name"));
+}
+
+static cst_val *es_tokentowords_one(cst_item *token, const char *name)
+{
+    cst_val *list_of_words;
+    char *name_mod;
+    /* Each token has defined four features:
+        - The token name: ffeature_string(token,"name");
+        - The token prepunctuation: ffeature_string(token,"prepunctuation");
+        - The token postpunctuation: ffeature_string(token,"punc");
+        - The token whitespace: ffeature_string(token,"whitespace");
+
+       We can also traverse the list of tokens for contextual information:
+        - The previous token: cst_item *prev_token = item_prev(token);
+        - The next token: cst_item *next_token = item_next(token);
+
+       So we can combine both traversing and accessing features:
+        - The name of the next token: ffeature_string(item_next(token), "name");
+
+       As text analysis requires constantly of checking context, we can use
+       feature paths:
+       Feature paths can be up to 200 characters long.
+       Their syntax is implemented in src/hrg/cst_ffeature.c. You may the
+       internal_ff function. In summary, feature paths are strings composed of
+       operators separated by dots. The most common operators applicable to 
+       tokens are:
+        - "n": Advances to the next token
+        - "nn": Advances to the next next token
+        - "p": Advances to the previous token
+        - "pp": Advances to the previous previous token
+
+        Other cst_item usually require other operators that we won't explore now:
+        - "parent": Advances to the parent item
+        - "daughter": Advances to the first daughter item
+        - "daughtern": Advances to the last daughter item
+        - "RNameOfRelation": Moves to another relation.
+
+        After the last operator, we typically want access to a token feature:
+        - Token. Previous. Name: ffeature_string(token,"p.name");
+        - Token. PreviousPrevious. Name: ffeature_string(token,"pp.name");
+        - Token. Previous. Name: ffeature_string(token,"p.name");
+        - Look the next-next-next token punctuation: ffeature_string(token, "nn.n.punc");
+
+    */
+    if (strcmp(name, "€") == 0)
+    {
+        list_of_words = cons_val(string_val("euro"), NULL);
+    } else if (name[cst_strlen(name)] == '%')
+    {
+        name_mod = cst_strdup(name);
+        name_mod[cst_strlen(name_mod)-1] = '\0';
+        list_of_words = es_tokentowords_one(token, name_mod);
+        list_of_words = val_append(list_of_words,
+                                   cons_val(string_val("por"),
+                                            cons_val(string_val("ciento"), NULL)));
+    } else if (strcmp(name, "17") == 0) /* TO DO: Handle all numbers */
+    {
+        list_of_words = cons_val(string_val("diecisiete"), NULL);       
+    } else
+    {
+        list_of_words = cons_val(string_val(cst_tolower_l(name, "es_ES")), NULL);
+    }
+    return list_of_words;
+}

--- a/lang/es_lang/es_text_analysis.c
+++ b/lang/es_lang/es_text_analysis.c
@@ -73,6 +73,7 @@ static cst_val *es_tokentowords_one(cst_item *token, const char *name)
         list_of_words = val_append(list_of_words,
                                    cons_val(string_val("por"),
                                             cons_val(string_val("ciento"), NULL)));
+        cst_free(name_mod);
     } else if (strcmp(name, "17") == 0) /* TO DO: Handle all numbers */
     {
         list_of_words = cons_val(string_val("diecisiete"), NULL);       

--- a/lang/es_lang/es_tokenizer.c
+++ b/lang/es_lang/es_tokenizer.c
@@ -1,0 +1,14 @@
+#include "es_lang.h"
+
+static const char* es_whitespace = " \t\n\r";
+static const char* es_singlecharsymbols = "€😃";
+static const char* es_prepunctuation = "¿¡«\"'``({[";
+static const char* es_punctuation = "»\"'``.,:;!?(){}[]";
+
+void es_init_tokenizer(cst_voice *v)
+{
+    feat_set_string(v->features, "text_whitespace", es_whitespace);
+    feat_set_string(v->features, "text_postpunctuation", es_punctuation);
+    feat_set_string(v->features, "text_prepunctuation", es_prepunctuation);
+    feat_set_string(v->features, "text_singlecharsymbols", es_singlecharsymbols);
+}

--- a/main/mimic_lang_list.c
+++ b/main/mimic_lang_list.c
@@ -18,6 +18,11 @@ cst_lexicon *cmu_indic_lex_init(void);
 cst_lexicon *cmu_grapheme_lex_init(void);
 #endif
 
+#if ENABLE_ES_ANALYSIS
+#include "lang/es_lang/es_lang.h"
+#endif
+
+
 void mimic_set_lang_list(void)
 {
    #if (ENABLE_USENGLISH & ENABLE_CMULEX)
@@ -28,5 +33,9 @@ void mimic_set_lang_list(void)
    mimic_add_lang("cmu_indic_lang",cmu_indic_lang_init,cmu_indic_lex_init);
    mimic_add_lang("cmu_grapheme_lang",cmu_grapheme_lang_init,cmu_grapheme_lex_init);
    #endif
+   #if ENABLE_ES_ANALYSIS
+   mimic_add_lang("es", es_init, NULL);
+   #endif
+
 }
 

--- a/unittests/es_text.txt
+++ b/unittests/es_text.txt
@@ -1,0 +1,3 @@
+Hola, hoy es 17 de julio.
+«Patata» es un sustantivo.
+¡Qué día tan bonito! ¿Te gusta tomar el sol?

--- a/unittests/es_tokenstream_test_main.c
+++ b/unittests/es_tokenstream_test_main.c
@@ -1,0 +1,114 @@
+#include "cutest.h"
+#include <stdio.h>
+#include <string.h>
+#include <stdbool.h>
+#include "cst_tokenstream.h"
+#include "cst_lexicon.h"
+#include "cst_synth.h"
+
+#include "es_lang.h"
+
+#ifndef TEST_FILE
+#define TEST_FILE "es_text.txt"
+#endif
+
+static const cst_synth_module text_to_words[] = {
+    {"tokenizer_func", default_tokenization},
+    {"textanalysis_func", default_textanalysis},
+    {"pos_tagger_func", NULL},
+    {"phrasing_func", NULL},
+    {"lexical_insertion_func", NULL},
+    {"pause_insertion_func", NULL},
+    {"intonation_func", NULL},
+    {"postlex_func", NULL},
+    {"duration_model_func", NULL},
+    {"f0_model_func", NULL},
+    {"wave_synth_func", NULL},
+    {"post_synth_hook_func", NULL},
+    {NULL, NULL}
+};
+
+
+
+void test_es_tokenizer(void)
+{
+    /* One entry per token */
+    char *names[] = { "Hola", "hoy", "es", "17", "de", "julio", "Patata",
+        "es", "un", "sustantivo", "Qué", "día", "tan",
+        "bonito", "Te", "gusta", "tomar", "el", "sol"
+    };
+    char *puncs[] = { ",", "", "", "", "", ".",
+        "»", "", "", ".",
+        "", "", "", "!", "", "", "", "", "?"
+    };
+    char *prepuncs[] = { "", "", "", "", "", "",
+        "«", "", "", "",
+        "¡", "", "", "", "¿", "", "", "", ""
+    };
+    int expected_num_tok = 19;  /* Expected number of tokens */
+    char *word_list[] = { "hola", "hoy", "es", "diecisiete", "de", "julio",
+        "patata", "es", "un", "sustantivo", "qué", "día", "tan", "bonito",
+        "te", "gusta", "tomar", "el", "sol"};
+    int expected_num_words = 19;
+
+    cst_tokenstream *ts;
+    cst_utterance *u;
+    cst_relation *rel;
+    cst_item *it;
+    int i = 0, j = 0;
+    const char *name, *prepunc, *punc;
+    cst_voice *v = new_voice();
+    const char *text_line;
+    es_init(v);
+    /* Read file line by line. Each ts_get(ts) will return a line */
+    ts = ts_open(TEST_FILE, "\n\r", "", "", "");
+    TEST_CHECK(ts != NULL);
+    while (!ts_eof(ts))
+    {
+        /* For each line, create an utterance, create its tokens and
+         * convert it to words */
+        text_line = ts_get(ts);
+        u = new_utterance();
+        utt_set_input_text(u, text_line);
+        utt_init(u, v);
+        apply_synth_method(u, text_to_words);
+        /* First check: Tokens are correct */
+        rel = utt_relation(u, "Token");
+        TEST_CHECK(rel != NULL);
+        it = relation_head(rel);
+        while (it != NULL)
+        {
+            name = item_feat_string(it, "name");
+            /* printf("name: %s\n", name); */
+            TEST_CHECK(strcmp(name, names[i]) == 0);
+            prepunc = item_feat_string(it, "prepunctuation");
+            TEST_CHECK(strcmp(prepunc, prepuncs[i]) == 0);
+            punc = item_feat_string(it, "punc");
+            TEST_CHECK(strcmp(punc, puncs[i]) == 0);
+            it = item_next(it);
+            i++;
+        }
+        /* Second check: Words are correct */
+        rel = utt_relation(u, "Word");
+        TEST_CHECK(rel != NULL);
+        for (it = relation_head(rel); it; it = item_next(it)) {
+            /*printf("name: %s\n", item_feat_string(it, "name"));*/
+            TEST_CHECK(cst_streq(item_feat_string(it, "name"), word_list[j]));
+            j++;
+        }
+        delete_utterance(u);
+    }
+        TEST_CHECK(i == expected_num_tok);      /* verify number of tokens */
+        TEST_CHECK(j == expected_num_words);      /* verify number of words */
+    ts_close(ts);
+    delete_voice(v);
+}
+
+TEST_LIST =
+{
+    {
+    "Spanish token to words", test_es_tokenizer}
+    ,
+    {
+    0}
+};

--- a/unittests/es_tokenstream_test_main.c
+++ b/unittests/es_tokenstream_test_main.c
@@ -104,11 +104,4 @@ void test_es_tokenizer(void)
     delete_voice(v);
 }
 
-TEST_LIST =
-{
-    {
-    "Spanish token to words", test_es_tokenizer}
-    ,
-    {
-    0}
-};
+TEST_LIST = {{"Spanish token to words", test_es_tokenizer}, {0}};


### PR DESCRIPTION
This pull request related to issue #3  provides a tokenizer and dummy token to words rules for Spanish.

These dummy token to word rules need to be improved to handle all numbers, recognize common Spanish abbreviations (tel. -> teléfono...), recognize roman numbers in expressions like "siglo XX", etc.

I have been working (not as much as I would like to, my time is very limited lately) on fixing https://github.com/TALP-UPC/saga, a library for phoneme transcription in Spanish that covers seven Spanish variants (Argentina, Castilla -Spain-, Chile, Colombia, Mexico, Perú, Venezuela).

I have found some CC-BY-SA Spanish HTS voice models, built by [aholab](http://aholab.ehu.es/aholab/), the speech processing lab of the University of the Basque Country.

If anyone wants to work on improving the token to words rules feel free to do so. Bringing HTS support into mimic would probably be a desirable feature too (#76) but it may be a bit harder to do.
