### PR TITLE
Crossbuild xenial windows

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,10 @@ matrix:
       os: linux
       compiler: gcc
       sudo: false
+    - env: TASK="gcc6"   # gcc-6
+      os: linux
+      compiler: gcc-6
+      sudo: false
     - env: TASK="arm-linux-gnueabihf-gcc" # arm build
       os: linux
       compiler: gcc
@@ -57,6 +61,10 @@ addons:
     - mingw32-runtime
     - wine
     - xvfb
+    - gcc-6
+    - g++-6
+    sources:
+    - sourceline: 'ppa:ubuntu-toolchain-r/test'
   coverity_scan:
     project:
       name: "MycroftAI/mimic"

--- a/README.md
+++ b/README.md
@@ -74,6 +74,14 @@ packages. Install `wine` too for testing
 
 1. Install dependencies:
 
+On Ubuntu 16.04 (xenial):
+```
+sudo apt-get install gcc make pkg-config automake libtool libicu-dev wine binutils-mingw-w64-i686 mingw-w64-i686-dev gcc-mingw-w64-i686 g++-mingw-w64-i686
+
+```
+
+On Ubuntu 14.04 (trusty):
+
 ```
 sudo apt-get install gcc make pkg-config automake libtool libicu-dev mingw32 mingw32-runtime wine
 ```

--- a/configure.ac
+++ b/configure.ac
@@ -1,7 +1,7 @@
 dnl Use autogen.sh to regenerate the configure script
 AC_PREREQ([2.62])
 AC_INIT([mimic],
-        [1.2.0.0],
+        [1.2.0.1],
         [https://github.com/MycroftAI/mimic/issues])
 
 AC_CONFIG_AUX_DIR([config])

--- a/include/cst_val_const.h
+++ b/include/cst_val_const.h
@@ -48,11 +48,11 @@
 /*  will use this code as exemplars of why this should be done in C++, I */
 /*  say good luck to them with their 4M footprint while I go for my      */
 /*  50K footprint.  But I *will* do cst_vals in 8 bytes and I *will*     */
-/*  have them defined const so they are in the text segment              */
+/*  have them defined const so they are in the text segment.             */
 /*                                                                       */
 /*  The problem here is that there is not yet a standard way to do       */
 /*  initialization of unions.  There is one in the C99 standard and GCC  */
-/*  already supports it, but other compilers do not so I can't use that  */
+/*  already supports it, but other compilers do not so I can't use that. */
 /*                                                                       */
 /*  So I need a way to make an object that will have the right 8 bytes   */
 /*  for ints, floats, strings and cons cells that will work on any C     */
@@ -82,7 +82,7 @@
 /*  preprocessor that could convert that.  You could make atoms always   */
 /*  have a pointer to another piece of memory, but that would take up    */
 /*  another 4 bytes not just for these constants but all other cst_vals  */
-/*  create                                                               */
+/*  create.                                                              */
 /*                                                                       */
 /*  So you could do                                                      */
 /*                                                                       */
@@ -102,7 +102,7 @@
 /*  At this moment, I think the second version is the least problematic  */
 /*  though it makes defining val_consts more unpleasant than they should */
 /*  be and forces changes elsewhere in the code even when the compiler   */
-/*  does support initialization of unions                                */
+/*  does support initialization of unions.                               */
 /*                                                                       */
 /*                                                                       */
 /*************************************************************************/

--- a/run_testsuite.sh
+++ b/run_testsuite.sh
@@ -152,6 +152,18 @@ case "${WHAT_TO_RUN}" in
     # for ubuntu precise in travis, that does not provide pkg-config:
     pkg-config --exists icui18n || export CFLAGS="$CFLAGS -I/usr/include/x86_64-linux-gnu"
     pkg-config --exists icui18n || export LDFLAGS="$LDFLAGS -licui18n -licuuc -licudata"
+    export CFLAGS="$CFLAGS --std=c99"
+    ./configure  --enable-shared || exit 1
+    make || exit 1
+    make check || exit 1
+    ;;
+  gcc6)
+    ./autogen.sh
+    # for ubuntu precise in travis, that does not provide pkg-config:
+    pkg-config --exists icui18n || export CFLAGS="$CFLAGS -I/usr/include/x86_64-linux-gnu"
+    pkg-config --exists icui18n || export LDFLAGS="$LDFLAGS -licui18n -licuuc -licudata"
+    export CC="/usr/bin/gcc-6"
+    export CXX="/usr/bin/g++-6"
     ./configure  --enable-shared || exit 1
     make || exit 1
     make check || exit 1

--- a/run_testsuite.sh
+++ b/run_testsuite.sh
@@ -4,6 +4,11 @@ WHAT_TO_RUN="$1"
 WORKDIR=`pwd`
 export MANIFEST_TOOL=:
 
+if [ "x${NCORES}" = "x" ]; then
+    NCORES=1
+fi
+
+
 crosscompile_icu()
 {
     # Download & Extract icu
@@ -18,7 +23,7 @@ crosscompile_icu()
     mkdir icu_build_build
     cd icu_build_build
     ../icu/source/configure "$@" || exit 1
-    make || exit 1
+    make -j ${NCORES} || exit 1
 
     # Now the host system:
     cd "${WORKDIR}"
@@ -34,7 +39,7 @@ crosscompile_icu()
                             RANLIB=${HOST_TRIPLET}-ranlib \
                             AR=${HOST_TRIPLET}-ar \
                             "$@"  || exit 1
-    make || exit 1
+    make -j ${NCORES} || exit 1
     make install || exit 1
     cd "${WORKDIR}"
 }
@@ -69,7 +74,7 @@ crosscompile_portaudio()
                            RANLIB=${HOST_TRIPLET}-ranlib \
                            AR=${HOST_TRIPLET}-ar \
                            "$@" || exit 1
-    make || exit 1
+    make -j ${NCORES} || exit 1
     make install || exit 1
     cd "${WORKDIR}"
 }
@@ -98,7 +103,7 @@ crosscompile_mimic()
                  PKG_CONFIG_PATH="$WORKDIR/install/lib/pkgconfig/:/usr/lib/${HOST_TRIPLET}/pkgconfig:/usr/${HOST_TRIPLET}/lib/pkgconfig" \
                  PKG_CONFIG=`which pkg-config` \
                  "$@" || exit 1
-    make || exit 1
+    make -j ${NCORES} || exit 1
     make install || exit 1
     cd "${WORKDIR}"
 }
@@ -134,7 +139,7 @@ case "${WHAT_TO_RUN}" in
     ./autogen.sh
     ./configure ICU_CFLAGS="-I/usr/local/opt/icu4c/include" \
                 ICU_LIBS="-L/usr/local/opt/icu4c/lib -licui18n -licuuc -licudata" || exit 1
-    make || exit 1
+    make -j ${NCORES} || exit 1
     make check || exit 1
     ;;
   coverage)
@@ -143,7 +148,7 @@ case "${WHAT_TO_RUN}" in
     pkg-config --exists icu-i18n || export CFLAGS="$CFLAGS -I/usr/include/x86_64-linux-gnu"
     pkg-config --exists icu-i18n || export LDFLAGS="$LDFLAGS -licui18n -licuuc -licudata"
     ./configure  CFLAGS="$CFLAGS --coverage --no-inline" LDFLAGS="$LDFLAGS --coverage" || exit 1
-    make || exit 1
+    make -j ${NCORES} || exit 1
     make check || exit 1
     ./do_gcov.sh
     ;;
@@ -165,7 +170,7 @@ case "${WHAT_TO_RUN}" in
     export CC="/usr/bin/gcc-6"
     export CXX="/usr/bin/g++-6"
     ./configure  --enable-shared || exit 1
-    make || exit 1
+    make -j ${NCORES} || exit 1
     make check || exit 1
     ;;
   arm-linux-gnueabihf-gcc)

--- a/run_testsuite.sh
+++ b/run_testsuite.sh
@@ -57,11 +57,11 @@ fix_icu_dll_filenames()
 crosscompile_portaudio()
 {
     # Download & Extract portaudio
-    if [ ! -e "pa_stable_v19_20140130.tgz" ]; then 
-        wget "http://www.portaudio.com/archives/pa_stable_v19_20140130.tgz"
+    if [ ! -e "pa_stable_v190600_20161030.tgz" ]; then 
+        wget "http://www.portaudio.com/archives/pa_stable_v190600_20161030.tgz"
     fi
-    echo "7f220406902af9dca009668e198cbd23  pa_stable_v19_20140130.tgz" | md5sum -c || exit 1
-    tar xzf "pa_stable_v19_20140130.tgz" # creates directory "portaudio"
+    echo "4df8224e047529ca9ad42f0521bf81a8  pa_stable_v190600_20161030.tgz" | md5sum -c || exit 1
+    tar xzf "pa_stable_v190600_20161030.tgz" # creates directory "portaudio"
     # Cross compile portaudio:
     mkdir portaudio_build
     cd portaudio_build

--- a/run_testsuite.sh
+++ b/run_testsuite.sh
@@ -126,7 +126,7 @@ put_dll_in_bindir()
       fi
     fi
     # ICU and portaudio libraries are installed into lib. wine can't find them.
-    cp "${WORKDIR}/install/lib/"*.dll "${WORKDIR}/install/bin/"
+    for file in `ls "${WORKDIR}/install/lib/"*.dll`; do cp "$file" "${WORKDIR}/install/bin/"; done
     cd "${WORKDIR}"
 }
 
@@ -203,7 +203,11 @@ case "${WHAT_TO_RUN}" in
     put_dll_in_bindir
     # Test mimic:
     cd "$WORKDIR" || exit 1
-    xvfb-run wine "install/bin/mimic.exe" -voice ap -t "hello world" "hello_world_winbuild.wav" || exit 1
+    if [ "x${DISPLAY}" = "x" ]; then
+      xvfb-run wine "install/bin/mimic.exe" -voice ap -t "hello world" "hello_world_winbuild.wav" || exit 1
+    else
+      wine "install/bin/mimic.exe" -voice ap -t "hello world" "hello_world_winbuild.wav" || exit 1
+    fi
     echo "fbe80cc64ed244c0ee02c62a8489f182  hello_world_winbuild.wav" | md5sum -c || exit 1
     ;;
   winbuild_shared)
@@ -225,7 +229,11 @@ case "${WHAT_TO_RUN}" in
     put_dll_in_bindir
     # Test mimic:
     cd "$WORKDIR" || exit 1
-    xvfb-run wine "install/bin/mimic.exe" -voice ap -t "hello world" "hello_world_winbuild_shared.wav" || exit 1
+    if [ "x${DISPLAY}" = "x" ]; then
+      xvfb-run wine "install/bin/mimic.exe" -voice ap -t "hello world" "hello_world_winbuild_shared.wav" || exit 1
+    else
+      wine "install/bin/mimic.exe" -voice ap -t "hello world" "hello_world_winbuild_shared.wav" || exit 1
+    fi
     ;;
   *)
     echo "Unknown WHAT_TO_RUN: ${WHAT_TO_RUN}"

--- a/src/audio/au_alsa.c
+++ b/src/audio/au_alsa.c
@@ -43,7 +43,7 @@
 
 #ifdef CST_AUDIO_ALSA
 
-#define _BSD_SOURCE /* alsa alloca stuff and nanosleep */
+#define _POSIX_C_SOURCE 200112L
 
 #include <stdlib.h>
 #include <unistd.h>
@@ -56,6 +56,9 @@
 #include "cst_wave.h"
 #include "cst_audio.h"
 
+/* alloca.h is not C99 compliant nor POSIX compliant, but alsa needs it and does not include it */
+/* See similar patch: https://lists.mplayerhq.hu/pipermail/mplayer-dev-eng/2008-July/058080.html */
+#include <alloca.h>
 #include <alsa/asoundlib.h>
 
 int audio_flush_alsa(cst_audiodev *ad);

--- a/src/utils/cst_mmap_posix.c
+++ b/src/utils/cst_mmap_posix.c
@@ -40,7 +40,7 @@
 
 #if (MMAP_TYPE == MMAP_TYPE_POSIX)
 
-# define _POSIX_C_SOURCE 200809L
+# define _POSIX_C_SOURCE 200112L
 
 #include <sys/types.h>
 #include <sys/mman.h>

--- a/src/utils/cst_socket.c
+++ b/src/utils/cst_socket.c
@@ -62,6 +62,7 @@ int cst_socket_close(int socket)
     return -1;
 }
 #else
+#define _POSIX_C_SOURCE 200112L
 #include <stdio.h>
 #include <stdlib.h>
 #ifndef _MSC_VER
@@ -80,6 +81,11 @@ int cst_socket_close(int socket)
 #endif
 #include "cst_socket.h"
 #include "cst_error.h"
+
+/* OSX el capitan does not define INADDR_NONE in all cases */
+#ifndef INADDR_NONE
+#define INADDR_NONE ((in_addr_t) -1)
+#endif
 
 int cst_socket_open(const char *host, int port)
 {
@@ -105,7 +111,7 @@ int cst_socket_open(const char *host, int port)
             cst_errmsg("cst_socket: gethostbyname failed\n");
             return -1;
         }
-        memmove(&serv_addr.sin_addr, serverhost->h_addr,
+        memmove(&serv_addr.sin_addr, serverhost->h_addr_list[0],
                 serverhost->h_length);
     }
     serv_addr.sin_family = AF_INET;

--- a/src/utils/cst_url.c
+++ b/src/utils/cst_url.c
@@ -41,6 +41,9 @@
 /*  Only support http: if sockets are available                          */
 /*                                                                       */
 /*************************************************************************/
+
+#define _POSIX_C_SOURCE 200112L
+
 #include <math.h>
 #include "cst_file.h"
 #include "cst_string.h"


### PR DESCRIPTION
Cross compiling on a Ubuntu 16.04 build machine for a windows machine needs to use `mingw-w64`. 

This PR adds instructions for cross compiling mimic on Ubuntu 16.04.

One can do `NCORES=7 ./run_testsuite winbuild` to crosscompile faster with 7 cores, beware that the build process will eat up to 2.5 GiB RAM.

@willauld, would you like to test this? 

Closes #97 

