### PR TITLE
added automake to list of dependencies to install for Mac OSX

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,9 +63,9 @@ $ sudo pacman -S --needed install gcc make pkg-config automake libtool icu alsa-
   $ /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
   ```
 
-- Install *pkg-config*, *libtool*, *icu* and *PortAudio*
+- Install *pkg-config*, *automake*, *libtool*, *icu* and *PortAudio*
   ```
-  $ brew install pkg-config libtool portaudio icu4c
+  $ brew install pkg-config automake libtool portaudio icu4c
   ```
 
 ### Windows


### PR DESCRIPTION
automake was necessary to install mimic on my machine (Mac OSX), but it wasn't on the list of dependencies to install for Mac OSX. 