### PR TITLE
Increase speed on embedded devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,8 @@ Mimic is a fast, lightweight Text-to-speech engine developed by [Mycroft A.I.](h
 
 **Untested**
 - Android
+- iOS (Built as a static library)
 
-**Future**
-- iOS
 
 ## Requirements
 
@@ -76,18 +75,12 @@ The fastest and most straightforward way to build mimic for windows is by
 cross-compilation from linux. This requires some additional packages to be
 installed.
 
-On Ubuntu 16.04 (xenial):
-```
-sudo apt-get install gcc make pkg-config automake libtool libpcre2-dev wine binutils-mingw-w64-i686 mingw-w64-i686-dev gcc-mingw-w64-i686
+On Ubuntu:
 
 ```
-
-On Ubuntu 14.04 (trusty):
+sudo apt-get install gcc make pkg-config automake libtool wine binutils-mingw-w64-i686 mingw-w64-i686-dev gcc-mingw-w64-i686
 
 ```
-sudo apt-get install gcc make pkg-config automake libtool mingw32 mingw32-runtime wine
-```
-
 
 #### Native Windows building
 
@@ -121,7 +114,9 @@ sudo apt-get install gcc make pkg-config automake libtool mingw32 mingw32-runtim
   $ ./autogen.sh
   ```
   
-- Configure.
+- Configure. Choose the flags that suit you. For instance, for an embedded device
+  use of `--enable-speed-embedded` is recommended in order to reduce the CPU requirements.
+  While it reduces the speech quality, in practice the quality drop is not too large.
 
   ```
   $ ./configure --prefix="/usr/local"

--- a/configure.ac
+++ b/configure.ac
@@ -167,6 +167,21 @@ AS_CASE([ ${host_os} ],
         [ android* ], [ AUDIODRIVER="none"],
         [ chrome* ], [AUDIODRIVER="none"])
 
+
+AC_ARG_ENABLE([speed-embedded],
+  [AS_HELP_STRING([--enable-speed-embedded],
+      [increase performance by reducing pade order in clustergen and hts voices])],
+  [],
+  [enable_speed_embedded=no]) dnl by default do not embed
+
+AS_IF([ test "x${enable_speed_embedded}" = "xyes" ],
+  [ AC_DEFINE([HTS_EMBEDDED], [1], [Use smaller pade order and shorter impulse response in HTS synthesis])
+    AC_DEFINE([SPEED_HACK], [1], [Use smaller pade order in clustergen voices])
+  ], 
+  [])
+
+AC_DEFINE([MMAP_TYPE_NONE], [0], [enum for mmap_types])
+
 dnl
 dnl allow the user to override the one detected above
 dnl


### PR DESCRIPTION
`./configure --enable-speed-embedded` is recommended in order to reduce the CPU usage on embedded devices (raspberry pi).

For benchmarking, the synthesis of `doc/alice` with the mycroft voice went from **1.9 seconds to 1.3 seconds on my workstation**, I don't have a pi to test now.

As doc/alice is 1h long and it may take a while for the benchmark to finish, you can do your own benchmark with the shorter `doc/intro.txt`:

No speed tricks:

```
./configure
make
time ./mimic -voice ap -f doc/intro.txt test_output_no_speed.wav
```

Speed tricks:

If you have built the "no speed tricks" and you just want to try the clustergen voices (like the mycroft voice) you can manually edit `src/cg/cst_mlsa.c`, add `#define SPEED_HACK 1` at the top and `make`, otherwise you can build everything again from scratch.

```
./configure --enable-speed-embedded
make
time ./mimic -voice ap -f doc/intro.txt test_output_yes_speed.wav
```

These were features already available in flite and hts, I just added a configure switch for them.
