### PR TITLE
Explain GPL and BSD licensing options. Offer switch

### DIFF
--- a/COPYING
+++ b/COPYING
@@ -2,7 +2,11 @@ Format: http://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
 Upstream-Name: Mimic
 Source: https://github.com/mycroftai/mimic
 Comment: Mimic is free software
- Mimic is available under permissive BSD-like licenses
+ Most of mimic is licensed under permissive BSD-like licenses.
+ Some optional mimic components will depend on GPLv3-licensed libraries, making
+ mimic redistributable only under the GPLv3.
+ Mimic offers a `--disable-gpl` switch at compile time to create BSD-3-like
+ licensed binaries that will disable the GPL-v3 mimic components.
  .
  This file lists all the copyrights and licenses of mimic files.
 

--- a/configure.ac
+++ b/configure.ac
@@ -114,7 +114,10 @@ AC_ARG_ENABLE([gpl],
   [],
   [enable_gpl=yes])
 
-
+AS_IF([ test "x${enable_gpl}" = "xyes"],
+  [ AC_DEFINE([ENABLE_GPL], [1], [Enable GPL code]) ],
+  [ AC_DEFINE([ENABLE_GPL], [0], [Enable GPL code]) ])
+ 
 dnl
 dnl determine audio type or use none if none supported on this platform
 dnl

--- a/configure.ac
+++ b/configure.ac
@@ -101,6 +101,18 @@ dnl Check libpcre2-8
 PKG_CHECK_MODULES([PCRE2], [libpcre2-8])
 PKGCONFIG_MIMIC_DEPS="${PKGCONFIG_MIMIC_DEPS} libpcre2-8"
                                    
+dnl License switch:
+dnl mimic is distributed under permissive BSD-3 like licenses with some
+dnl specific mimic components (listed in the COPYING file)
+dnl under a GPLv3 license.
+dnl
+dnl This switch gives the option to disable all features that depend on
+dnl GPL software, so a BSD-like binary mimic version is available.
+AC_ARG_ENABLE([gpl],
+  [AS_HELP_STRING([--disable-gpl],
+       [disable all GPL related code])],
+  [],
+  [enable_gpl=yes])
 
 
 dnl

--- a/dependencies.sh
+++ b/dependencies.sh
@@ -1,4 +1,37 @@
 #!/bin/sh
+#POSIX
+
+# Reset all variables that might be set
+enable_gpl="yes"
+
+show_help()
+{
+cat << EOF
+Usage: ${0##*/} [ --enable-gpl | --disable-gpl ] [ other flags passed to configure ]
+Install dependencies for mimic
+
+    -h          display this help and exit
+    --enable-gpl Builds and installs optional GPL-licensed dependencies
+    --disable-gpl Skips GPL dependencies.
+EOF
+}
+
+case $1 in
+  -h|-\?|--help)   # Call a "show_help" function to display a synopsis, then exit.
+    show_help
+    exit
+    ;;
+  --disable-gpl)
+    enable_gpl="no"
+    shift
+    ;;
+  --enable-gpl)
+    enable_gpl="yes"
+    shift
+    ;;
+  *)
+    ;;
+esac
 
 #### This function emulates readlink -f, not available on osx ####
 readlink2()

--- a/src/synth/mimic.c
+++ b/src/synth/mimic.c
@@ -592,3 +592,13 @@ int mimic_munmap_clunit_voxdata(cst_voice *voice)
 
     return 0;
 }
+
+int mimic_gpl_enabled()
+{
+#if ENABLE_GPL == 1
+  return 1;
+#else
+  return 0;
+#endif
+}
+


### PR DESCRIPTION
This is just a compile switch and a message on the COPYING file. Basically

`./configure --disable-gpl` will build BSD-like mimic libraries, disabling any GPL optional component.

Right now it does not do anything, because there is no GPL code in mimic.

This is a requirement for Spanish support #3 

Spanish support demo: https://www.dropbox.com/s/tjvx5pavx93p72q/mimic_spanish.mp3?dl=0