### PR TITLE
Check for libpulse-simple.pc

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -186,7 +186,7 @@ AS_CASE( [ ${AUDIODRIVER} ],
            [ AUDIODEFS="${AUDIODEFS_PULSEAUDIO}"
              AUDIOLIBS="${AUDIOLIBS_PULSEAUDIO}"
              AUDIODETECTED="${AUDIODETECTED_PULSEAUDIO}"
-             PKGCONFIG_MIMIC_DEPS="${PKGCONFIG_MIMIC_DEPS} libpulse"
+             PKGCONFIG_MIMIC_DEPS="${PKGCONFIG_MIMIC_DEPS} libpulse-simple"
            ],
          [ portaudio ],
            [ AUDIODEFS="${AUDIODEFS_PORTAUDIO}"


### PR DESCRIPTION
I needed this change in order to get mimic to build. (I have version 11.0 installed, but pulseaudio-simple.pc has existed since at least version 0.9.12, so this change looks safe to me.)