### PR TITLE
Modify License text for Bellbird parts

### DIFF
--- a/COPYING
+++ b/COPYING
@@ -957,19 +957,6 @@ License: MIT/X11 (BSD like)
  IN THE SOFTWARE.
 
 Licence: BellBird
-Belbird is free software and branched from Flite
-
-Flite it a fine speech synthesizer but it did not do
-exactly what I wanted to. I have butchered it to create Bellbird.
-The vast majority of code comes from Flite.  It has been
-modified for the purposes of Bellbird.
-
-The vast majority of files in bellbird have been modified (often
-only in tiny ways). As such bellbird in a derivative work of a number
-of different code sources.
-
-Any code which appears only in bellbird has the following license:
-
   (c) Copyright the authors of Bellbird. All rights reserved.
 
   Permission is hereby granted, free of charge, to use and distribute  
@@ -995,35 +982,4 @@ Any code which appears only in bellbird has the following license:
   AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION,          
   ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF       
   THIS SOFTWARE.  
-
-We also include a list of original underlying copyright notices for the source
-components of bellbird.
-
-The files in CMakeScripts/* are written by Michihiro NAKAJIMA and were
-licensed with the BSD license given below. They have been modified for use
-with bellbird.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions
-are met:
-
-1. Redistributions of source code must retain the copyright
-   notice, this list of conditions and the following disclaimer.
-2. Redistributions in binary form must reproduce the copyright
-   notice, this list of conditions and the following disclaimer in the
-   documentation and/or other materials provided with the distribution.
-3. The name of the author may not be used to endorse or promote products
-   derived from this software without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
-IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
-OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
-IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
-INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
-NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
-THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
 


### PR DESCRIPTION
Via a private email, Bellbird author mentioned that we were just
using a small part of Bellbird and therefore we did not need
to include some of Bellbird license text (basically the preamble)

This PR shortens the Bellbird license text removing those parts
that are unrelated to the fraction of Bellbird we are using,
which is src/filter/bb_mlsacore.c

* Whether you have signed a CLA (Contributor Licensing Agreement)
Yes
