### PR TITLE
SSML Prosody: Pitch and Range attributes

### DIFF
--- a/src/cg/cst_cg.c
+++ b/src/cg/cst_cg.c
@@ -439,16 +439,16 @@ static void cg_smooth_F0(cst_utterance *utt, cst_cg_db *cg_db,
     /* Smooth F0 and mark unvoice frames as 0.0 */
     cst_item *mcep;
     int i;
-    float mean, stddev;
+    float base_mean, base_stddev;
 
     /* cg_smooth_F0_naive(param_track); */
 
     cg_F0_interpolate_spline(utt, param_track);
 
-    mean =
+    base_mean =
         get_param_float(utt->features, "int_f0_target_mean", cg_db->f0_mean);
-    mean *= get_param_float(utt->features, "f0_shift", 1.0);
-    stddev =
+    base_mean *= get_param_float(utt->features, "f0_shift", 1.0);
+    base_stddev =
         get_param_float(utt->features, "int_f0_target_stddev",
                         cg_db->f0_stddev);
 
@@ -457,6 +457,8 @@ static void cg_smooth_F0(cst_utterance *utt, cst_cg_db *cg_db,
     {
         if (voiced_frame(mcep))
         {
+            float mean = base_mean;
+            float stddev = base_stddev;
             float local_f0_mean =
             ffeature_float(mcep,
                 "R:mcep_link.parent.R:segstate.parent.R:SylStructure.parent.parent.R:Token.parent.local_f0_mean"
@@ -471,7 +473,7 @@ static void cg_smooth_F0(cst_utterance *utt, cst_cg_db *cg_db,
             );
             if (local_f0_precision <= 1.0)
             {
-                stddev = stddev * (1.0 - local_f0_precision);
+                stddev = base_stddev * (1.0 - local_f0_precision);
             }
             /* scale the F0 -- which normally wont change it at all */
             param_track->frames[i][0] =

--- a/src/cg/cst_cg.c
+++ b/src/cg/cst_cg.c
@@ -457,6 +457,22 @@ static void cg_smooth_F0(cst_utterance *utt, cst_cg_db *cg_db,
     {
         if (voiced_frame(mcep))
         {
+            float local_f0_mean =
+            ffeature_float(mcep,
+                "R:mcep_link.parent.R:segstate.parent.R:SylStructure.parent.parent.R:Token.parent.local_f0_mean"
+            );
+            if (local_f0_mean != 0.0)
+            {
+                mean = local_f0_mean;
+            }
+            float local_f0_precision =
+            ffeature_float(mcep,
+                "R:mcep_link.parent.R:segstate.parent.R:SylStructure.parent.parent.R:Token.parent.local_f0_precision"
+            );
+            if (local_f0_precision <= 1.0)
+            {
+                stddev = stddev * (1.0 - local_f0_precision);
+            }
             /* scale the F0 -- which normally wont change it at all */
             param_track->frames[i][0] =
                 (((param_track->frames[i][0] -

--- a/src/cg/cst_cg.c
+++ b/src/cg/cst_cg.c
@@ -469,7 +469,7 @@ static void cg_smooth_F0(cst_utterance *utt, cst_cg_db *cg_db,
             }
             float local_f0_range =
             ffeature_float(mcep,
-                "R:mcep_link.parent.R:segstate.parent.R:SylStructure.parent.parent.R:Token.parent.local_f0_precision"
+                "R:mcep_link.parent.R:segstate.parent.R:SylStructure.parent.parent.R:Token.parent.local_f0_range"
             );
             if (local_f0_range > 0.0)
             {

--- a/src/cg/cst_cg.c
+++ b/src/cg/cst_cg.c
@@ -467,13 +467,14 @@ static void cg_smooth_F0(cst_utterance *utt, cst_cg_db *cg_db,
             {
                 mean = local_f0_mean;
             }
-            float local_f0_precision =
+            float local_f0_range =
             ffeature_float(mcep,
                 "R:mcep_link.parent.R:segstate.parent.R:SylStructure.parent.parent.R:Token.parent.local_f0_precision"
             );
-            if (local_f0_precision <= 1.0)
+            if (local_f0_range > 0.0)
             {
-                stddev = base_stddev * (1.0 - local_f0_precision);
+                /* feature_float returns 0 by default, shifted to allow 0 to be passed. */
+                stddev = local_f0_range - 1.0;
             }
             /* scale the F0 -- which normally wont change it at all */
             param_track->frames[i][0] =

--- a/src/synth/cst_ssml.c
+++ b/src/synth/cst_ssml.c
@@ -103,6 +103,16 @@ static cst_features *ssml_get_attributes(cst_tokenstream *ts)
             fnn = "_name1";
             vnn = "_val1";
         }
+        else if (cst_streq("pitch", name))
+        {
+            fnn = "_name2";
+            vnn = "_val2";
+        }
+        else if (cst_streq("pitch_precision", name))
+        {
+            fnn = "_name3";
+            vnn = "_val3";
+        }
         if (cst_streq(name, "/"))
             feat_set_string(a, "_type", "startend");
         else
@@ -207,6 +217,16 @@ static cst_utterance *ssml_apply_tag(const char *tag,
                 ("volume", get_param_string(attributes, "_name1", "")))
                 feat_set_float(word_feats, "local_gain",
                                feat_float(attributes, "_val1") / 100.0);
+            // pitch is stored in _name2
+            if (cst_streq("pitch", get_param_string(attributes, "_name2", "")))
+            {
+                feat_set_float(word_feats, "local_f0_mean", feat_float(attributes, "_val2"));
+            }
+            // pitch_precision is stored in _name3
+            if (cst_streq("pitch_precision", get_param_string(attributes, "_name3", "")))
+            {
+                feat_set_float(word_feats, "local_f0_precision", feat_float(attributes, "_val3"));
+            }
         }
         else if (cst_streq("end", feat_string(attributes, "_type")))
         {

--- a/src/synth/cst_ssml.c
+++ b/src/synth/cst_ssml.c
@@ -96,6 +96,8 @@ static cst_features *ssml_get_attributes(cst_tokenstream *ts)
         /* I want names and values to be const */
         fnn = "_name0";
         vnn = "_val0";
+        // Tags with more than one attribute need to have additional
+        // attributes defined here.
         if (cst_streq("volume", name))
         {
             fnn = "_name1";

--- a/src/synth/cst_ssml.c
+++ b/src/synth/cst_ssml.c
@@ -108,7 +108,7 @@ static cst_features *ssml_get_attributes(cst_tokenstream *ts)
             fnn = "_name2";
             vnn = "_val2";
         }
-        else if (cst_streq("pitch_precision", name))
+        else if (cst_streq("range", name))
         {
             fnn = "_name3";
             vnn = "_val3";
@@ -222,10 +222,12 @@ static cst_utterance *ssml_apply_tag(const char *tag,
             {
                 feat_set_float(word_feats, "local_f0_mean", feat_float(attributes, "_val2"));
             }
-            // pitch_precision is stored in _name3
-            if (cst_streq("pitch_precision", get_param_string(attributes, "_name3", "")))
+            // range is stored in _name3
+            if (cst_streq("range", get_param_string(attributes, "_name3", "")))
             {
-                feat_set_float(word_feats, "local_f0_precision", feat_float(attributes, "_val3"));
+                feat_set_float(word_feats, "local_f0_range",
+                               // shift by + 1.0 to allow 0.0 to be passed.
+                               feat_float(attributes, "_val3") + 1.0);
             }
         }
         else if (cst_streq("end", feat_string(attributes, "_type")))
@@ -233,7 +235,7 @@ static cst_utterance *ssml_apply_tag(const char *tag,
             feat_remove(word_feats, "local_duration_stretch");
             feat_remove(word_feats, "local_gain");
             feat_remove(word_feats, "local_f0_mean");
-            feat_remove(word_feats, "local_f0_precision");
+            feat_remove(word_feats, "local_f0_range");
         }
 
     }

--- a/src/synth/cst_ssml.c
+++ b/src/synth/cst_ssml.c
@@ -232,6 +232,8 @@ static cst_utterance *ssml_apply_tag(const char *tag,
         {
             feat_remove(word_feats, "local_duration_stretch");
             feat_remove(word_feats, "local_gain");
+            feat_remove(word_feats, "local_f0_mean");
+            feat_remove(word_feats, "local_f0_precision");
         }
 
     }

--- a/src/synth/cst_ssml.c
+++ b/src/synth/cst_ssml.c
@@ -94,12 +94,9 @@ static cst_features *ssml_get_attributes(cst_tokenstream *ts)
     while (!cst_streq(">", name))
     {
         /* I want names and values to be const */
-        if (i == 0)
-        {
-            fnn = "_name0";
-            vnn = "_val0";
-        }
-        else
+        fnn = "_name0";
+        vnn = "_val0";
+        if (cst_streq("volume", name))
         {
             fnn = "_name1";
             vnn = "_val1";
@@ -203,13 +200,7 @@ static cst_utterance *ssml_apply_tag(const char *tag,
             if (cst_streq("rate", get_param_string(attributes, "_name0", "")))
                 feat_set_float(word_feats, "local_duration_stretch",
                                1.0 / feat_float(attributes, "_val0"));
-            if (cst_streq("rate", get_param_string(attributes, "_name1", "")))
-                feat_set_float(word_feats, "local_duration_stretch",
-                               1.0 / feat_float(attributes, "_val1"));
-            if (cst_streq
-                ("volume", get_param_string(attributes, "_name0", "")))
-                feat_set_float(word_feats, "local_gain",
-                               feat_float(attributes, "_val0") / 100.0);
+            // volume is stored in _name1
             if (cst_streq
                 ("volume", get_param_string(attributes, "_name1", "")))
                 feat_set_float(word_feats, "local_gain",


### PR DESCRIPTION
* adresses #148 

* ```./mimic -ssml "hi friends hey <prosody rate='.5' pitch='220' range='8'>hey hello</prosody> --  <range='0Hz' pitch='440Hz'>hi</prosody> friends."```

This implements pitch in the simplest way -- code side. See the discussion in #148 regarding implementation of the pitch attribute

`range` inputs the stddev of the range.

* Whether you have signed a CLA (Contributor Licensing Agreement)

Yes.