### PR TITLE
src/utils/cst_tokenstream.c: initialize plast

### DIFF
--- a/src/utils/cst_tokenstream.c
+++ b/src/utils/cst_tokenstream.c
@@ -705,7 +705,7 @@ static void get_token_sub_part_2(cst_tokenstream *ts,
 
 static void get_token_postpunctuation(cst_tokenstream *ts)
 {
-    int p, t, plast;
+    int p, t, plast = 0;
     const cst_string *one_cp;
 
     t = cst_strlen(ts->token);


### PR DESCRIPTION
Fix the following build failure:

```
src/utils/cst_tokenstream.c: In function ‘get_token_postpunctuation’:
src/utils/cst_tokenstream.c:732:51: error: ‘plast’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
         memmove(ts->postpunctuation, &ts->token[p + plast], (t - p));
                                                 ~~^~~~~~~
```

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>