### PR TITLE
Supress ls no such file error message

### DIFF
--- a/run_testsuite.sh
+++ b/run_testsuite.sh
@@ -136,7 +136,7 @@ put_dll_in_bindir()
 {
     # Portaudio libraries are installed into lib. wine can't find them.
     # Copy all libs to ${MIMIC_INSTALL_DIR}/bin
-    for file in `ls "${MIMIC_INSTALL_DIR}/lib/"*.dll`; do
+    for file in `ls "${MIMIC_INSTALL_DIR}/lib/"*.dll 2>/dev/null`; do
         cp "$file" "${MIMIC_INSTALL_DIR}/bin/"
     done
 }


### PR DESCRIPTION


* Description of what the PR does, such as fixes # {issue number}
When there are no dlls to copy, it seems like there's an error.
This change would supress the error message but wouldn't harm functionality.
* Description of how to validate or test this PR
The best way would be to check the method changed individually, in case there are dlls to copy and in case there are none.
* Whether you have signed a CLA (Contributor Licensing Agreement)
Yes

