### PR TITLE
cmu_indic_lang: Make cst_rx_not_indic as extern declaration

### DIFF
--- a/lang/cmu_indic_lang/cmu_indic_lang.h
+++ b/lang/cmu_indic_lang/cmu_indic_lang.h
@@ -51,7 +51,7 @@ void cmu_indic_lang_init(cst_voice *v);
 extern const cst_phoneset cmu_indic_phoneset;
 extern const cst_cart cmu_indic_phrasing_cart; 
 
-const cst_regex * const cst_rx_not_indic;
+extern const cst_regex * const cst_rx_not_indic;
 
 #ifdef __cplusplus
 } /* extern "C" */


### PR DESCRIPTION
Fixes build with gcc-10 which has -fno-common turned on by default

Signed-off-by: Khem Raj <raj.khem@gmail.com>

* Description of what the PR does, such as fixes # {issue number}

* Description of how to validate or test this PR

* Whether you have signed a CLA (Contributor Licensing Agreement)

