### PR TITLE
Add basic validation for empty phoneme string

### DIFF
--- a/main/mimic_main.c
+++ b/main/mimic_main.c
@@ -213,7 +213,7 @@ int main(int argc, char **argv)
     cst_voice *desired_voice = 0;
     const char *voicedir = NULL;
     int i;
-	int err;
+    int err;
     float durs;
     double time_start, time_end;
     int mimic_verbose, mimic_loop, mimic_bench;

--- a/src/synth/mimic.c
+++ b/src/synth/mimic.c
@@ -38,6 +38,7 @@
 /*                                                                       */
 /*************************************************************************/
 #include <errno.h>
+#include <string.h>
 #include "cst_tokenstream.h"
 #include "mimic.h"
 #include "cst_alloc.h"
@@ -381,7 +382,8 @@ int mimic_phones_to_speech(const char *text, cst_voice *voice,
                            const char *outtype, float *dur)
 {
     int ret;
-    if ((dur == NULL) || (voice == NULL) || (text == NULL) || (outtype == NULL))
+    if ((dur == NULL) || (voice == NULL) || (text == NULL)
+        || !strcmp(text, "") || (outtype == NULL))
     {
         ret = -EINVAL;
     }


### PR DESCRIPTION
Add simple validation to make sure the phoneme string is valid before passing it on to be processed. Fixes #221 