### PR TITLE
change download source

### DIFF
--- a/dependencies.sh
+++ b/dependencies.sh
@@ -51,7 +51,7 @@ if [ "x${HAVE_PCRE2}" = "xno" ]; then
   # Prepare pcre2-10.23 source:
   (mkdir -p "${WORKDIR}/thirdparty/" && \
     cd "${WORKDIR}/thirdparty" && \
-    wget "ftp://ftp.pcre.org/pub/pcre/pcre2-10.23.zip"
+    wget "https://master.dl.sourceforge.net/project/pcre/pcre2/10.23/pcre2-10.23.zip"
     echo "56c07f59ccd052ccdbdedadf24574a63  pcre2-10.23.zip" | md5sum -c || exit 1
     unzip "pcre2-10.23.zip" && \
     cd "pcre2-10.23" && \


### PR DESCRIPTION
The website (http://pcre.org/) now says to download the files from source forge. The md5sum is still the same.

* Description of what the PR does, such as fixes # {issue number}

* Description of how to validate or test this PR

* Whether you have signed a CLA (Contributor Licensing Agreement)

