### PR TITLE
Fix build: HTSEngine: use HTS_free

### DIFF
--- a/src/hts/hts_engine_API/lib/HTS_model.c
+++ b/src/hts/hts_engine_API/lib/HTS_model.c
@@ -698,7 +698,7 @@ static HTS_Boolean HTS_Model_load_pdf(HTS_Model * model, HTS_File * fp, size_t v
    }
    if (result == FALSE) {
       model->npdf += 2;
-      free(model->npdf);
+      HTS_free(model->npdf);
       HTS_Model_initialize(model);
       return FALSE;
    }


### PR DESCRIPTION
* Fix build, fixes #231

* Whether you have signed a CLA (Contributor Licensing Agreement)
That sounds not CLA-worthy contribution (not signed)
